### PR TITLE
Ensure challenge server always returns JSON errors

### DIFF
--- a/challenge-server/api.ts
+++ b/challenge-server/api.ts
@@ -117,7 +117,7 @@ async function updateChallenge(req: Request, res: Response): Promise<void> {
           request.update,
         );
         if (result === null) {
-          res.status(409).send();
+          res.status(409).json({ error: { message: 'Update rejected' } });
         } else {
           res.json(result);
         }

--- a/challenge-server/event-processing/challenge-processor.ts
+++ b/challenge-server/event-processing/challenge-processor.ts
@@ -959,7 +959,7 @@ export default abstract class ChallengeProcessor {
 
         if (currentPb === undefined) {
           personalBests.new[playerKey] ??= [];
-          personalBests.new[playerKey].push([split.id, split.ticks]);
+          personalBests.new[playerKey].push([split.type, split.ticks]);
           pbRowsToCreate.push({
             player_id: playerId,
             challenge_split_id: split.id,
@@ -967,7 +967,7 @@ export default abstract class ChallengeProcessor {
           });
         } else if (split.ticks < currentPb.ticks) {
           personalBests.updated[playerKey] ??= [];
-          personalBests.updated[playerKey].push([split.id, split.ticks]);
+          personalBests.updated[playerKey].push([split.type, split.ticks]);
           pbRowsToCreate.push({
             player_id: playerId,
             challenge_split_id: split.id,


### PR DESCRIPTION
Updates the case where a challenge update is rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Return JSON error payload on challenge update conflicts and log personal bests using split type instead of DB ID.
> 
> - **API** (`challenge-server/api.ts`):
>   - `updateChallenge`: on `null` update result, return `409` with JSON `{ error: { message: 'Update rejected' } }` instead of empty response.
> - **Event processing** (`challenge-server/event-processing/challenge-processor.ts`):
>   - `updatePersonalBests`: log `personalBests` entries with `[split.type, ticks]` instead of `[split.id, ticks]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e55209bdc1639070a7b42961c28f34975b1ecaa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->