### PR TITLE
Set challenge UUID when deferred-joining

### DIFF
--- a/challenge-server/challenge-manager.ts
+++ b/challenge-server/challenge-manager.ts
@@ -451,6 +451,7 @@ export default class ChallengeManager {
                 `${partyMembers} is initializing; deferring join`,
             );
             startAction = StartAction.DEFERRED_JOIN;
+            challengeUuid = lastChallengeForParty;
           } else {
             logger.info(
               `User ${userId}: Joining existing challenge type ${type} for ${partyMembers}`,


### PR DESCRIPTION
The deferred join branch of challenge creation had ommitted setting the challenge UUID, causing the guard following the transaction to fail the start action. This corrects it to ensure a UUID is set.