### PR TITLE
Don't re-set loading on pulling dashboard updates

### DIFF
--- a/web/app/(challenges)/activity-dashboard.tsx
+++ b/web/app/(challenges)/activity-dashboard.tsx
@@ -265,7 +265,6 @@ export default function ActivityDashboard({
 
   useEffect(() => {
     const fetchData = async () => {
-      setIsLoading(true);
       fetchTimeout.current = null;
 
       const today = new Date();


### PR DESCRIPTION
Loading state should only be set for the intial load; subsequent fetches should not trigger UI updates.