### PR TITLE
Allow linking Discord accounts to Blert accounts

### DIFF
--- a/common/migrations/20251117152006-add-discord-linking.ts
+++ b/common/migrations/20251117152006-add-discord-linking.ts
@@ -1,0 +1,30 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE TABLE account_linking_codes (
+      id INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      user_id INT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+      type VARCHAR(20) NOT NULL,
+      code VARCHAR(8) NOT NULL UNIQUE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      expires_at TIMESTAMPTZ NOT NULL,
+      UNIQUE (user_id, type)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX idx_account_linking_codes_expires_at
+    ON account_linking_codes(expires_at)
+  `;
+
+  await sql`
+    ALTER TABLE users
+    ADD COLUMN discord_id VARCHAR(20) UNIQUE,
+    ADD COLUMN discord_username VARCHAR(37)
+  `;
+
+  await sql`
+    CREATE INDEX idx_users_discord_id ON users(discord_id)
+  `;
+}

--- a/common/user.ts
+++ b/common/user.ts
@@ -14,6 +14,9 @@ export type User = {
 
   // TODO(frolv): This is temporary for controlling initial access to the API.
   canCreateApiKey: boolean;
+
+  discordId: string | null;
+  discordUsername: string | null;
 };
 
 export enum RecordingType {

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,3 +1,4 @@
 BLERT_DATABASE_URI=postgres://blert:blert@localhost:5433/blert
 BLERT_REDIS_URI=redis://localhost:6379
+BLERT_DISCORD_BOT_SECRET=blert
 AUTH_SECRET=blert

--- a/web/__tests__/actions/admin.test.ts
+++ b/web/__tests__/actions/admin.test.ts
@@ -1,0 +1,207 @@
+import { grantApiAccess, verifyDiscordLink } from '@/actions/admin';
+import { sql } from '@/actions/db';
+
+describe('admin actions', () => {
+  let testUserId: number;
+  let testUserId2: number;
+
+  beforeEach(async () => {
+    const users = await sql<{ id: number }[]>`
+      INSERT INTO users (username, password, email)
+      VALUES
+        ('test-user', 'hashed-password', 'test-user@example.com'),
+        ('test-user-2', 'hashed-password-2', 'test-user-2@example.com')
+      RETURNING id
+    `;
+    testUserId = users[0].id;
+    testUserId2 = users[1].id;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM account_linking_codes`;
+    await sql`DELETE FROM users`;
+  });
+
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  describe('verifyDiscordLink', () => {
+    it('should successfully link a Discord account with a valid code', async () => {
+      const code = 'ABC12345';
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+      await sql`
+        INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+        VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+      `;
+
+      const result = await verifyDiscordLink(
+        code,
+        '123456789012345678',
+        'testuser#1234',
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user.id).toBe(testUserId);
+        expect(result.user.username).toBe('test-user');
+        expect(result.user.discordId).toBe('123456789012345678');
+        expect(result.user.discordUsername).toBe('testuser#1234');
+      }
+
+      const users = await sql<
+        { discord_id: string; discord_username: string }[]
+      >`
+        SELECT discord_id, discord_username
+        FROM users
+        WHERE id = ${testUserId}
+      `;
+      expect(users[0].discord_id).toBe('123456789012345678');
+      expect(users[0].discord_username).toBe('testuser#1234');
+
+      // Verify the code was deleted.
+      const codes = await sql`
+        SELECT * FROM account_linking_codes WHERE code = ${code}
+      `;
+      expect(codes).toHaveLength(0);
+    });
+
+    it('should return invalid_code error for non-existent code', async () => {
+      const result = await verifyDiscordLink(
+        'INVALID1',
+        '123456789012345678',
+        'testuser#1234',
+      );
+
+      expect(result).toEqual({ success: false, error: 'invalid_code' });
+    });
+
+    it('should return expired error and delete code when code is expired', async () => {
+      const code = 'EXPIRED1';
+      const expiresAt = new Date(Date.now() - 1000);
+
+      await sql`
+        INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+        VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+      `;
+
+      const result = await verifyDiscordLink(
+        code,
+        '123456789012345678',
+        'testuser#1234',
+      );
+
+      expect(result).toEqual({ success: false, error: 'expired' });
+
+      // Verify the expired code was deleted.
+      const codes = await sql`
+        SELECT * FROM account_linking_codes WHERE code = ${code}
+      `;
+      expect(codes).toHaveLength(0);
+    });
+
+    it('should return conflict error when Discord account is already linked to a different user', async () => {
+      await sql`
+        UPDATE users
+        SET discord_id = '123456789012345678', discord_username = 'existing#5678'
+        WHERE id = ${testUserId2}
+      `;
+
+      // Try to link the same Discord account to user 1.
+      const code = 'CNFLCT01';
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+      await sql`
+        INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+        VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+      `;
+
+      const result = await verifyDiscordLink(
+        code,
+        '123456789012345678',
+        'testuser#1234',
+      );
+
+      expect(result).toEqual({ success: false, error: 'conflict' });
+    });
+
+    it('should allow relinking the same Discord account to the same user', async () => {
+      await sql`
+        UPDATE users
+        SET discord_id = '123456789012345678', discord_username = 'old#1234'
+        WHERE id = ${testUserId}
+      `;
+
+      // Try to link the same Discord account to the same user with a new
+      // username.
+      const code = 'RELINK01';
+      const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+      await sql`
+        INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+        VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+      `;
+
+      const result = await verifyDiscordLink(
+        code,
+        '123456789012345678',
+        'new#5678',
+      );
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user.discordUsername).toBe('new#5678');
+      }
+    });
+  });
+
+  describe('grantApiAccess', () => {
+    it('should successfully grant API access to a user with linked Discord account', async () => {
+      await sql`
+        UPDATE users
+        SET discord_id = '123456789012345678', discord_username = 'testuser#1234'
+        WHERE id = ${testUserId}
+      `;
+
+      const result = await grantApiAccess('123456789012345678');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user.id).toBe(testUserId);
+        expect(result.user.username).toBe('test-user');
+        expect(result.user.canCreateApiKey).toBe(true);
+      }
+
+      const users = await sql<{ can_create_api_key: boolean }[]>`
+        SELECT can_create_api_key
+        FROM users
+        WHERE id = ${testUserId}
+      `;
+      expect(users[0].can_create_api_key).toBe(true);
+    });
+
+    it('should return user_not_found error when Discord ID is not linked', async () => {
+      const result = await grantApiAccess('999999999999999999');
+
+      expect(result).toEqual({ success: false, error: 'user_not_found' });
+    });
+
+    it('should be idempotent when granting access twice', async () => {
+      await sql`
+        UPDATE users
+        SET discord_id = '123456789012345678',
+            discord_username = 'testuser#1234',
+            can_create_api_key = true
+        WHERE id = ${testUserId}
+      `;
+
+      const result = await grantApiAccess('123456789012345678');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user.canCreateApiKey).toBe(true);
+      }
+    });
+  });
+});

--- a/web/__tests__/api/admin/auth.test.ts
+++ b/web/__tests__/api/admin/auth.test.ts
@@ -1,0 +1,73 @@
+import { validateDiscordBotAuth } from '@/api/admin/auth';
+
+describe('validateDiscordBotAuth', () => {
+  const originalEnv = process.env.BLERT_DISCORD_BOT_SECRET;
+
+  beforeEach(() => {
+    process.env.BLERT_DISCORD_BOT_SECRET = 'test-secret-key';
+  });
+
+  afterEach(() => {
+    process.env.BLERT_DISCORD_BOT_SECRET = originalEnv;
+  });
+
+  it('should return true for valid Bearer token', () => {
+    const authHeader = 'Bearer test-secret-key';
+    expect(validateDiscordBotAuth(authHeader)).toBe(true);
+  });
+
+  it('should return false for null header', () => {
+    expect(validateDiscordBotAuth(null)).toBe(false);
+  });
+
+  it('should return false for invalid secret', () => {
+    const authHeader = 'Bearer wrong-secret';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false for malformed header without Bearer prefix', () => {
+    const authHeader = 'test-secret-key';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false for malformed header with wrong prefix', () => {
+    const authHeader = 'Basic test-secret-key';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false for empty Bearer token', () => {
+    const authHeader = 'Bearer ';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false for header with extra spaces', () => {
+    const authHeader = 'Bearer  test-secret-key';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false for header with multiple parts', () => {
+    const authHeader = 'Bearer test-secret-key extra-part';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false when BLERT_DISCORD_BOT_SECRET is not configured', () => {
+    delete process.env.BLERT_DISCORD_BOT_SECRET;
+    const authHeader = 'Bearer test-secret-key';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should return false for secrets of different lengths (timing attack protection)', () => {
+    const authHeader = 'Bearer short';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should be case-sensitive for the secret', () => {
+    const authHeader = 'Bearer TEST-SECRET-KEY';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+
+  it('should be case-sensitive for the Bearer prefix', () => {
+    const authHeader = 'bearer test-secret-key';
+    expect(validateDiscordBotAuth(authHeader)).toBe(false);
+  });
+});

--- a/web/__tests__/api/admin/grant-api-access.test.ts
+++ b/web/__tests__/api/admin/grant-api-access.test.ts
@@ -1,0 +1,186 @@
+import { POST } from '@/api/admin/grant-api-access/route';
+import { sql } from '@/actions/db';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/api/admin/auth', () => ({
+  validateDiscordBotAuth: jest.fn(),
+}));
+
+import { validateDiscordBotAuth } from '@/api/admin/auth';
+
+const mockValidateAuth = validateDiscordBotAuth as jest.MockedFunction<
+  typeof validateDiscordBotAuth
+>;
+
+describe('POST /api/admin/grant-api-access', () => {
+  let testUserId: number;
+
+  beforeEach(async () => {
+    mockValidateAuth.mockClear();
+
+    const users = await sql<{ id: number }[]>`
+      INSERT INTO users (username, password, email)
+      VALUES ('test-user', 'hashed-password', 'test@example.com')
+      RETURNING id
+    `;
+    testUserId = users[0].id;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM users`;
+  });
+
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  const createRequest = (body: unknown, authHeader?: string | null) => {
+    const headers = new Headers();
+    if (authHeader !== undefined) {
+      if (authHeader !== null) {
+        headers.set('authorization', authHeader);
+      }
+    }
+
+    return new NextRequest('http://localhost:3000/api/admin/grant-api-access', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+  };
+
+  it('should return 401 when authentication fails', async () => {
+    mockValidateAuth.mockReturnValue(false);
+
+    const request = createRequest(
+      {
+        discordId: '123456789012345678',
+      },
+      'Bearer invalid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: 'unauthorized' });
+    expect(mockValidateAuth).toHaveBeenCalledWith('Bearer invalid');
+  });
+
+  it('should return 400 when request body is invalid JSON', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/grant-api-access',
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer valid' },
+        body: 'invalid json{',
+      },
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'invalid_body' });
+  });
+
+  it('should return 400 when discordId is missing', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = createRequest({}, 'Bearer valid');
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'missing_fields' });
+  });
+
+  it('should return 404 when user is not found', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = createRequest(
+      {
+        discordId: '999999999999999999',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toEqual({ error: 'user_not_found' });
+  });
+
+  it('should return 200 and grant API access successfully', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    await sql`
+      UPDATE users
+      SET discord_id = '123456789012345678', discord_username = 'testuser#1234'
+      WHERE id = ${testUserId}
+    `;
+
+    const request = createRequest(
+      {
+        discordId: '123456789012345678',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      user: {
+        id: testUserId,
+        username: 'test-user',
+        canCreateApiKey: true,
+      },
+    });
+
+    const users = await sql<{ can_create_api_key: boolean }[]>`
+      SELECT can_create_api_key
+      FROM users
+      WHERE id = ${testUserId}
+    `;
+    expect(users[0].can_create_api_key).toBe(true);
+  });
+
+  it('should be idempotent when granting access twice', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    await sql`
+      UPDATE users
+      SET discord_id = '123456789012345678',
+          discord_username = 'testuser#1234',
+          can_create_api_key = true
+      WHERE id = ${testUserId}
+    `;
+
+    const request = createRequest(
+      {
+        discordId: '123456789012345678',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      user: {
+        id: testUserId,
+        username: 'test-user',
+        canCreateApiKey: true,
+      },
+    });
+  });
+});

--- a/web/__tests__/api/admin/verify-link.test.ts
+++ b/web/__tests__/api/admin/verify-link.test.ts
@@ -1,0 +1,273 @@
+import { POST } from '@/api/admin/verify-link/route';
+import { sql } from '@/actions/db';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/api/admin/auth', () => ({
+  validateDiscordBotAuth: jest.fn(),
+}));
+
+import { validateDiscordBotAuth } from '@/api/admin/auth';
+
+const mockValidateAuth = validateDiscordBotAuth as jest.MockedFunction<
+  typeof validateDiscordBotAuth
+>;
+
+describe('POST /api/admin/verify-link', () => {
+  let testUserId: number;
+
+  beforeEach(async () => {
+    mockValidateAuth.mockClear();
+
+    const users = await sql<{ id: number }[]>`
+      INSERT INTO users (username, password, email)
+      VALUES ('test-user', 'hashed-password', 'test@example.com')
+      RETURNING id
+    `;
+    testUserId = users[0].id;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM account_linking_codes`;
+    await sql`DELETE FROM users`;
+  });
+
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  const createRequest = (body: unknown, authHeader?: string | null) => {
+    const headers = new Headers();
+    if (authHeader !== undefined) {
+      if (authHeader !== null) {
+        headers.set('authorization', authHeader);
+      }
+    }
+
+    return new NextRequest('http://localhost:3000/api/admin/verify-link', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+  };
+
+  it('should return 401 when authentication fails', async () => {
+    mockValidateAuth.mockReturnValue(false);
+
+    const request = createRequest(
+      {
+        code: 'ABC12345',
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer invalid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data).toEqual({ error: 'unauthorized' });
+    expect(mockValidateAuth).toHaveBeenCalledWith('Bearer invalid');
+  });
+
+  it('should return 400 when request body is invalid JSON', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = new NextRequest(
+      'http://localhost:3000/api/admin/verify-link',
+      {
+        method: 'POST',
+        headers: { authorization: 'Bearer valid' },
+        body: 'invalid json{',
+      },
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'invalid_body' });
+  });
+
+  it('should return 400 when code is missing', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = createRequest(
+      {
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'missing_fields' });
+  });
+
+  it('should return 400 when discordId is missing', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = createRequest(
+      {
+        code: 'ABC12345',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'missing_fields' });
+  });
+
+  it('should return 400 when discordUsername is missing', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = createRequest(
+      {
+        code: 'ABC12345',
+        discordId: '123456789012345678',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({ error: 'missing_fields' });
+  });
+
+  it('should return 404 when code is invalid', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const request = createRequest(
+      {
+        code: 'INVALID1',
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data).toEqual({ error: 'invalid_code' });
+  });
+
+  it('should return 410 when code is expired', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const code = 'EXPIRED1';
+    const expiresAt = new Date(Date.now() - 1000);
+
+    await sql`
+      INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+      VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+    `;
+
+    const request = createRequest(
+      {
+        code,
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(410);
+    expect(data).toEqual({ error: 'expired' });
+  });
+
+  it('should return 409 when Discord account is already linked to another user', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    // Create another user with the Discord account
+    await sql`
+      INSERT INTO users (username, password, email, discord_id, discord_username)
+      VALUES ('other-user', 'password', 'other@example.com', '123456789012345678', 'existing#5678')
+    `;
+
+    const code = 'CNFLCT01';
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+    await sql`
+      INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+      VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+    `;
+
+    const request = createRequest(
+      {
+        code,
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data).toEqual({ error: 'conflict' });
+  });
+
+  it('should return 200 and link Discord account successfully', async () => {
+    mockValidateAuth.mockReturnValue(true);
+
+    const code = 'VALID001';
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+
+    await sql`
+      INSERT INTO account_linking_codes (code, user_id, type, expires_at)
+      VALUES (${code}, ${testUserId}, 'discord', ${expiresAt})
+    `;
+
+    const request = createRequest(
+      {
+        code,
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+      'Bearer valid',
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      user: {
+        id: testUserId,
+        username: 'test-user',
+        discordId: '123456789012345678',
+        discordUsername: 'testuser#1234',
+      },
+    });
+
+    // User should be updated and the code should be deleted.
+    const users = await sql<{ discord_id: string; discord_username: string }[]>`
+      SELECT discord_id, discord_username
+      FROM users
+      WHERE id = ${testUserId}
+    `;
+    expect(users[0].discord_id).toBe('123456789012345678');
+    expect(users[0].discord_username).toBe('testuser#1234');
+
+    const codes = await sql`
+      SELECT * FROM account_linking_codes WHERE code = ${code}
+    `;
+    expect(codes).toHaveLength(0);
+  });
+});

--- a/web/app/(account)/settings/account/page.tsx
+++ b/web/app/(account)/settings/account/page.tsx
@@ -1,0 +1,41 @@
+import { getSignedInUser } from '@/actions/users';
+import Card from '@/components/card';
+
+import PasswordSection from './password-section';
+
+import styles from '../style.module.scss';
+
+export default async function AccountSettings() {
+  const user = await getSignedInUser();
+  if (user === null) {
+    return null;
+  }
+
+  return (
+    <>
+      <Card className={styles.header} primary>
+        <h1>Account Settings</h1>
+        <div className={styles.accountInfo}>
+          <div className={styles.field}>
+            <label>Username</label>
+            <div className={styles.value}>
+              {user.username}
+              <span className={styles.memberSince}>
+                Member since {user.createdAt.toLocaleDateString()}
+              </span>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <PasswordSection />
+    </>
+  );
+}
+
+export const metadata = {
+  title: 'Account Settings',
+  description: 'Manage your Blert account settings.',
+};
+
+export const dynamic = 'force-dynamic';

--- a/web/app/(account)/settings/account/password-reset-form.tsx
+++ b/web/app/(account)/settings/account/password-reset-form.tsx
@@ -8,7 +8,7 @@ import Button from '@/components/button';
 import Input from '@/components/input';
 import { useToast } from '@/components/toast';
 
-import styles from './style.module.scss';
+import styles from '../style.module.scss';
 
 function FormFields({ errors }: { errors: PasswordResetErrors | null }) {
   const { pending } = useFormStatus();

--- a/web/app/(account)/settings/account/password-section.tsx
+++ b/web/app/(account)/settings/account/password-section.tsx
@@ -1,6 +1,6 @@
 import PasswordResetForm from './password-reset-form';
 
-import styles from './style.module.scss';
+import styles from '../style.module.scss';
 
 export default function PasswordSection() {
   return (

--- a/web/app/(account)/settings/api-keys/api-key-form.tsx
+++ b/web/app/(account)/settings/api-keys/api-key-form.tsx
@@ -11,7 +11,7 @@ import {
 import Button from '@/components/button';
 import Input from '@/components/input';
 
-import styles from './style.module.scss';
+import styles from '../style.module.scss';
 
 function FormFields() {
   const { pending } = useFormStatus();

--- a/web/app/(account)/settings/api-keys/api-key.tsx
+++ b/web/app/(account)/settings/api-keys/api-key.tsx
@@ -7,7 +7,7 @@ import Button from '@/components/button';
 import { Modal } from '@/components/modal/modal';
 import { useToast } from '@/components/toast';
 
-import styles from './style.module.scss';
+import styles from '../style.module.scss';
 
 type ApiKeyProps = {
   apiKey: ApiKeyWithUsername;
@@ -30,7 +30,7 @@ export default function ApiKey({ apiKey, onDelete }: ApiKeyProps) {
     try {
       await deleteApiKey(apiKey.key);
       onDelete();
-    } catch (e) {
+    } catch {
       showToast('Failed to delete API key');
     }
     setIsDeleting(false);
@@ -57,7 +57,7 @@ export default function ApiKey({ apiKey, onDelete }: ApiKeyProps) {
             <button
               title="Copy key"
               className={styles.action}
-              onClick={handleCopy}
+              onClick={() => void handleCopy()}
             >
               <i className="fa-solid fa-copy" />
             </button>
@@ -101,7 +101,7 @@ export default function ApiKey({ apiKey, onDelete }: ApiKeyProps) {
             >
               Cancel
             </Button>
-            <Button onClick={handleDelete} loading={isDeleting}>
+            <Button onClick={() => void handleDelete()} loading={isDeleting}>
               Delete
             </Button>
           </div>

--- a/web/app/(account)/settings/api-keys/api-keys-section.tsx
+++ b/web/app/(account)/settings/api-keys/api-keys-section.tsx
@@ -7,7 +7,7 @@ import { ApiKeyWithUsername } from '@/actions/users';
 import ApiKey from './api-key';
 import ApiKeyForm from './api-key-form';
 
-import styles from './style.module.scss';
+import styles from '../style.module.scss';
 
 type ApiKeysSectionProps = {
   initialApiKeys: ApiKeyWithUsername[];

--- a/web/app/(account)/settings/api-keys/page.tsx
+++ b/web/app/(account)/settings/api-keys/page.tsx
@@ -1,0 +1,16 @@
+import { getUserSettings } from '@/actions/users';
+
+import ApiKeysSection from './api-keys-section';
+
+export default async function ApiKeysSettings() {
+  const settings = await getUserSettings();
+
+  return <ApiKeysSection initialApiKeys={settings.apiKeys} />;
+}
+
+export const metadata = {
+  title: 'API Keys',
+  description: 'Manage your Blert API keys.',
+};
+
+export const dynamic = 'force-dynamic';

--- a/web/app/(account)/settings/layout.tsx
+++ b/web/app/(account)/settings/layout.tsx
@@ -1,0 +1,29 @@
+import { redirect } from 'next/navigation';
+
+import { getSignedInUser } from '@/actions/users';
+
+import SettingsTabs from './settings-tabs';
+
+import styles from './style.module.scss';
+
+export default async function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const user = await getSignedInUser();
+  if (user === null) {
+    redirect('/login?next=/settings');
+  }
+
+  return (
+    <div className={styles.settings}>
+      <div className={styles.settingsInner}>
+        <SettingsTabs />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export const dynamic = 'force-dynamic';

--- a/web/app/(account)/settings/linked-accounts/discord-linking-section.tsx
+++ b/web/app/(account)/settings/linked-accounts/discord-linking-section.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { DiscordLinkStatus, LinkingCode } from '@/actions/users';
+import {
+  generateDiscordLinkingCode,
+  getDiscordLinkStatus,
+  unlinkDiscord,
+} from '@/actions/users';
+import ConfirmationModal from '@/components/confirmation-modal';
+import { useToast } from '@/components/toast';
+import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
+
+import styles from '../style.module.scss';
+
+type Props = {
+  initialStatus: DiscordLinkStatus;
+  initialLinkingCode: LinkingCode | null;
+  autoGenerate: boolean;
+};
+
+export default function DiscordLinkingSection({
+  initialStatus,
+  initialLinkingCode,
+  autoGenerate,
+}: Props) {
+  const [linkStatus, setLinkStatus] = useState(initialStatus);
+  const [linkingCode, setLinkingCode] = useState<LinkingCode | null>(
+    initialLinkingCode,
+  );
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isUnlinking, setIsUnlinking] = useState(false);
+  const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
+  const [isCopied, setIsCopied] = useState(false);
+  const [showUnlinkModal, setShowUnlinkModal] = useState(false);
+  const [showLinkSuccess, setShowLinkSuccess] = useState(false);
+  const successTimeoutRef = useRef<number | null>(null);
+  const previousLinkState = useRef(linkStatus.isLinked);
+  const showToast = useToast();
+
+  // Auto-generate code if URL param is present.
+  useEffect(() => {
+    if (autoGenerate && !linkStatus.isLinked && !linkingCode) {
+      void handleGenerateCode();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!linkingCode) {
+      setTimeRemaining(null);
+      return;
+    }
+
+    const updateTimer = () => {
+      const now = Date.now();
+      const expiresAt = new Date(linkingCode.expiresAt).getTime();
+      const remaining = Math.max(0, Math.floor((expiresAt - now) / 1000));
+      setTimeRemaining(remaining);
+
+      if (remaining === 0) {
+        setLinkingCode(null);
+        showToast('Linking code expired. Generate a new one.', 'info');
+      }
+    };
+
+    updateTimer();
+    const interval = setInterval(updateTimer, 1000);
+
+    return () => clearInterval(interval);
+  }, [linkingCode, showToast]);
+
+  useEffect(() => {
+    if (!linkingCode || linkStatus.isLinked) {
+      return;
+    }
+
+    let isCancelled = false;
+    const POLL_INTERVAL_MS = 5000;
+
+    const refreshLinkStatus = async () => {
+      try {
+        const status = await getDiscordLinkStatus();
+        if (isCancelled) {
+          return;
+        }
+
+        const shouldClearCode = status.isLinked;
+        setLinkStatus((previous) => {
+          if (
+            previous.isLinked === status.isLinked &&
+            previous.discordId === status.discordId &&
+            previous.discordUsername === status.discordUsername
+          ) {
+            return previous;
+          }
+
+          return status;
+        });
+
+        if (shouldClearCode) {
+          setLinkingCode(null);
+        }
+      } catch (error) {
+        console.error('Failed to refresh Discord link status', error);
+      }
+    };
+
+    const interval = window.setInterval(() => {
+      void refreshLinkStatus();
+    }, POLL_INTERVAL_MS);
+
+    void refreshLinkStatus();
+
+    return () => {
+      isCancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [linkingCode, linkStatus.isLinked]);
+
+  useEffect(() => {
+    if (!previousLinkState.current && linkStatus.isLinked) {
+      setShowLinkSuccess(true);
+    }
+    previousLinkState.current = linkStatus.isLinked;
+  }, [linkStatus.isLinked]);
+
+  useEffect(() => {
+    if (!showLinkSuccess) {
+      return;
+    }
+
+    if (successTimeoutRef.current) {
+      window.clearTimeout(successTimeoutRef.current);
+    }
+
+    successTimeoutRef.current = window.setTimeout(() => {
+      setShowLinkSuccess(false);
+    }, 3500);
+
+    return () => {
+      if (successTimeoutRef.current) {
+        window.clearTimeout(successTimeoutRef.current);
+        successTimeoutRef.current = null;
+      }
+    };
+  }, [showLinkSuccess]);
+
+  const handleGenerateCode = async () => {
+    setIsGenerating(true);
+    try {
+      const code = await generateDiscordLinkingCode();
+      setLinkingCode(code);
+      showToast('Linking code generated!', 'success');
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : 'Failed to generate code',
+        'error',
+      );
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleUnlinkConfirm = async () => {
+    setIsUnlinking(true);
+    try {
+      await unlinkDiscord();
+      setLinkStatus({
+        isLinked: false,
+        discordId: null,
+        discordUsername: null,
+      });
+      setShowUnlinkModal(false);
+      showToast('Discord account unlinked', 'success');
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : 'Failed to unlink account',
+        'error',
+      );
+    } finally {
+      setIsUnlinking(false);
+    }
+  };
+
+  const handleCopyCode = async () => {
+    if (!linkingCode) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(linkingCode.code);
+      setIsCopied(true);
+      showToast('Code copied to clipboard!', 'success');
+      setTimeout(() => setIsCopied(false), 4000);
+    } catch {
+      showToast('Failed to copy code', 'error');
+    }
+  };
+
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const selectText = (element: HTMLElement) => {
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  };
+
+  return (
+    <>
+      <div className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <h2>
+            <i className="fab fa-discord" />
+            Discord
+          </h2>
+        </div>
+
+        {showLinkSuccess ? (
+          <div className={styles.linkSuccess}>
+            <div className={styles.successIcon}>
+              <i className="fas fa-check" />
+            </div>
+            <div className={styles.successContent}>
+              <h3>Discord linked!</h3>
+              <p>
+                {linkStatus.discordUsername ? (
+                  <span>{linkStatus.discordUsername}</span>
+                ) : (
+                  'Your Discord account '
+                )}
+                is now connected.
+              </p>
+            </div>
+          </div>
+        ) : linkStatus.isLinked ? (
+          <div className={styles.linkedAccount}>
+            <div className={styles.accountInfo}>
+              <i className={`fas fa-check-circle ${styles.linkedIcon}`} />
+              <div className={styles.accountDetails}>
+                <div className={styles.accountLabel}>Linked Account</div>
+                <div className={styles.accountValue}>
+                  {linkStatus.discordUsername}
+                </div>
+              </div>
+            </div>
+            <button
+              className={styles.unlinkButton}
+              onClick={() => setShowUnlinkModal(true)}
+              disabled={isUnlinking}
+            >
+              <i className="fas fa-unlink" />
+              Unlink
+            </button>
+          </div>
+        ) : (
+          <div className={styles.unlinkedAccount}>
+            <div className={styles.instructionsBox}>
+              <div className={styles.step}>
+                <div className={styles.stepNumber}>1</div>
+                <div className={styles.stepContent}>
+                  <h3>Generate a verification code</h3>
+                  <p>
+                    Click the button below to generate a unique code that
+                    expires in 15 minutes.
+                  </p>
+                </div>
+              </div>
+              <div className={styles.step}>
+                <div className={styles.stepNumber}>2</div>
+                <div className={styles.stepContent}>
+                  <h3>Enter the code in Discord</h3>
+                  <p>
+                    Use the <code>/verify</code> command in the Blert Discord
+                    server and paste your code.
+                  </p>
+                </div>
+              </div>
+              <div className={`${styles.step} ${styles.completion}`}>
+                <div className={styles.stepContent}>
+                  <h3>That&apos;s it! You&apos;re done.</h3>
+                </div>
+              </div>
+            </div>
+
+            {linkingCode ? (
+              <div className={styles.codeDisplay}>
+                <div className={styles.codeBox}>
+                  <div className={styles.codeLabel}>Your verification code</div>
+                  <div className={styles.codeValue}>
+                    <span onClick={(e) => selectText(e.currentTarget)}>
+                      {linkingCode.code}
+                    </span>
+                    <button
+                      className={styles.copyButton}
+                      onClick={() => void handleCopyCode()}
+                      disabled={isCopied}
+                      data-tooltip-id={GLOBAL_TOOLTIP_ID}
+                      data-tooltip-content={isCopied ? 'Copied!' : 'Copy code'}
+                    >
+                      <i className={`fas fa-${isCopied ? 'check' : 'copy'}`} />
+                    </button>
+                  </div>
+                  {timeRemaining !== null && (
+                    <div className={styles.codeExpiry}>
+                      Expires in{' '}
+                      <span className={styles.time}>
+                        {formatTime(timeRemaining)}
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <p className={styles.codeHint}>
+                  Copy this code and use{' '}
+                  <code onClick={(e) => selectText(e.currentTarget)}>
+                    /verify {linkingCode.code}
+                  </code>{' '}
+                  in the Blert Discord server.
+                </p>
+              </div>
+            ) : (
+              <button
+                className={styles.generateButton}
+                onClick={() => void handleGenerateCode()}
+                disabled={isGenerating}
+              >
+                {isGenerating ? (
+                  <>
+                    <i className="fas fa-spinner fa-spin" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <i className="fas fa-key" />
+                    Generate Linking Code
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ConfirmationModal
+        open={showUnlinkModal}
+        onClose={() => setShowUnlinkModal(false)}
+        onConfirm={() => void handleUnlinkConfirm()}
+        title="Unlink Discord Account"
+        message={
+          <>
+            Are you sure you want to unlink your Discord account{' '}
+            <strong>{linkStatus.discordUsername}</strong>? You will need to
+            generate a new code to link it again.
+          </>
+        }
+        confirmText="Unlink"
+        cancelText="Cancel"
+        variant="danger"
+        loading={isUnlinking}
+      />
+    </>
+  );
+}

--- a/web/app/(account)/settings/linked-accounts/page.tsx
+++ b/web/app/(account)/settings/linked-accounts/page.tsx
@@ -1,0 +1,44 @@
+import { getActiveLinkingCode, getDiscordLinkStatus } from '@/actions/users';
+
+import Card from '@/components/card';
+
+import DiscordLinkingSection from './discord-linking-section';
+
+import styles from '../style.module.scss';
+
+export default async function LinkedAccountsSettings({
+  searchParams,
+}: {
+  searchParams: Promise<{ generate?: string }>;
+}) {
+  const [linkStatus, activeLinkingCode] = await Promise.all([
+    getDiscordLinkStatus(),
+    getActiveLinkingCode(),
+  ]);
+  const params = await searchParams;
+  const autoGenerate = params.generate === 'discord';
+
+  return (
+    <>
+      <Card className={styles.header} primary>
+        <h1>Linked Accounts</h1>
+        <p className={styles.description}>
+          Connect external accounts to unlock special Blert integrations.
+        </p>
+      </Card>
+
+      <DiscordLinkingSection
+        initialStatus={linkStatus}
+        initialLinkingCode={activeLinkingCode}
+        autoGenerate={autoGenerate}
+      />
+    </>
+  );
+}
+
+export const metadata = {
+  title: 'Linked Accounts',
+  description: 'Link your Discord account to Blert.',
+};
+
+export const dynamic = 'force-dynamic';

--- a/web/app/(account)/settings/page.tsx
+++ b/web/app/(account)/settings/page.tsx
@@ -1,50 +1,5 @@
 import { redirect } from 'next/navigation';
 
-import { getSignedInUser, getUserSettings } from '@/actions/users';
-import Card from '@/components/card';
-
-import ApiKeysSection from './api-keys-section';
-import PasswordSection from './password-section';
-
-import styles from './style.module.scss';
-
-export default async function Settings() {
-  const user = await getSignedInUser();
-  if (user === null) {
-    redirect('/login?next=/settings');
-  }
-
-  const settings = await getUserSettings();
-
-  return (
-    <div className={styles.settings}>
-      <div className={styles.settingsInner}>
-        <Card className={styles.header} primary>
-          <h1>Account Settings</h1>
-          <div className={styles.accountInfo}>
-            <div className={styles.field}>
-              <label>Username</label>
-              <div className={styles.value}>
-                {user.username}
-                <span className={styles.memberSince}>
-                  Member since {user.createdAt.toLocaleDateString()}
-                </span>
-              </div>
-            </div>
-          </div>
-        </Card>
-
-        <PasswordSection />
-
-        <ApiKeysSection initialApiKeys={settings.apiKeys} />
-      </div>
-    </div>
-  );
+export default function Settings() {
+  redirect('/settings/account');
 }
-
-export const metadata = {
-  title: 'Account Settings',
-  description: 'Manage your Blert account settings and API keys.',
-};
-
-export const dynamic = 'force-dynamic';

--- a/web/app/(account)/settings/settings-tabs.tsx
+++ b/web/app/(account)/settings/settings-tabs.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import styles from './style.module.scss';
+
+export default function SettingsTabs() {
+  const pathname = usePathname();
+
+  const tabs = [
+    { href: '/settings/account', label: 'Account', icon: 'fas fa-user' },
+    { href: '/settings/api-keys', label: 'API Keys', icon: 'fas fa-key' },
+    {
+      href: '/settings/linked-accounts',
+      label: 'Linked Accounts',
+      icon: 'fas fa-link',
+    },
+  ];
+
+  return (
+    <div className={styles.tabs}>
+      {tabs.map((tab) => (
+        <Link
+          key={tab.href}
+          href={tab.href}
+          className={styles.tab}
+          aria-current={pathname === tab.href ? 'page' : undefined}
+        >
+          <i className={tab.icon} />
+          <span>{tab.label}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/web/app/(account)/settings/style.module.scss
+++ b/web/app/(account)/settings/style.module.scss
@@ -1,9 +1,11 @@
 @use '../../mixins.scss' as *;
 
 .settings {
+  width: 100%;
   max-width: 800px;
   margin: 0 auto;
   padding: 32px 20px;
+  min-height: calc(100vh - 120px);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     padding: 0;
@@ -15,9 +17,71 @@
   display: flex;
   flex-direction: column;
   gap: 32px;
+  align-items: stretch;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     gap: 16px;
+  }
+}
+
+.tabs {
+  display: flex;
+  gap: 0;
+  padding: 0;
+  margin-bottom: 32px;
+  background: var(--nav-bg);
+  border-radius: 8px;
+  overflow: hidden;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    margin-bottom: 16px;
+    border-bottom-width: 1px;
+    border-radius: 0;
+  }
+
+  .tab {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 14px 20px;
+    text-align: center;
+    text-decoration: none;
+    color: var(--font-color-nav);
+    font-weight: 500;
+    border-bottom: 3px solid transparent;
+    transition: all 0.2s ease;
+    position: relative;
+    background: transparent;
+    letter-spacing: -0.01em;
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      padding: 12px 12px;
+      font-size: 0.9em;
+      border-bottom-width: 2px;
+    }
+
+    i {
+      font-size: 0.9em;
+    }
+
+    &:hover {
+      color: var(--blert-text-color);
+      border-bottom-color: rgba(var(--blert-button-base), 0.3);
+      background: rgba(var(--nav-bg-lightened-base), 0.5);
+    }
+
+    &[aria-current='page'] {
+      color: var(--blert-text-color);
+      border-bottom-color: var(--blert-button);
+      background: rgba(var(--blert-button-base), 0.05);
+      font-weight: 600;
+
+      i {
+        color: var(--blert-button);
+      }
+    }
   }
 }
 
@@ -78,6 +142,11 @@
     color: var(--font-color-nav);
     font-size: 0.95em;
     line-height: 1.5;
+  }
+
+  i {
+    margin-right: 12px;
+    color: var(--blert-button);
   }
 }
 
@@ -336,6 +405,378 @@
 
     button {
       min-width: 80px;
+    }
+  }
+}
+
+.description {
+  margin: 8px 0 0 0;
+  color: var(--font-color-nav);
+  font-size: 0.95em;
+  line-height: 1.5;
+}
+
+.linkSuccess {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  border-radius: 12px;
+  background: rgba(var(--blert-green-base), 0.05);
+  border: 1px solid rgba(var(--blert-green-base), 0.4);
+  box-shadow: 0 2px 8px rgba(var(--blert-green-base), 0.2);
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .successIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: rgba(var(--blert-green-base), 0.2);
+    color: var(--blert-green);
+    font-size: 1.8em;
+    flex-shrink: 0;
+  }
+
+  .successContent {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    h3 {
+      margin: 0;
+      font-size: 1.4em;
+      color: var(--blert-text-color);
+    }
+
+    p {
+      margin: 0;
+      font-size: 0.95em;
+      color: rgba(var(--blert-text-color-base), 0.85);
+
+      & > span {
+        color: var(--blert-green);
+        font-weight: 600;
+        margin-right: 4px;
+      }
+    }
+
+    & > span {
+      font-size: 0.85em;
+      color: var(--font-color-nav);
+    }
+  }
+}
+
+.linkedAccount {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px;
+  background: var(--nav-bg);
+  border-radius: 8px;
+  gap: 20px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .accountInfo {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+
+    .linkedIcon {
+      color: var(--blert-button);
+      font-size: 1.5em;
+    }
+
+    .accountDetails {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+
+      .accountLabel {
+        font-size: 0.85em;
+        color: var(--font-color-nav);
+      }
+
+      .accountValue {
+        font-size: 1.1em;
+        font-weight: 600;
+        color: var(--blert-text-color);
+      }
+    }
+  }
+
+  .unlinkButton {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    background: transparent;
+    border: 1px solid var(--blert-red);
+    border-radius: 6px;
+    color: var(--blert-red);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover:not(:disabled) {
+      background: var(--blert-red);
+      color: #fff;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.unlinkedAccount {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  * {
+    user-select: text;
+  }
+
+  .instructionsBox {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 20px;
+    background: rgba(var(--blert-button-base), 0.02);
+    border: 1px solid rgba(var(--blert-button-base), 0.15);
+    border-radius: 8px;
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      padding: 16px;
+    }
+
+    .step {
+      display: flex;
+      gap: 16px;
+
+      .stepNumber {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        background: rgba(var(--blert-button-base), 0.15);
+        color: var(--blert-button);
+        border-radius: 50%;
+        font-weight: 600;
+        font-size: 0.85em;
+      }
+
+      .stepContent {
+        flex: 1;
+
+        h3 {
+          margin: 0 0 8px 0;
+          font-size: 1em;
+          color: var(--blert-text-color);
+        }
+
+        p {
+          margin: 0;
+          font-size: 0.9em;
+          color: var(--font-color-nav);
+          line-height: 1.5;
+        }
+      }
+
+      &.completion .stepContent {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+
+        h3 {
+          margin: 0;
+        }
+      }
+    }
+  }
+
+  code {
+    padding: 3px 8px;
+    background: var(--nav-bg);
+    border-radius: 4px;
+    font-family: var(--font-roboto-mono), monospace;
+    font-size: 0.95em;
+    color: var(--blert-button);
+    cursor: text;
+    user-select: all;
+
+    &::selection {
+      background: rgba(var(--blert-button-base), 0.3);
+    }
+  }
+
+  .codeDisplay {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    .codeBox {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 32px;
+      background: linear-gradient(
+        135deg,
+        rgba(var(--blert-button-base), 0.1) 0%,
+        rgba(var(--blert-button-base), 0.05) 100%
+      );
+      border: 2px dashed rgba(var(--blert-button-base), 0.3);
+      border-radius: 12px;
+      gap: 12px;
+
+      @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+        padding: 24px;
+      }
+
+      .codeLabel {
+        font-size: 0.9em;
+        color: var(--font-color-nav);
+        font-weight: 500;
+      }
+
+      .codeValue {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        font-family: var(--font-roboto-mono), monospace;
+        font-size: 2em;
+        font-weight: 700;
+        color: var(--blert-button);
+        letter-spacing: 0.2em;
+        cursor: text;
+
+        @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+          font-size: 1.5em;
+          gap: 12px;
+        }
+
+        span {
+          user-select: all;
+        }
+
+        &::selection {
+          background: rgba(var(--blert-button-base), 0.3);
+        }
+      }
+
+      .copyButton {
+        position: absolute;
+        right: -46px;
+        top: 50%;
+        transform: translateY(-50%);
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border-radius: 6px;
+        border: 1px solid rgba(var(--blert-button-base), 0.3);
+        background: rgba(var(--nav-bg-base), 0.5);
+        color: var(--blert-button);
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+          width: 32px;
+          height: 32px;
+        }
+
+        &:hover:not(:disabled) {
+          background: rgba(var(--blert-button-base), 0.15);
+          border-color: var(--blert-button);
+        }
+
+        &:disabled {
+          color: var(--blert-green);
+          border-color: rgba(var(--blert-green-base), 0.3);
+          background: rgba(var(--blert-green-base), 0.1);
+          cursor: default;
+        }
+
+        i {
+          font-size: 1em;
+        }
+      }
+
+      .codeExpiry {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        font-size: 0.85em;
+        color: var(--font-color-nav);
+        padding: 6px 12px;
+        background: var(--nav-bg);
+        border-radius: 20px;
+
+        .time {
+          font-family: var(--font-roboto-mono), monospace;
+          font-size: 0.95em;
+        }
+      }
+    }
+
+    .codeHint {
+      text-align: center;
+      color: var(--font-color-nav);
+      font-size: 0.9em;
+      line-height: 1.5;
+      margin: 0;
+    }
+  }
+
+  .generateButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 12px 24px;
+    background: rgba(var(--blert-button-base), 0.9);
+    border: none;
+    border-radius: 8px;
+    color: #fff;
+    font-size: 1em;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    align-self: center;
+
+    &:hover:not(:disabled) {
+      background: rgba(var(--blert-button-base), 0.8);
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.4);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    i {
+      font-size: 1.1em;
     }
   }
 }

--- a/web/app/actions/admin.ts
+++ b/web/app/actions/admin.ts
@@ -1,0 +1,162 @@
+'use server';
+
+import { isPostgresUniqueViolation, User } from '@blert/common';
+
+import { sql } from './db';
+
+type LinkedUser = Pick<
+  User,
+  'id' | 'username' | 'discordId' | 'discordUsername'
+>;
+
+export type VerifyLinkResult =
+  | {
+      success: true;
+      user: LinkedUser;
+    }
+  | {
+      success: false;
+      error:
+        | 'invalid_code'
+        | 'expired'
+        | 'conflict'
+        | 'user_not_found'
+        | 'internal_error';
+    };
+
+/**
+ * Verifies a Discord linking code and links the Discord account to the Blert
+ * user.
+ *
+ * @param code The 8-character linking code
+ * @param discordId The Discord user ID
+ * @param discordUsername The Discord username
+ * @returns Result object with user data on success or error on failure
+ */
+export async function verifyDiscordLink(
+  code: string,
+  discordId: string,
+  discordUsername: string,
+): Promise<VerifyLinkResult> {
+  const linkingCodeResult = await sql<{ user_id: number; expires_at: Date }[]>`
+    SELECT user_id, expires_at
+    FROM account_linking_codes
+    WHERE code = ${code}
+    AND type = 'discord'
+  `;
+
+  if (linkingCodeResult.length === 0) {
+    return { success: false, error: 'invalid_code' };
+  }
+
+  const { user_id: userId, expires_at: expiresAt } = linkingCodeResult[0];
+
+  if (new Date() > expiresAt) {
+    await sql`
+      DELETE FROM account_linking_codes
+      WHERE code = ${code}
+    `;
+
+    return { success: false, error: 'expired' };
+  }
+
+  const existingLinkResult = await sql<{ id: number; username: string }[]>`
+    SELECT id, username
+    FROM users
+    WHERE discord_id = ${discordId}
+  `;
+
+  if (existingLinkResult.length > 0) {
+    const existingUser = existingLinkResult[0];
+    if (existingUser.id !== userId) {
+      return { success: false, error: 'conflict' };
+    }
+  }
+
+  let user: LinkedUser;
+
+  try {
+    const [userResult] = await sql<
+      {
+        id: number;
+        username: string;
+        discord_id: string;
+        discord_username: string;
+      }[]
+    >`
+      UPDATE users
+      SET discord_id = ${discordId},
+          discord_username = ${discordUsername}
+      WHERE id = ${userId}
+      RETURNING id, username, discord_id, discord_username
+    `;
+
+    if (!userResult) {
+      // This is unlikely to occur as it would require the user to be deleted
+      // between reading the linking code from the database and updating the
+      // user.
+      return { success: false, error: 'user_not_found' };
+    }
+
+    user = {
+      id: userResult.id,
+      username: userResult.username,
+      discordId: userResult.discord_id,
+      discordUsername: userResult.discord_username,
+    };
+  } catch (e) {
+    if (isPostgresUniqueViolation(e)) {
+      return { success: false, error: 'conflict' };
+    }
+    console.error('Error verifying Discord link:', e);
+    return { success: false, error: 'internal_error' };
+  }
+
+  await sql`
+    DELETE FROM account_linking_codes
+    WHERE code = ${code}
+  `;
+
+  return { success: true, user };
+}
+
+export type GrantApiAccessResult =
+  | {
+      success: true;
+      user: { id: number; username: string; canCreateApiKey: boolean };
+    }
+  | { success: false; error: 'user_not_found' };
+
+/**
+ * Grants API key creation access to a user by their Discord ID.
+ *
+ * @param discordId The Discord user ID
+ * @returns Result object with user data on success or error on failure
+ */
+export async function grantApiAccess(
+  discordId: string,
+): Promise<GrantApiAccessResult> {
+  const result = await sql<
+    { id: number; username: string; can_create_api_key: boolean }[]
+  >`
+    UPDATE users
+    SET can_create_api_key = true
+    WHERE discord_id = ${discordId}
+    RETURNING id, username, can_create_api_key
+  `;
+
+  if (result.length === 0) {
+    return { success: false, error: 'user_not_found' };
+  }
+
+  const user = result[0];
+
+  return {
+    success: true,
+    user: {
+      id: user.id,
+      username: user.username,
+      canCreateApiKey: user.can_create_api_key,
+    },
+  };
+}

--- a/web/app/api/admin/auth.ts
+++ b/web/app/api/admin/auth.ts
@@ -1,0 +1,39 @@
+import { timingSafeEqual } from 'crypto';
+
+/**
+ * Validates the Discord bot secret from the Authorization header.
+ *
+ * @param authHeader The Authorization header value (e.g., "Bearer <secret>")
+ * @returns True if the secret is valid, false otherwise
+ */
+export function validateDiscordBotAuth(authHeader: string | null): boolean {
+  if (authHeader === null) {
+    return false;
+  }
+
+  const secret = process.env.BLERT_DISCORD_BOT_SECRET;
+  if (!secret) {
+    console.error('BLERT_DISCORD_BOT_SECRET is not configured');
+    return false;
+  }
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return false;
+  }
+
+  const providedSecret = parts[1];
+  try {
+    const secretBuffer = Buffer.from(secret, 'utf-8');
+    const providedBuffer = Buffer.from(providedSecret, 'utf-8');
+
+    // Buffers must be the same length for timingSafeEqual.
+    if (secretBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(secretBuffer, providedBuffer);
+  } catch {
+    return false;
+  }
+}

--- a/web/app/api/admin/grant-api-access/route.ts
+++ b/web/app/api/admin/grant-api-access/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server';
+
+import { grantApiAccess } from '@/actions/admin';
+
+import { validateDiscordBotAuth } from '../auth';
+
+type GrantApiAccessRequest = {
+  discordId: string;
+};
+
+/**
+ * Admin endpoint for Discord bot to grant API key creation access to a user.
+ *
+ * @param request Request with `{ discordId }` in body.
+ * @returns 200 with user info on success, or error response on failure.
+ */
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!validateDiscordBotAuth(authHeader)) {
+    return Response.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  let body: GrantApiAccessRequest;
+  try {
+    body = (await request.json()) as GrantApiAccessRequest;
+  } catch {
+    return Response.json({ error: 'invalid_body' }, { status: 400 });
+  }
+
+  const { discordId } = body;
+
+  if (!discordId) {
+    return Response.json({ error: 'missing_fields' }, { status: 400 });
+  }
+
+  try {
+    const result = await grantApiAccess(discordId);
+
+    if (!result.success) {
+      return Response.json({ error: result.error }, { status: 404 });
+    }
+
+    return Response.json(result);
+  } catch (error) {
+    console.error('Error granting API access:', error);
+    return Response.json({ error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/web/app/api/admin/verify-link/route.ts
+++ b/web/app/api/admin/verify-link/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest } from 'next/server';
+
+import { verifyDiscordLink } from '@/actions/admin';
+
+import { validateDiscordBotAuth } from '../auth';
+
+type VerifyLinkRequest = {
+  code: string;
+  discordId: string;
+  discordUsername: string;
+};
+
+/**
+ * Admin endpoint for Discord bot to verify a linking code and link a Discord
+ * account to a Blert account.
+ *
+ * @param request Request with `{ code, discordId, discordUsername }` in body.
+ * @returns 200 with user info on success, or error response on failure.
+ */
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (!validateDiscordBotAuth(authHeader)) {
+    return Response.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  let body: VerifyLinkRequest;
+  try {
+    body = (await request.json()) as VerifyLinkRequest;
+  } catch {
+    return Response.json({ error: 'invalid_body' }, { status: 400 });
+  }
+
+  const { code, discordId, discordUsername } = body;
+
+  if (!code || !discordId || !discordUsername) {
+    return Response.json({ error: 'missing_fields' }, { status: 400 });
+  }
+
+  try {
+    const result = await verifyDiscordLink(code, discordId, discordUsername);
+
+    if (!result.success) {
+      const statusMap = {
+        invalid_code: 404,
+        expired: 410,
+        conflict: 409,
+        user_not_found: 404,
+        internal_error: 500,
+      } as const;
+      return Response.json(
+        { error: result.error },
+        { status: statusMap[result.error] },
+      );
+    }
+
+    return Response.json(result);
+  } catch (error) {
+    console.error('Error verifying Discord link:', error);
+    return Response.json({ error: 'internal_error' }, { status: 500 });
+  }
+}

--- a/web/app/components/confirmation-modal/confirmation-modal.tsx
+++ b/web/app/components/confirmation-modal/confirmation-modal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Button from '@/components/button';
+import Modal from '@/components/modal';
+
+import styles from './style.module.scss';
+
+export type ConfirmationModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: string | React.ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: 'primary' | 'danger';
+  loading?: boolean;
+};
+
+export function ConfirmationModal({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  variant = 'primary',
+  loading = false,
+}: ConfirmationModalProps) {
+  const handleConfirm = () => {
+    onConfirm();
+  };
+
+  return (
+    <Modal className={styles.confirmationModal} open={open} onClose={onClose}>
+      <div className={styles.modalHeader}>
+        <h2>{title}</h2>
+        <button onClick={onClose}>
+          <i className="fas fa-times" />
+          <span className="sr-only">Close</span>
+        </button>
+      </div>
+      <div className={styles.modalContent}>
+        {typeof message === 'string' ? <p>{message}</p> : message}
+      </div>
+      <div className={styles.modalActions}>
+        <Button onClick={onClose} simple disabled={loading}>
+          {cancelText}
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          className={variant === 'danger' ? styles.dangerButton : undefined}
+          loading={loading}
+        >
+          {confirmText}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/web/app/components/confirmation-modal/index.ts
+++ b/web/app/components/confirmation-modal/index.ts
@@ -1,0 +1,2 @@
+export { ConfirmationModal as default } from './confirmation-modal';
+export type { ConfirmationModalProps } from './confirmation-modal';

--- a/web/app/components/confirmation-modal/style.module.scss
+++ b/web/app/components/confirmation-modal/style.module.scss
@@ -1,0 +1,105 @@
+@use '../../mixins.scss' as *;
+
+.confirmationModal {
+  max-width: 500px;
+  width: 90vw;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    max-width: 100%;
+    width: 100%;
+  }
+
+  .modalHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    border-bottom: 1px solid rgba(var(--blert-button-base), 0.15);
+    background: linear-gradient(
+      135deg,
+      var(--panel-bg) 0%,
+      rgba(var(--nav-bg-base), 0.8) 100%
+    );
+
+    h2 {
+      margin: 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--blert-text-color);
+    }
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      border-radius: 6px;
+      border: none;
+      background: transparent;
+      color: var(--font-color-nav);
+      cursor: pointer;
+      transition: all 0.2s ease;
+
+      i {
+        position: relative;
+        top: 1px;
+      }
+
+      &:hover {
+        background: rgba(var(--blert-red-base), 0.1);
+        color: var(--blert-red);
+      }
+    }
+  }
+
+  .modalContent {
+    padding: 24px;
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      padding: 20px;
+    }
+
+    p {
+      margin: 0;
+      color: var(--font-color-nav);
+      line-height: 1.6;
+      font-size: 0.95rem;
+    }
+
+    strong {
+      color: var(--blert-text-color);
+      font-weight: 600;
+    }
+  }
+
+  .modalActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 16px 24px;
+    border-top: 1px solid rgba(var(--blert-button-base), 0.1);
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      padding: 16px 20px;
+    }
+
+    button {
+      min-width: 100px;
+
+      @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+        min-width: 80px;
+      }
+    }
+  }
+
+  .dangerButton {
+    background: var(--blert-red);
+    border-color: var(--blert-red);
+
+    &:hover:not(:disabled) {
+      background: rgba(var(--blert-red-base), 0.8);
+      border-color: rgba(var(--blert-red-base), 0.8);
+    }
+  }
+}


### PR DESCRIPTION
Updates Blert accounts with Discord ID/username fields. Creates a code-based verification process where users generate a linking code from their settings page and have it verified via admin API endpoints to confirm their Discord information. Additionally, adds an admin route to grant users API key generation access.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Discord account linking via time-limited codes, secured admin APIs, and new settings UI, backed by a migration adding linking codes and Discord fields.
> 
> - **Database**:
>   - Add `account_linking_codes` table (unique `code`, per-`user_id`+`type`, `expires_at` index).
>   - Add `users.discord_id` (unique, indexed) and `users.discord_username`.
> - **Common Types**:
>   - Extend `User` with `discordId` and `discordUsername`.
> - **Server Actions**:
>   - `actions/users`: generate/get active Discord linking code, get link status, unlink Discord; strengthen auth helpers and query typing.
>   - `actions/admin`: `verifyDiscordLink(code, discordId, discordUsername)` and `grantApiAccess(discordId)`.
> - **Admin API**:
>   - `POST /api/admin/verify-link` and `POST /api/admin/grant-api-access` with Bearer auth using `BLERT_DISCORD_BOT_SECRET` and timing-safe compare.
> - **Web UI (Settings)**:
>   - New tabbed settings layout with pages: `account`, `api-keys`, `linked-accounts`.
>   - Discord linking section: code generation, countdown/polling, copy, and unlink flow with `ConfirmationModal`.
>   - Minor API keys/account settings refactors (shared styles, small handler tweaks).
> - **Components**:
>   - New `components/confirmation-modal`.
> - **Config/Env**:
>   - Add `BLERT_DISCORD_BOT_SECRET` to `.env.development`.
> - **Tests**:
>   - Unit tests for admin actions and admin API routes (auth, verify-link, grant-api-access).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2329e8d3b5a2afceee1fad0a0732b593f4dfba96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->