### PR TITLE
Handle Verzik bounces and Sotetseg maze return

### DIFF
--- a/challenge-server/jest.config.js
+++ b/challenge-server/jest.config.js
@@ -1,6 +1,8 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 module.exports = {
   testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  coveragePathIgnorePatterns: ['/__tests__/fixtures\\.ts$'],
   transform: {
     '^.+.tsx?$': ['ts-jest', {}],
   },

--- a/challenge-server/merging/__tests__/client-events.test.ts
+++ b/challenge-server/merging/__tests__/client-events.test.ts
@@ -1,5 +1,4 @@
 import {
-  ChallengeStatus,
   ChallengeType,
   DataSource,
   EventType,
@@ -16,48 +15,42 @@ import {
 } from '@blert/common/generated/event_pb';
 
 import { ClientEvents, ClientAnomaly } from '../client-events';
+import { createPlayerUpdateEvent } from './fixtures';
+import { ChallengeInfo } from '../merge';
 
-const challengeInfo = {
-  id: 123,
-  uuid: '11111111-2222-3333-4444-555555555555',
-  type: ChallengeType.TOB,
-  status: ChallengeStatus.IN_PROGRESS,
-  stage: Stage.TOB_MAIDEN,
-  party: ['player1', 'player2'],
-};
+type ProtoEventType = ProtoEvent.TypeMap[keyof ProtoEvent.TypeMap];
+type ProtoStage = StageMap[keyof StageMap];
 
-type Proto<T> = T[keyof T];
-type ProtoEventType = Proto<ProtoEvent.TypeMap>;
-type ProtoStage = Proto<StageMap>;
-type ProtoDataSource = Proto<ProtoEvent.Player.DataSourceMap>;
-
-function createPlayerUpdate({
+function createVerzikBounceEvent({
   tick,
-  name,
-  source = DataSource.PRIMARY,
-  x = 0,
-  y = 0,
+  npcAttackTick,
+  bouncedPlayer,
 }: {
   tick: number;
-  name: string;
-  source?: DataSource;
-  x?: number;
-  y?: number;
+  npcAttackTick: number;
+  bouncedPlayer: string;
 }): ProtoEvent {
   const event = new ProtoEvent();
-  event.setType(EventType.PLAYER_UPDATE as ProtoEventType);
+  event.setType(EventType.TOB_VERZIK_BOUNCE as ProtoEventType);
   event.setTick(tick);
-  event.setStage(Stage.TOB_MAIDEN as ProtoStage);
-  event.setXCoord(x);
-  event.setYCoord(y);
+  event.setStage(Stage.TOB_VERZIK as ProtoStage);
 
-  const player = new ProtoEvent.Player();
-  player.setName(name);
-  player.setDataSource(source as ProtoDataSource);
-  event.setPlayer(player);
+  const bounce = new ProtoEvent.VerzikBounce();
+  bounce.setNpcAttackTick(npcAttackTick);
+  bounce.setBouncedPlayer(bouncedPlayer);
+  event.setVerzikBounce(bounce);
 
   return event;
 }
+
+type ProtoDataSource =
+  ProtoEvent.Player.DataSourceMap[keyof ProtoEvent.Player.DataSourceMap];
+
+const challengeInfo: ChallengeInfo = {
+  uuid: '11111111-2222-3333-4444-555555555555',
+  type: ChallengeType.TOB,
+  party: ['player1', 'player2'],
+};
 
 describe('ClientEvents', () => {
   it('derives recorded ticks when not provided', () => {
@@ -72,8 +65,8 @@ describe('ClientEvents', () => {
         serverTicks: null,
       },
       [
-        createPlayerUpdate({ tick: 0, name: 'player1' }),
-        createPlayerUpdate({ tick: 5, name: 'player1' }),
+        createPlayerUpdateEvent({ tick: 0, name: 'player1' }),
+        createPlayerUpdateEvent({ tick: 5, name: 'player1' }),
       ],
     );
 
@@ -82,200 +75,605 @@ describe('ClientEvents', () => {
     expect(client.isAccurate()).toBe(false);
   });
 
-  it('treats multiple primary players as a spectator recording', () => {
-    const client = ClientEvents.fromRawEvents(
-      2,
-      challengeInfo,
-      {
-        stage: Stage.TOB_MAIDEN,
-        status: StageStatus.STARTED,
-        accurate: false,
-        recordedTicks: 1,
-        serverTicks: null,
-      },
-      [
-        createPlayerUpdate({ tick: 0, name: 'player1' }),
-        createPlayerUpdate({ tick: 0, name: 'player2' }),
-      ],
-    );
+  describe('anomalies', () => {
+    it('treats multiple primary players as a spectator recording', () => {
+      const client = ClientEvents.fromRawEvents(
+        2,
+        challengeInfo,
+        {
+          stage: Stage.TOB_MAIDEN,
+          status: StageStatus.STARTED,
+          accurate: false,
+          recordedTicks: 1,
+          serverTicks: null,
+        },
+        [
+          createPlayerUpdateEvent({
+            tick: 0,
+            name: 'player1',
+            source: DataSource.PRIMARY,
+          }),
+          createPlayerUpdateEvent({
+            tick: 0,
+            name: 'player2',
+            source: DataSource.PRIMARY,
+          }),
+        ],
+      );
 
-    expect(client.isSpectator()).toBe(true);
-    expect(client.hasAnomaly(ClientAnomaly.MULTIPLE_PRIMARY_PLAYERS)).toBe(
-      true,
-    );
-  });
+      expect(client.isSpectator()).toBe(true);
+      expect(client.hasAnomaly(ClientAnomaly.MULTIPLE_PRIMARY_PLAYERS)).toBe(
+        true,
+      );
+    });
 
-  it('flags clients whose recorded ticks exceed reported server ticks', () => {
-    const client = ClientEvents.fromRawEvents(
-      3,
-      challengeInfo,
-      {
-        stage: Stage.TOB_MAIDEN,
-        status: StageStatus.COMPLETED,
-        accurate: true,
-        recordedTicks: 5,
-        serverTicks: { count: 4, precise: true },
-      },
-      [
-        createPlayerUpdate({ tick: 0, name: 'player1' }),
-        createPlayerUpdate({ tick: 4, name: 'player1' }),
-      ],
-    );
+    it('flags clients whose recorded ticks exceed reported server ticks', () => {
+      const client = ClientEvents.fromRawEvents(
+        3,
+        challengeInfo,
+        {
+          stage: Stage.TOB_MAIDEN,
+          status: StageStatus.COMPLETED,
+          accurate: true,
+          recordedTicks: 5,
+          serverTicks: { count: 4, precise: true },
+        },
+        [
+          createPlayerUpdateEvent({ tick: 0, name: 'player1' }),
+          createPlayerUpdateEvent({ tick: 4, name: 'player1' }),
+        ],
+      );
 
-    expect(client.hasInvalidTickCount()).toBe(true);
-    expect(client.isAccurate()).toBe(false);
-  });
+      expect(client.hasInvalidTickCount()).toBe(true);
+      expect(client.isAccurate()).toBe(false);
+    });
 
-  it('detects inconsistent movement when players skip too many tiles', () => {
-    const client = ClientEvents.fromRawEvents(
-      4,
-      challengeInfo,
-      {
-        stage: Stage.TOB_MAIDEN,
-        status: StageStatus.STARTED,
-        accurate: true,
-        recordedTicks: 2,
-        serverTicks: { count: 2, precise: true },
-      },
-      [
-        createPlayerUpdate({ tick: 0, name: 'player1', x: 0, y: 0 }),
-        createPlayerUpdate({ tick: 1, name: 'player1', x: 10, y: 0 }),
-      ],
-    );
+    it('flags missing stage metadata when no stage end update is present', () => {
+      const eventsMessage = new ChallengeEvents();
+      eventsMessage.setEventsList([
+        createPlayerUpdateEvent({ tick: 0, name: 'alice' }),
+      ]);
+      const stream: StageStreamEvents = {
+        type: StageStreamType.STAGE_EVENTS,
+        clientId: 6,
+        events: eventsMessage.serializeBinary(),
+      };
 
-    expect(client.hasConsistencyIssues()).toBe(true);
-    expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(true);
-    // expect(client.isAccurate()).toBe(false);
-    const issues = client.getConsistencyIssues();
-    expect(issues).toHaveLength(1);
-    expect(issues[0]).toMatchObject({
-      player: 'player1',
-      delta: { x: 10, y: 0 },
-      ticksSinceLast: 1,
+      const client = ClientEvents.fromClientStream(
+        6,
+        challengeInfo,
+        Stage.TOB_MAIDEN,
+        [stream],
+      );
+
+      expect(client.hasAnomaly(ClientAnomaly.MISSING_STAGE_METADATA)).toBe(
+        true,
+      );
+    });
+
+    describe('movement consistency', () => {
+      it('detects inconsistent movement when players skip too many tiles', () => {
+        const client = ClientEvents.fromRawEvents(
+          4,
+          challengeInfo,
+          {
+            stage: Stage.TOB_MAIDEN,
+            status: StageStatus.STARTED,
+            accurate: true,
+            recordedTicks: 2,
+            serverTicks: { count: 2, precise: true },
+          },
+          [
+            createPlayerUpdateEvent({ tick: 0, name: 'player1', x: 0, y: 0 }),
+            createPlayerUpdateEvent({ tick: 1, name: 'player1', x: 10, y: 0 }),
+          ],
+        );
+
+        expect(client.hasConsistencyIssues()).toBe(true);
+        expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(true);
+        // expect(client.isAccurate()).toBe(false);
+        const issues = client.getConsistencyIssues();
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toMatchObject({
+          player: 'player1',
+          delta: { x: 10, y: 0 },
+          ticksSinceLast: 1,
+        });
+      });
+
+      it('accepts movement within allowable distance', () => {
+        const client = ClientEvents.fromRawEvents(
+          5,
+          challengeInfo,
+          {
+            stage: Stage.TOB_MAIDEN,
+            status: StageStatus.STARTED,
+            accurate: true,
+            recordedTicks: 2,
+            serverTicks: { count: 2, precise: true },
+          },
+          [
+            createPlayerUpdateEvent({ tick: 0, name: 'player1', x: 0, y: 0 }),
+            createPlayerUpdateEvent({ tick: 1, name: 'player1', x: 2, y: 1 }),
+          ],
+        );
+
+        expect(client.hasConsistencyIssues()).toBe(false);
+        expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(false);
+        expect(client.isAccurate()).toBe(true);
+      });
+
+      describe('special teleports', () => {
+        describe('Verzik bounce', () => {
+          it('allows exactly 3-tile movement when bounce event is present', () => {
+            const client = ClientEvents.fromRawEvents(
+              10,
+              challengeInfo,
+              {
+                stage: Stage.TOB_VERZIK,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4308,
+                  stage: Stage.TOB_VERZIK,
+                }),
+                createVerzikBounceEvent({
+                  tick: 1,
+                  npcAttackTick: 0,
+                  bouncedPlayer: 'player1',
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4305,
+                  stage: Stage.TOB_VERZIK,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(false);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              false,
+            );
+            expect(client.isAccurate()).toBe(true);
+          });
+
+          it('flags 3-tile movement when bounce event is missing', () => {
+            const client = ClientEvents.fromRawEvents(
+              11,
+              challengeInfo,
+              {
+                stage: Stage.TOB_VERZIK,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4308,
+                  stage: Stage.TOB_VERZIK,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4305,
+                  stage: Stage.TOB_VERZIK,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+            const issues = client.getConsistencyIssues();
+            expect(issues).toHaveLength(1);
+            expect(issues[0]).toMatchObject({
+              player: 'player1',
+              delta: { x: 0, y: -3 },
+              ticksSinceLast: 1,
+            });
+          });
+
+          it('flags 4-tile movement even with bounce event', () => {
+            const client = ClientEvents.fromRawEvents(
+              21,
+              challengeInfo,
+              {
+                stage: Stage.TOB_VERZIK,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4308,
+                  stage: Stage.TOB_VERZIK,
+                }),
+                createVerzikBounceEvent({
+                  tick: 1,
+                  npcAttackTick: 0,
+                  bouncedPlayer: 'player1',
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4304,
+                  stage: Stage.TOB_VERZIK,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+
+          it('flags bounce movement when player does not match', () => {
+            const client = ClientEvents.fromRawEvents(
+              12,
+              challengeInfo,
+              {
+                stage: Stage.TOB_VERZIK,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4308,
+                  stage: Stage.TOB_VERZIK,
+                }),
+                createVerzikBounceEvent({
+                  tick: 1,
+                  npcAttackTick: 0,
+                  bouncedPlayer: 'player2',
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4305,
+                  stage: Stage.TOB_VERZIK,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+
+          it('only applies to 1-tick movement', () => {
+            const client = ClientEvents.fromRawEvents(
+              13,
+              challengeInfo,
+              {
+                stage: Stage.TOB_VERZIK,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 3,
+                serverTicks: { count: 3, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4308,
+                  stage: Stage.TOB_VERZIK,
+                }),
+                createVerzikBounceEvent({
+                  tick: 1,
+                  npcAttackTick: 0,
+                  bouncedPlayer: 'player1',
+                }),
+                createPlayerUpdateEvent({
+                  tick: 2,
+                  name: 'player1',
+                  x: 3160,
+                  y: 4303,
+                  stage: Stage.TOB_VERZIK,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+        });
+
+        describe('Sotetseg maze teleport', () => {
+          it('allows teleport to overworld maze start tile', () => {
+            const client = ClientEvents.fromRawEvents(
+              14,
+              challengeInfo,
+              {
+                stage: Stage.TOB_SOTETSEG,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3275,
+                  y: 4310,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3274,
+                  y: 4307,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(false);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              false,
+            );
+            expect(client.isAccurate()).toBe(true);
+          });
+
+          it('allows teleport to underworld maze start tile', () => {
+            const client = ClientEvents.fromRawEvents(
+              15,
+              challengeInfo,
+              {
+                stage: Stage.TOB_SOTETSEG,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3280,
+                  y: 4320,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3360,
+                  y: 4309,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(false);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              false,
+            );
+            expect(client.isAccurate()).toBe(true);
+          });
+
+          it('flags large movement to non-maze tile', () => {
+            const client = ClientEvents.fromRawEvents(
+              16,
+              challengeInfo,
+              {
+                stage: Stage.TOB_SOTETSEG,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3275,
+                  y: 4310,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3300,
+                  y: 4350,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+
+          it('flags maze teleport when not starting from room area', () => {
+            const client = ClientEvents.fromRawEvents(
+              17,
+              challengeInfo,
+              {
+                stage: Stage.TOB_SOTETSEG,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3200,
+                  y: 4200,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 3274,
+                  y: 4307,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+
+          it('only applies to 1-tick movement', () => {
+            const client = ClientEvents.fromRawEvents(
+              18,
+              challengeInfo,
+              {
+                stage: Stage.TOB_SOTETSEG,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 3,
+                serverTicks: { count: 3, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 3275,
+                  y: 4312,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 2,
+                  name: 'player1',
+                  x: 3274,
+                  y: 4307,
+                  stage: Stage.TOB_SOTETSEG,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+        });
+      });
     });
   });
 
-  it('accepts movement within allowable distance', () => {
-    const client = ClientEvents.fromRawEvents(
-      5,
-      challengeInfo,
-      {
-        stage: Stage.TOB_MAIDEN,
-        status: StageStatus.STARTED,
-        accurate: true,
-        recordedTicks: 2,
-        serverTicks: { count: 2, precise: true },
-      },
-      [
-        createPlayerUpdate({ tick: 0, name: 'player1', x: 0, y: 0 }),
-        createPlayerUpdate({ tick: 1, name: 'player1', x: 2, y: 1 }),
-      ],
-    );
+  describe('player state history', () => {
+    it('builds player state history with coordinates and deaths', () => {
+      const updates = [
+        createPlayerUpdateEvent({ tick: 0, name: 'player1', x: 5, y: 5 }),
+        createPlayerUpdateEvent({ tick: 1, name: 'player1', x: 6, y: 7 }),
+        (() => {
+          const death = new ProtoEvent();
+          death.setType(EventType.PLAYER_DEATH as ProtoEventType);
+          death.setTick(2);
+          death.setStage(Stage.TOB_MAIDEN as ProtoStage);
+          const player = new ProtoEvent.Player();
+          player.setName('player1');
+          death.setPlayer(player);
+          return death;
+        })(),
+      ];
 
-    expect(client.hasConsistencyIssues()).toBe(false);
-    expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(false);
-    expect(client.isAccurate()).toBe(true);
-  });
+      const client = ClientEvents.fromRawEvents(
+        7,
+        challengeInfo,
+        {
+          stage: Stage.TOB_MAIDEN,
+          status: StageStatus.STARTED,
+          accurate: true,
+          recordedTicks: 2,
+          serverTicks: null,
+        },
+        updates,
+      );
 
-  it('flags missing stage metadata when no stage end update is present', () => {
-    const eventsMessage = new ChallengeEvents();
-    eventsMessage.setEventsList([
-      createPlayerUpdate({ tick: 0, name: 'alice' }),
-    ]);
-    const stream: StageStreamEvents = {
-      type: StageStreamType.STAGE_EVENTS,
-      clientId: 6,
-      events: eventsMessage.serializeBinary(),
-    };
+      const tick0 = client.getTickState(0)?.getPlayerState('player1');
+      expect(tick0).toMatchObject({ x: 5, y: 5, isDead: false });
 
-    const client = ClientEvents.fromClientStream(
-      6,
-      challengeInfo,
-      Stage.TOB_MAIDEN,
-      [stream],
-    );
+      const tick1 = client.getTickState(1)?.getPlayerState('player1');
+      expect(tick1).toMatchObject({ x: 6, y: 7, isDead: false });
 
-    expect(client.hasAnomaly(ClientAnomaly.MISSING_STAGE_METADATA)).toBe(true);
-  });
+      const tick2 = client.getTickState(2)?.getPlayerState('player1');
+      expect(tick2).toMatchObject({ x: 6, y: 7, isDead: true });
+    });
 
-  it('builds player state history with coordinates and deaths', () => {
-    const updates = [
-      createPlayerUpdate({ tick: 0, name: 'player1', x: 5, y: 5 }),
-      createPlayerUpdate({ tick: 1, name: 'player1', x: 6, y: 7 }),
-      (() => {
-        const death = new ProtoEvent();
-        death.setType(EventType.PLAYER_DEATH as ProtoEventType);
-        death.setTick(2);
-        death.setStage(Stage.TOB_MAIDEN as ProtoStage);
+    it('applies equipment deltas when building player state', () => {
+      const createUpdate = (
+        tick: number,
+        deltas: [number, number, boolean][],
+      ) => {
+        const event = new ProtoEvent();
+        event.setType(EventType.PLAYER_UPDATE as ProtoEventType);
+        event.setTick(tick);
+        event.setStage(Stage.TOB_MAIDEN as ProtoStage);
         const player = new ProtoEvent.Player();
         player.setName('player1');
-        death.setPlayer(player);
-        return death;
-      })(),
-    ];
+        player.setDataSource(DataSource.PRIMARY as ProtoDataSource);
+        for (const [itemId, slot, added] of deltas) {
+          const delta = new ItemDelta(itemId, 1, slot, added);
+          player.addEquipmentDeltas(delta.toRaw());
+        }
+        event.setPlayer(player);
+        return event;
+      };
 
-    const client = ClientEvents.fromRawEvents(
-      7,
-      challengeInfo,
-      {
-        stage: Stage.TOB_MAIDEN,
-        status: StageStatus.STARTED,
-        accurate: true,
-        recordedTicks: 2,
-        serverTicks: null,
-      },
-      updates,
-    );
+      const client = ClientEvents.fromRawEvents(
+        8,
+        challengeInfo,
+        {
+          stage: Stage.TOB_MAIDEN,
+          status: StageStatus.STARTED,
+          accurate: true,
+          recordedTicks: 1,
+          serverTicks: null,
+        },
+        [
+          createUpdate(0, [[11840, 1, true]]),
+          createUpdate(1, [[11840, 1, false]]),
+        ],
+      );
 
-    const tick0 = client.getTickState(0)?.getPlayerState('player1');
-    expect(tick0).toMatchObject({ x: 5, y: 5, isDead: false });
-
-    const tick1 = client.getTickState(1)?.getPlayerState('player1');
-    expect(tick1).toMatchObject({ x: 6, y: 7, isDead: false });
-
-    const tick2 = client.getTickState(2)?.getPlayerState('player1');
-    expect(tick2).toMatchObject({ x: 6, y: 7, isDead: true });
-  });
-
-  it('applies equipment deltas when building player state', () => {
-    const createUpdate = (
-      tick: number,
-      deltas: [number, number, boolean][],
-    ) => {
-      const event = new ProtoEvent();
-      event.setType(EventType.PLAYER_UPDATE as ProtoEventType);
-      event.setTick(tick);
-      event.setStage(Stage.TOB_MAIDEN as ProtoStage);
-      const player = new ProtoEvent.Player();
-      player.setName('player1');
-      player.setDataSource(DataSource.PRIMARY as ProtoDataSource);
-      for (const [itemId, slot, added] of deltas) {
-        const delta = new ItemDelta(itemId, 1, slot, added);
-        player.addEquipmentDeltas(delta.toRaw());
-      }
-      event.setPlayer(player);
-      return event;
-    };
-
-    const client = ClientEvents.fromRawEvents(
-      8,
-      challengeInfo,
-      {
-        stage: Stage.TOB_MAIDEN,
-        status: StageStatus.STARTED,
-        accurate: true,
-        recordedTicks: 1,
-        serverTicks: null,
-      },
-      [
-        createUpdate(0, [[11840, 1, true]]),
-        createUpdate(1, [[11840, 1, false]]),
-      ],
-    );
-
-    const tick0State = client.getTickState(0)?.getPlayerState('player1');
-    expect(tick0State?.equipment[1]).toMatchObject({ id: 11840, quantity: 1 });
-    const tick1State = client.getTickState(1)?.getPlayerState('player1');
-    expect(tick1State?.equipment[1]).toBeNull();
+      const tick0State = client.getTickState(0)?.getPlayerState('player1');
+      expect(tick0State?.equipment[1]).toMatchObject({
+        id: 11840,
+        quantity: 1,
+      });
+      const tick1State = client.getTickState(1)?.getPlayerState('player1');
+      expect(tick1State?.equipment[1]).toBeNull();
+    });
   });
 });

--- a/challenge-server/merging/__tests__/fixtures.ts
+++ b/challenge-server/merging/__tests__/fixtures.ts
@@ -1,0 +1,148 @@
+import {
+  DataSource,
+  EquipmentSlot,
+  ItemDelta,
+  Stage,
+  SkillLevel,
+} from '@blert/common';
+import {
+  Event as ProtoEvent,
+  StageMap,
+} from '@blert/common/generated/event_pb';
+
+import { TickState, PlayerState, EquippedItem } from '../tick-state';
+
+type ProtoStage = StageMap[keyof StageMap];
+type ProtoDataSource =
+  ProtoEvent.Player.DataSourceMap[keyof ProtoEvent.Player.DataSourceMap];
+
+export type PlayerStateOptions = {
+  username: string;
+  source?: DataSource;
+  x?: number;
+  y?: number;
+  isDead?: boolean;
+  equipment?: Partial<Record<EquipmentSlot, EquippedItem | null>>;
+};
+
+export function createPlayerState({
+  username,
+  source = DataSource.SECONDARY,
+  x = 0,
+  y = 0,
+  isDead = false,
+  equipment = {},
+}: PlayerStateOptions): PlayerState {
+  const emptyEquipment: Record<EquipmentSlot, EquippedItem | null> = {
+    [EquipmentSlot.HEAD]: null,
+    [EquipmentSlot.CAPE]: null,
+    [EquipmentSlot.AMULET]: null,
+    [EquipmentSlot.AMMO]: null,
+    [EquipmentSlot.WEAPON]: null,
+    [EquipmentSlot.TORSO]: null,
+    [EquipmentSlot.SHIELD]: null,
+    [EquipmentSlot.LEGS]: null,
+    [EquipmentSlot.GLOVES]: null,
+    [EquipmentSlot.BOOTS]: null,
+    [EquipmentSlot.RING]: null,
+    [EquipmentSlot.QUIVER]: null,
+  };
+
+  for (const [slot, item] of Object.entries(equipment)) {
+    emptyEquipment[slot as unknown as EquipmentSlot] = item ?? null;
+  }
+
+  return {
+    username,
+    source,
+    x,
+    y,
+    isDead,
+    equipment: emptyEquipment,
+  };
+}
+
+export function createPlayerUpdateEvent({
+  tick,
+  name,
+  source = DataSource.SECONDARY,
+  x = 0,
+  y = 0,
+  equipmentDeltas = [],
+  stage = Stage.TOB_MAIDEN,
+}: {
+  tick: number;
+  name: string;
+  source?: DataSource;
+  x?: number;
+  y?: number;
+  equipmentDeltas?: ItemDelta[];
+  stage?: Stage;
+}): ProtoEvent {
+  const event = new ProtoEvent();
+  event.setType(ProtoEvent.Type.PLAYER_UPDATE);
+  event.setTick(tick);
+  event.setStage(stage as ProtoStage);
+  event.setXCoord(x);
+  event.setYCoord(y);
+
+  const player = new ProtoEvent.Player();
+  player.setName(name);
+  player.setDataSource(source as ProtoDataSource);
+  player.setEquipmentDeltasList(equipmentDeltas.map((delta) => delta.toRaw()));
+  event.setPlayer(player);
+
+  return event;
+}
+
+export function createNpcSpawnEvent({
+  tick,
+  roomId,
+  npcId,
+  x,
+  y,
+  hitpointsCurrent,
+  hitpointsBase,
+  stage = Stage.TOB_MAIDEN,
+}: {
+  tick: number;
+  roomId: number;
+  npcId: number;
+  x: number;
+  y: number;
+  hitpointsCurrent: number;
+  hitpointsBase?: number;
+  stage?: Stage;
+}): ProtoEvent {
+  const event = new ProtoEvent();
+  event.setType(ProtoEvent.Type.NPC_SPAWN);
+  event.setTick(tick);
+  event.setStage(stage as ProtoStage);
+  event.setXCoord(x);
+  event.setYCoord(y);
+
+  const npc = new ProtoEvent.Npc();
+  npc.setRoomId(roomId);
+  npc.setId(npcId);
+  const base = hitpointsBase ?? hitpointsCurrent;
+  npc.setHitpoints(new SkillLevel(hitpointsCurrent, base).toRaw());
+  event.setNpc(npc);
+
+  return event;
+}
+
+export function createTickState(
+  tick: number,
+  players: PlayerState[],
+  events: ProtoEvent[] = [],
+): TickState {
+  const playerStates = players.reduce<Record<string, PlayerState | null>>(
+    (acc, player) => ({
+      ...acc,
+      [player.username]: player,
+    }),
+    {},
+  );
+
+  return new TickState(tick, events, playerStates);
+}


### PR DESCRIPTION
Updates the `isSpecialTeleport` check to allow both players getting bounced by Verzik and players returning from the underworld to the overworld after running a maze.