### PR TITLE
Added splits to attack timeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,28 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -964,6 +986,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3514,6 +3541,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -3526,6 +3565,19 @@
       "integrity": "sha512-2KsBEEs+qRhKx/kekUVNSTIpop3Jwd7SRBm0R4Eiq3mPeswRGSsftY9FpKsE/lXLdURyQFiHeHFrIUxLYskG5g==",
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.26.3.tgz",
+      "integrity": "sha512-MpYAws8CEHUd/RC4GaDCdoceph/T4KHM5vS5Dbk8FOmLMvvIht2ymP2htWdrke7K6lqPO8rz8+bnwWUIXeDlzg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/readdirp": {
@@ -3740,6 +3792,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -4512,7 +4572,8 @@
         "next": "14.0.1",
         "react": "^18",
         "react-dom": "^18",
-        "react-timeago": "^7.2.0"
+        "react-timeago": "^7.2.0",
+        "react-tooltip": "^5.26.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4804,24 +4865,6 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "web/node_modules/react-dom": {
-      "version": "18.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "web/node_modules/scheduler": {
-      "version": "0.23.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
     },
     "web/node_modules/streamsearch": {
       "version": "1.1.0",

--- a/web/app/components/boss-page-attack-timeline/styles.module.scss
+++ b/web/app/components/boss-page-attack-timeline/styles.module.scss
@@ -13,11 +13,12 @@
 }
 
 .attackTimeline__Scrollable {
-  padding: 10px 10px 3px 12px;
+  padding: 85px 10px 25px 12px;
   overflow-x: scroll;
   width: 100%;
   display: flex;
   flex-direction: row;
+  overflow-y: visible;
 
   &::-webkit-scrollbar {
     width: 6px;
@@ -66,6 +67,7 @@
   top: 4px;
   width: 134px;
   margin-right: 0;
+  top: 80px;
   align-items: flex-end !important;
 }
 
@@ -102,6 +104,59 @@
 
   &:hover {
     color: white;
+  }
+}
+
+.attackTimeline__RoomSplit {
+  position: absolute;
+  height: 50px;
+  width: 71px;
+  top: -55px;
+  left: -14px;
+
+  &.splitIndicatorBottom {
+    transform: rotate(180deg);
+    bottom: -40px;
+    top: unset;
+  }
+
+  span {
+    border: 1px solid var(--blert-text-color);
+    cursor: pointer;
+    background-color: #23242f;
+    border-radius: 3px;
+    padding: 0px 5px;
+    text-align: center;
+    position: absolute;
+    top: -3px;
+    left: 50%;
+    font-size: 28px;
+    transform: translateX(-50%);
+  }
+
+  div.splitIndicatorWrapper {
+    position: relative;
+    top: -8px;
+
+    .splitIndicatorPt1 {
+      position: absolute;
+      bottom: -58px;
+      height: 10px;
+      width: 100%;
+      border-left: 4px solid var(--blert-text-color);
+      border-right: 4px solid var(--blert-text-color);
+      border-top: 4px solid var(--blert-text-color);
+      border-bottom-left-radius: 5px;
+      border-bottom-right-radius: 5px;
+    }
+
+    .splitIndicatorPt2 {
+      bottom: -49px;
+      height: 5px;
+      position: absolute;
+      left: 33px;
+      border-left: 4px solid var(--blert-text-color);
+    }
   }
 }
 

--- a/web/app/components/ligma-tooltip/ligma-tooltip.tsx
+++ b/web/app/components/ligma-tooltip/ligma-tooltip.tsx
@@ -1,0 +1,31 @@
+import ReactDOM from 'react-dom';
+import styles from './style.module.scss';
+import { useRef } from 'react';
+import { Tooltip } from 'react-tooltip';
+
+type LigmaTooltipProps = {
+  children: React.ReactNode;
+  tooltipId: string;
+};
+
+export function LigmaTooltip(props: LigmaTooltipProps) {
+  const { children, tooltipId } = props;
+  const portalNode = useRef(document.getElementById('tooltip-portal'));
+
+  return ReactDOM.createPortal(
+    <Tooltip
+      id={tooltipId}
+      openOnClick={true}
+      style={{
+        backgroundColor: '#171821',
+        borderRadius: '5px',
+        opacity: 1,
+        boxShadow: '0px 0px 5px rgba(255, 2555, 255, 0.5)',
+        zIndex: 999,
+      }}
+    >
+      {children}
+    </Tooltip>,
+    portalNode.current!,
+  );
+}

--- a/web/app/components/ligma-tooltip/style.module.scss
+++ b/web/app/components/ligma-tooltip/style.module.scss
@@ -1,0 +1,1 @@
+@import '../../mixins.scss';

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
       <body className={inter.className}>
         <div className={styles.siteParent}>
           <LeftNav />
-
+          <div id="tooltip-portal" />
           <div className={styles.pageParentContent}>{children}</div>
         </div>
       </body>

--- a/web/app/raids/tob/[id]/(bosses)/bloat/page.tsx
+++ b/web/app/raids/tob/[id]/(bosses)/bloat/page.tsx
@@ -86,6 +86,18 @@ export default function BloatPage() {
     }
   }
 
+  const splits = [
+    {
+      tick: 5,
+      splitName: "Ligma's Split",
+      splitCustomContent: (
+        <>
+          <h1>Ligma lol</h1>
+        </>
+      ),
+    },
+  ];
+
   return (
     <>
       <div className={styles.bossPage__Overview}>
@@ -120,6 +132,7 @@ export default function BloatPage() {
         timelineTicks={totalTicks}
         updateTickOnPage={updateTickOnPage}
         inventoryTags={memes.inventoryTags}
+        splits={splits}
       />
 
       <BossPageReplay entities={entities} mapDef={BLOAT_MAP_DEFINITION} />

--- a/web/app/raids/tob/[id]/(bosses)/maiden/page.tsx
+++ b/web/app/raids/tob/[id]/(bosses)/maiden/page.tsx
@@ -8,6 +8,7 @@ import {
   PlayerUpdateEvent,
   Room,
 } from '@blert/common';
+import { TimelineSplit } from '../../../../../components/boss-page-attack-timeline/boss-page-attack-timeline';
 import { useContext, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { MAIDEN } from '../../../../../bosses/tob';
@@ -76,8 +77,6 @@ export default function Maiden({ params: { id } }: { params: { id: string } }) {
     return <>Loading...</>;
   }
 
-  console.log(raidData);
-
   const eventsForCurrentTick = eventsByTick[currentTick] ?? [];
 
   const entities: Entity[] = [];
@@ -120,6 +119,35 @@ export default function Maiden({ params: { id } }: { params: { id: string } }) {
     }
   }
 
+  const splits: TimelineSplit[] = [];
+
+  const maidenData = raidData.rooms[Room.MAIDEN];
+
+  if (maidenData === null) {
+    throw new Error('No maiden data???');
+  }
+
+  if (maidenData.splits.SEVENTIES) {
+    splits.push({
+      tick: maidenData.splits.SEVENTIES,
+      splitName: '70s',
+    });
+  }
+
+  if (maidenData.splits.FIFTIES) {
+    splits.push({
+      tick: maidenData.splits.FIFTIES,
+      splitName: '50s',
+    });
+  }
+
+  if (maidenData.splits.THIRTIES) {
+    splits.push({
+      tick: maidenData.splits.THIRTIES,
+      splitName: '30s',
+    });
+  }
+
   return (
     <>
       <div className={styles.bossPage__Overview}>
@@ -154,6 +182,7 @@ export default function Maiden({ params: { id } }: { params: { id: string } }) {
         timelineTicks={totalTicks}
         updateTickOnPage={updateTickOnPage}
         inventoryTags={memes.inventoryTags}
+        splits={splits}
       />
 
       <BossPageReplay entities={entities} mapDef={MAIDEN_MAP_DEFINITION} />

--- a/web/app/raids/tob/[id]/(bosses)/nylocas/page.tsx
+++ b/web/app/raids/tob/[id]/(bosses)/nylocas/page.tsx
@@ -231,6 +231,12 @@ export default function NylocasPage() {
     );
   }
 
+  const splits =
+    eventsByType[EventType.NYLO_WAVE_SPAWN]?.map((evt) => ({
+      tick: evt.tick,
+      splitName: `${(evt as NyloWaveSpawnEvent).nyloWave.wave}`,
+    })) ?? [];
+
   return (
     <>
       <div className={styles.bossPage__Overview}>
@@ -265,6 +271,7 @@ export default function NylocasPage() {
         timelineTicks={totalTicks}
         updateTickOnPage={updateTickOnPage}
         inventoryTags={memes.inventoryTags}
+        splits={splits}
       />
 
       <BossPageReplay entities={entities} mapDef={NYLOCAS_MAP_DEFINITION} />

--- a/web/app/raids/tob/[id]/(bosses)/sotetseg/page.tsx
+++ b/web/app/raids/tob/[id]/(bosses)/sotetseg/page.tsx
@@ -102,6 +102,18 @@ export default function SotetsegPage() {
     }
   }
 
+  const splits = [
+    {
+      tick: 5,
+      splitName: "Ligma's Split",
+      splitCustomContent: (
+        <>
+          <h1>Ligma lol</h1>
+        </>
+      ),
+    },
+  ];
+
   return (
     <>
       <div className={styles.bossPage__Overview}>
@@ -136,6 +148,7 @@ export default function SotetsegPage() {
         timelineTicks={totalTicks}
         updateTickOnPage={updateTickOnPage}
         inventoryTags={memes.inventoryTags}
+        splits={splits}
       />
 
       <BossPageReplay entities={entities} mapDef={SOTETSEG_MAP_DEFINITION} />

--- a/web/app/raids/tob/[id]/(bosses)/verzik/page.tsx
+++ b/web/app/raids/tob/[id]/(bosses)/verzik/page.tsx
@@ -114,6 +114,18 @@ export default function VerzikPage() {
     }
   }
 
+  const splits = [
+    {
+      tick: 5,
+      splitName: "Ligma's Split",
+      splitCustomContent: (
+        <>
+          <h1>Ligma lol</h1>
+        </>
+      ),
+    },
+  ];
+
   return (
     <>
       <div className={styles.bossPage__Overview}>
@@ -148,6 +160,7 @@ export default function VerzikPage() {
         timelineTicks={totalTicks}
         updateTickOnPage={updateTickOnPage}
         inventoryTags={memes.inventoryTags}
+        splits={splits}
       />
 
       <BossPageReplay entities={entities} mapDef={VERZIK_MAP_DEFINITION} />

--- a/web/app/raids/tob/[id]/(bosses)/xarpus/page.tsx
+++ b/web/app/raids/tob/[id]/(bosses)/xarpus/page.tsx
@@ -78,6 +78,18 @@ export default function XarpusPage() {
     }
   }
 
+  const splits = [
+    {
+      tick: 5,
+      splitName: "Ligma's Split",
+      splitCustomContent: (
+        <>
+          <h1>Ligma lol</h1>
+        </>
+      ),
+    },
+  ];
+
   return (
     <>
       <div className={styles.bossPage__Overview}>
@@ -112,6 +124,7 @@ export default function XarpusPage() {
         timelineTicks={totalTicks}
         updateTickOnPage={updateTickOnPage}
         inventoryTags={memes.inventoryTags}
+        splits={splits}
       />
 
       <BossPageReplay entities={entities} mapDef={XARPUS_MAP_DEFINITION} />

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,8 @@
     "next": "14.0.1",
     "react": "^18",
     "react-dom": "^18",
-    "react-timeago": "^7.2.0"
+    "react-timeago": "^7.2.0",
+    "react-tooltip": "^5.26.3"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
Splits now appear on the attack timeline with parameters: `tick` (number), `splitName` (string) and `splitCustomContent` (arbitrary HTML). Visually they appear as stylized "brackets" above and below a column on the timeline. Clicking on one of the split titles will open a tooltip with the `splitCustomContent` as its contents.

Also added the <LigmaTooltip /> component for rendering tooltips. Uses React Portal to render the tooltip outside of the normal DOM hierarchy and the library react-tooltip (also installed as a part of this repo) to handle the positioning and visibility of the tooltip.