### PR TITLE
Update to semantic CSS color variable names

### DIFF
--- a/web/app/(account)/change-name/style.module.scss
+++ b/web/app/(account)/change-name/style.module.scss
@@ -20,8 +20,8 @@
   width: 100%;
   max-width: 500px;
   position: relative;
-  background: var(--panel-bg);
-  border: 1px solid var(--font-color-nav-divider);
+  background: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-divider-color);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     padding: 24px;
@@ -31,16 +31,16 @@
     font-size: 1.8em;
     margin: 0 0 8px 0;
     text-align: center;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .subtitle {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.95em;
     margin: 12px 0 24px 0;
 
     a {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       text-decoration: none;
 
       &:hover {

--- a/web/app/(account)/name-changes/style.module.scss
+++ b/web/app/(account)/name-changes/style.module.scss
@@ -38,7 +38,7 @@
   h1 {
     font-size: 1.8em;
     margin: 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     display: flex;
     align-items: center;
     gap: 12px;
@@ -48,7 +48,7 @@
     }
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.9em;
     }
   }
@@ -60,14 +60,14 @@
   gap: 8px;
   padding: 8px 16px;
   border-radius: 6px;
-  background: var(--blert-button);
+  background: var(--blert-purple);
   color: #fff;
   text-decoration: none;
   font-size: 0.95em;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.8);
+    background: rgba(var(--blert-purple-base), 0.8);
   }
 
   i {
@@ -96,7 +96,7 @@
   align-items: center;
   padding: 20px;
   gap: 24px;
-  border-bottom: 1px solid var(--nav-bg-lightened);
+  border-bottom: 1px solid var(--blert-surface-light);
 
   &:last-child {
     border-bottom: none;
@@ -126,7 +126,7 @@
 
   .oldName,
   .newName {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -135,7 +135,7 @@
   i {
     position: relative;
     top: 1px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.9em;
   }
 }
@@ -160,12 +160,12 @@
 
   .label {
     font-size: 0.75em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .value {
     font-size: 0.85em;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -189,8 +189,8 @@
   position: relative;
 
   &.pending {
-    background: rgba(var(--blert-text-color-base), 0.1);
-    color: var(--blert-text-color);
+    background: rgba(var(--blert-font-color-primary-base), 0.1);
+    color: var(--blert-font-color-primary);
   }
 
   &.accepted {

--- a/web/app/(account)/settings/account/password-reset-form.tsx
+++ b/web/app/(account)/settings/account/password-reset-form.tsx
@@ -33,7 +33,7 @@ function FormFields({ errors }: { errors: PasswordResetErrors | null }) {
         fluid
         id="current-password"
         label="Current Password"
-        labelBg="var(--nav-bg)"
+        labelBg="var(--blert-surface-dark)"
         type="password"
         required
         faIcon="fa-solid fa-lock"
@@ -45,7 +45,7 @@ function FormFields({ errors }: { errors: PasswordResetErrors | null }) {
         fluid
         id="new-password"
         label="New Password"
-        labelBg="var(--nav-bg)"
+        labelBg="var(--blert-surface-dark)"
         type="password"
         required
         faIcon="fa-solid fa-key"
@@ -60,7 +60,7 @@ function FormFields({ errors }: { errors: PasswordResetErrors | null }) {
         fluid
         id="confirm-password"
         label="Confirm New Password"
-        labelBg="var(--nav-bg)"
+        labelBg="var(--blert-surface-dark)"
         type="password"
         required
         faIcon="fa-solid fa-key"

--- a/web/app/(account)/settings/api-keys/api-key-form.tsx
+++ b/web/app/(account)/settings/api-keys/api-key-form.tsx
@@ -23,7 +23,7 @@ function FormFields() {
         fluid
         id="blert-api-key-rsn"
         label="OSRS username"
-        labelBg="var(--nav-bg)"
+        labelBg="var(--blert-surface-dark)"
         maxLength={12}
         required
         faIcon="fa-solid fa-user"

--- a/web/app/(account)/settings/style.module.scss
+++ b/web/app/(account)/settings/style.module.scss
@@ -29,7 +29,7 @@
   gap: 0;
   padding: 0;
   margin-bottom: 32px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   overflow: hidden;
 
@@ -48,7 +48,7 @@
     padding: 14px 20px;
     text-align: center;
     text-decoration: none;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-weight: 500;
     border-bottom: 3px solid transparent;
     transition: all 0.2s ease;
@@ -67,19 +67,19 @@
     }
 
     &:hover {
-      color: var(--blert-text-color);
-      border-bottom-color: rgba(var(--blert-button-base), 0.3);
-      background: rgba(var(--nav-bg-lightened-base), 0.5);
+      color: var(--blert-font-color-primary);
+      border-bottom-color: rgba(var(--blert-purple-base), 0.3);
+      background: rgba(var(--blert-surface-light-base), 0.5);
     }
 
     &[aria-current='page'] {
-      color: var(--blert-text-color);
-      border-bottom-color: var(--blert-button);
-      background: rgba(var(--blert-button-base), 0.05);
+      color: var(--blert-font-color-primary);
+      border-bottom-color: var(--blert-purple);
+      background: rgba(var(--blert-purple-base), 0.05);
       font-weight: 600;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -89,7 +89,7 @@
   h1 {
     font-size: 1.8em;
     margin: 0 0 24px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       font-size: 1.5em;
@@ -111,7 +111,7 @@
   h2 {
     font-size: 1.5em;
     margin: 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       font-size: 1.3em;
@@ -121,7 +121,7 @@
   h3 {
     font-size: 1.2em;
     margin: 0 0 16px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       font-size: 1.1em;
@@ -139,14 +139,14 @@
 
   .description {
     margin: 8px 0 0 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.95em;
     line-height: 1.5;
   }
 
   i {
     margin-right: 12px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -155,7 +155,7 @@
     label {
       display: block;
       font-size: 0.9em;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       margin-bottom: 4px;
     }
 
@@ -164,7 +164,7 @@
       align-items: baseline;
       gap: 12px;
       font-size: 1.1em;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
         flex-direction: column;
@@ -173,7 +173,7 @@
 
       .memberSince {
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
     }
   }
@@ -195,19 +195,19 @@
     align-items: center;
     text-align: center;
     padding: 32px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
       font-size: 2em;
       margin-bottom: 16px;
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     h3 {
       margin: 0 0 8px 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 1.2em;
     }
 
@@ -221,7 +221,7 @@
 }
 
 .apiKey {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   padding: 16px;
 
@@ -251,11 +251,11 @@
 
     .dots {
       letter-spacing: 0px;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .key {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       letter-spacing: 1px;
       user-select: all;
       word-break: break-all;
@@ -282,13 +282,13 @@
       border-radius: 6px;
       border: none;
       background: transparent;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       cursor: pointer;
       transition: all 0.2s ease;
 
       &:hover {
-        background: var(--nav-bg-lightened);
-        color: var(--blert-button);
+        background: var(--blert-surface-light);
+        color: var(--blert-purple);
       }
 
       &:disabled {
@@ -303,7 +303,7 @@
     align-items: center;
     gap: 16px;
     font-size: 0.9em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       flex-direction: column;
@@ -312,17 +312,17 @@
     }
 
     strong {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .lastUsed {
-      color: var(--font-color-nav-dimmed);
+      color: var(--blert-font-color-secondary-dimmed);
     }
   }
 }
 
 .generateKey {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   padding: 20px;
 
@@ -348,7 +348,7 @@
 }
 
 .passwordForm {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   padding: 20px;
 
@@ -375,7 +375,7 @@
 
 .deleteModal {
   padding: 24px;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 8px;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -384,17 +384,17 @@
 
   h3 {
     margin: 0 0 16px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 1.3em;
   }
 
   p {
     margin: 0 0 24px 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     line-height: 1.5;
 
     strong {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
   }
 
@@ -411,7 +411,7 @@
 
 .description {
   margin: 8px 0 0 0;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.95em;
   line-height: 1.5;
 }
@@ -452,13 +452,13 @@
     h3 {
       margin: 0;
       font-size: 1.4em;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     p {
       margin: 0;
       font-size: 0.95em;
-      color: rgba(var(--blert-text-color-base), 0.85);
+      color: rgba(var(--blert-font-color-primary-base), 0.85);
 
       & > span {
         color: var(--blert-green);
@@ -469,7 +469,7 @@
 
     & > span {
       font-size: 0.85em;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
   }
 }
@@ -479,7 +479,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 20px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   gap: 20px;
 
@@ -494,7 +494,7 @@
     gap: 16px;
 
     .linkedIcon {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1.5em;
     }
 
@@ -505,13 +505,13 @@
 
       .accountLabel {
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       .accountValue {
         font-size: 1.1em;
         font-weight: 600;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
   }
@@ -555,8 +555,8 @@
     flex-direction: column;
     gap: 20px;
     padding: 20px;
-    background: rgba(var(--blert-button-base), 0.02);
-    border: 1px solid rgba(var(--blert-button-base), 0.15);
+    background: rgba(var(--blert-purple-base), 0.02);
+    border: 1px solid rgba(var(--blert-purple-base), 0.15);
     border-radius: 8px;
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -574,8 +574,8 @@
         justify-content: center;
         width: 28px;
         height: 28px;
-        background: rgba(var(--blert-button-base), 0.15);
-        color: var(--blert-button);
+        background: rgba(var(--blert-purple-base), 0.15);
+        color: var(--blert-purple);
         border-radius: 50%;
         font-weight: 600;
         font-size: 0.85em;
@@ -587,13 +587,13 @@
         h3 {
           margin: 0 0 8px 0;
           font-size: 1em;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
         }
 
         p {
           margin: 0;
           font-size: 0.9em;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           line-height: 1.5;
         }
       }
@@ -613,16 +613,16 @@
 
   code {
     padding: 3px 8px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 4px;
     font-family: var(--font-roboto-mono), monospace;
     font-size: 0.95em;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     cursor: text;
     user-select: all;
 
     &::selection {
-      background: rgba(var(--blert-button-base), 0.3);
+      background: rgba(var(--blert-purple-base), 0.3);
     }
   }
 
@@ -638,10 +638,10 @@
       padding: 32px;
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.1) 0%,
-        rgba(var(--blert-button-base), 0.05) 100%
+        rgba(var(--blert-purple-base), 0.1) 0%,
+        rgba(var(--blert-purple-base), 0.05) 100%
       );
-      border: 2px dashed rgba(var(--blert-button-base), 0.3);
+      border: 2px dashed rgba(var(--blert-purple-base), 0.3);
       border-radius: 12px;
       gap: 12px;
 
@@ -651,7 +651,7 @@
 
       .codeLabel {
         font-size: 0.9em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-weight: 500;
       }
 
@@ -663,7 +663,7 @@
         font-family: var(--font-roboto-mono), monospace;
         font-size: 2em;
         font-weight: 700;
-        color: var(--blert-button);
+        color: var(--blert-purple);
         letter-spacing: 0.2em;
         cursor: text;
 
@@ -677,7 +677,7 @@
         }
 
         &::selection {
-          background: rgba(var(--blert-button-base), 0.3);
+          background: rgba(var(--blert-purple-base), 0.3);
         }
       }
 
@@ -693,9 +693,9 @@
         width: 36px;
         height: 36px;
         border-radius: 6px;
-        border: 1px solid rgba(var(--blert-button-base), 0.3);
-        background: rgba(var(--nav-bg-base), 0.5);
-        color: var(--blert-button);
+        border: 1px solid rgba(var(--blert-purple-base), 0.3);
+        background: rgba(var(--blert-surface-dark-base), 0.5);
+        color: var(--blert-purple);
         cursor: pointer;
         transition: all 0.2s ease;
 
@@ -705,8 +705,8 @@
         }
 
         &:hover:not(:disabled) {
-          background: rgba(var(--blert-button-base), 0.15);
-          border-color: var(--blert-button);
+          background: rgba(var(--blert-purple-base), 0.15);
+          border-color: var(--blert-purple);
         }
 
         &:disabled {
@@ -726,9 +726,9 @@
         align-items: center;
         gap: 5px;
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         padding: 6px 12px;
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
         border-radius: 20px;
 
         .time {
@@ -740,7 +740,7 @@
 
     .codeHint {
       text-align: center;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
       line-height: 1.5;
       margin: 0;
@@ -753,7 +753,7 @@
     justify-content: center;
     gap: 10px;
     padding: 12px 24px;
-    background: rgba(var(--blert-button-base), 0.9);
+    background: rgba(var(--blert-purple-base), 0.9);
     border: none;
     border-radius: 8px;
     color: #fff;
@@ -764,9 +764,9 @@
     align-self: center;
 
     &:hover:not(:disabled) {
-      background: rgba(var(--blert-button-base), 0.8);
+      background: rgba(var(--blert-purple-base), 0.8);
       transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.4);
+      box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.4);
     }
 
     &:disabled {

--- a/web/app/(account)/style.module.scss
+++ b/web/app/(account)/style.module.scss
@@ -21,8 +21,8 @@
   width: 100%;
   max-width: 420px;
   position: relative;
-  background: var(--panel-bg);
-  border: 1px solid var(--font-color-nav-divider);
+  background: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-divider-color);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     padding: 24px;
@@ -39,12 +39,12 @@
     font-size: 1.8em;
     margin: 0 0 8px 0;
     text-align: center;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .subtitle {
     text-align: center;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.95em;
     margin: 0 0 24px 0;
   }
@@ -76,7 +76,7 @@
     align-items: center;
     gap: 12px;
     margin: 24px 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.9em;
 
     &:before,
@@ -84,18 +84,18 @@
       content: '';
       flex: 1;
       height: 1px;
-      background: var(--font-color-nav-divider);
+      background: var(--blert-divider-color);
     }
   }
 
   .altLink {
     text-align: center;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.95em;
     margin-top: 16px;
 
     a {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       text-decoration: none;
       font-weight: 500;
       margin-left: 4px;

--- a/web/app/(challenges)/activity-dashboard.module.scss
+++ b/web/app/(challenges)/activity-dashboard.module.scss
@@ -28,7 +28,7 @@
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
   }
@@ -38,7 +38,7 @@
   overflow: hidden;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
   }
@@ -46,14 +46,14 @@
 
 .cardHeader {
   padding: 1.25rem 1.5rem 0.75rem;
-  border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
 
   h3 {
     margin: 0;
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--blert-text-color);
-    text-shadow: 0 0 3px rgba(var(--blert-button-base), 0.4);
+    color: var(--blert-font-color-primary);
+    text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.4);
   }
 }
 
@@ -88,9 +88,9 @@
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0 1.5rem 0;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid rgba(var(--blert-button-base), 0.2);
+  border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
   position: relative;
 
   &::after {
@@ -100,11 +100,11 @@
     left: 0;
     width: 60px;
     height: 2px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
   }
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1.2rem;
   }
 }
@@ -120,10 +120,10 @@
   font-size: 1rem;
   font-weight: 600;
   margin: 0 0 1rem 0;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -157,7 +157,7 @@
 
 .legendItem {
   font-size: 0.8rem !important;
-  color: var(--blert-text-color) !important;
+  color: var(--blert-font-color-primary) !important;
 }
 
 // Skeleton Animations
@@ -186,7 +186,7 @@
 .skeletonCircle {
   width: 100px;
   height: 50px;
-  background: var(--font-color-nav-divider);
+  background: var(--blert-divider-color);
   border-radius: 100px 100px 0 0;
   animation: pulse 1.5s ease-in-out infinite;
   margin-top: 1rem;
@@ -202,7 +202,7 @@
 .skeletonLegendItem {
   width: 80px;
   height: 12px;
-  background: var(--font-color-nav-divider);
+  background: var(--blert-divider-color);
   border-radius: 6px;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: calc(var(--item-index, 0) * 200ms);
@@ -236,7 +236,7 @@
 .skeletonLabel {
   width: 110px;
   height: 16px;
-  background: var(--font-color-nav-divider);
+  background: var(--blert-divider-color);
   border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: calc(var(--row-index, 0) * 100ms);
@@ -244,7 +244,7 @@
 
 .skeletonBar {
   height: 20px;
-  background: rgba(var(--blert-button-base), 0.2);
+  background: rgba(var(--blert-purple-base), 0.2);
   border-radius: 0 4px 4px 0;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: calc(var(--row-index, 0) * 100ms + 50ms);
@@ -283,19 +283,19 @@
   align-items: center;
   justify-content: center;
   gap: 1rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 8px;
   padding: 2rem;
 
   i {
     font-size: 1.5rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   span {
@@ -313,12 +313,12 @@
   padding: 2rem;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   .placeholderIcon {
     width: 60px;
@@ -326,8 +326,8 @@
     border-radius: 50%;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.1) 0%,
-      rgba(var(--blert-button-base), 0.05) 100%
+      rgba(var(--blert-purple-base), 0.1) 0%,
+      rgba(var(--blert-purple-base), 0.05) 100%
     );
     display: flex;
     align-items: center;
@@ -336,7 +336,7 @@
 
     i {
       font-size: 1.5rem;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       opacity: 0.7;
     }
   }
@@ -354,21 +354,21 @@
   align-items: center;
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.8) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.8) 100%
   );
   justify-content: space-between;
   padding: 1.5rem;
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 12px;
   transition: all 0.3s ease;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.4);
+    border-color: rgba(var(--blert-purple-base), 0.4);
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.08) 0%,
-      rgba(var(--blert-button-base), 0.03) 100%
+      rgba(var(--blert-purple-base), 0.08) 0%,
+      rgba(var(--blert-purple-base), 0.03) 100%
     );
   }
 }
@@ -384,7 +384,7 @@
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0 0.5rem 0;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .teamStats {
@@ -398,10 +398,10 @@
   align-items: center;
   gap: 0.75rem;
   font-size: 0.85rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     width: 12px;
     text-align: center;
   }
@@ -434,13 +434,13 @@
   padding: 1rem;
   background: linear-gradient(
     135deg,
-    rgba(var(--blert-button-base), 0.06) 0%,
-    rgba(var(--blert-button-base), 0.02) 100%
+    rgba(var(--blert-purple-base), 0.06) 0%,
+    rgba(var(--blert-purple-base), 0.02) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   border-radius: 8px;
   text-decoration: none;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
@@ -455,18 +455,18 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.08),
+      rgba(var(--blert-purple-base), 0.08),
       transparent
     );
     transition: left 0.4s ease;
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.25);
+    border-color: rgba(var(--blert-purple-base), 0.25);
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.1) 0%,
-      rgba(var(--blert-button-base), 0.04) 100%
+      rgba(var(--blert-purple-base), 0.1) 0%,
+      rgba(var(--blert-purple-base), 0.04) 100%
     );
     transform: translateX(4px);
 
@@ -486,8 +486,8 @@
     width: 32px;
     height: 32px;
     border-radius: 6px;
-    background: rgba(var(--blert-button-base), 0.15);
-    color: var(--blert-button);
+    background: rgba(var(--blert-purple-base), 0.15);
+    color: var(--blert-purple);
     font-size: 14px;
   }
 
@@ -501,17 +501,17 @@
   .linkTitle {
     font-weight: 600;
     font-size: 0.95rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .linkDescription {
     font-size: 0.8rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     line-height: 1.3;
   }
 
   .linkArrow {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.9rem;
     transition: transform 0.3s ease;
   }

--- a/web/app/(challenges)/activity-dashboard.tsx
+++ b/web/app/(challenges)/activity-dashboard.tsx
@@ -169,7 +169,7 @@ function PieChartComponent({
           innerRadius="100%"
           startAngle={180}
           endAngle={0}
-          stroke="var(--nav-bg)"
+          stroke="var(--blert-surface-dark)"
         >
           {data.map((v, i) => (
             <Cell key={`cell-${i}`} fill={v.color} />
@@ -547,7 +547,7 @@ export default function ActivityDashboard({
               />
               <XAxis
                 type="number"
-                tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+                tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
                 axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
                 tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
                 allowDecimals={false}
@@ -557,16 +557,16 @@ export default function ActivityDashboard({
                 dataKey="key"
                 type="category"
                 width={110}
-                tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+                tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
                 axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
                 tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               />
               <Tooltip
                 contentStyle={{
-                  backgroundColor: 'var(--panel-bg)',
-                  border: '1px solid var(--nav-bg-lightened)',
+                  backgroundColor: 'var(--blert-panel-background-color)',
+                  border: '1px solid var(--blert-surface-light)',
                   borderRadius: '6px',
-                  color: 'var(--blert-text-color)',
+                  color: 'var(--blert-font-color-primary)',
                   boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
                 }}
                 cursor={{ fill: 'rgba(139, 92, 246, 0.1)' }}
@@ -575,7 +575,7 @@ export default function ActivityDashboard({
                     <span
                       style={{
                         fontWeight: 600,
-                        color: 'var(--font-color-nav)',
+                        color: 'var(--blert-font-color-secondary)',
                       }}
                     >
                       {label}
@@ -585,7 +585,7 @@ export default function ActivityDashboard({
                 formatter={(value: number) => [
                   <span
                     key="challenges"
-                    style={{ color: 'var(--blert-text-color)' }}
+                    style={{ color: 'var(--blert-font-color-primary)' }}
                   >
                     {value.toLocaleString()} raid{value === 1 ? '' : 's'}
                   </span>,

--- a/web/app/(challenges)/challenges/colosseum/[id]/overview/style.module.scss
+++ b/web/app/(challenges)/challenges/colosseum/[id]/overview/style.module.scss
@@ -27,7 +27,7 @@
   h2 {
     font-size: 1.3em;
     margin: 0 0 20px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .waves {
@@ -49,8 +49,8 @@
 
     &:hover {
       transform: translateY(-2px);
-      background: var(--nav-bg-lightened);
-      outline: 1px solid var(--blert-button);
+      background: var(--blert-surface-light);
+      outline: 1px solid var(--blert-purple);
     }
 
     .waveImg {
@@ -60,7 +60,7 @@
       flex-shrink: 0;
       border-radius: 6px;
       overflow: hidden;
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
     }
 
     .waveDetails {
@@ -77,7 +77,7 @@
       gap: 8px;
       font-size: 1.1em;
       margin: 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 500;
 
       .time {
@@ -89,7 +89,7 @@
         font-family: var(--font-roboto-mono), monospace;
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
     }
@@ -99,7 +99,7 @@
         font-size: 0.9em;
         font-weight: 500;
         margin: 0 0 8px;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       ul {
@@ -127,7 +127,7 @@
         bottom: 56px;
         left: 60px;
         position: absolute;
-        background: var(--blert-button);
+        background: var(--blert-purple);
         opacity: 0.3;
       }
     }

--- a/web/app/(challenges)/challenges/inferno/[id]/overview/style.module.scss
+++ b/web/app/(challenges)/challenges/inferno/[id]/overview/style.module.scss
@@ -18,7 +18,7 @@
   h2 {
     font-size: 1.3em;
     margin: 0 0 20px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .groups {
@@ -32,11 +32,11 @@
   .waveGroup {
     &.special {
       .groupTitle {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-weight: 600;
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
     }
@@ -47,7 +47,7 @@
       justify-content: space-between;
       margin-bottom: 16px;
       padding-bottom: 12px;
-      border-bottom: 2px solid rgba(var(--blert-button-base), 0.3);
+      border-bottom: 2px solid rgba(var(--blert-purple-base), 0.3);
 
       .groupInfo {
         display: flex;
@@ -62,11 +62,11 @@
           gap: 8px;
           font-size: 1.2em;
           font-weight: 600;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
 
           i {
             font-size: 1em;
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
 
@@ -81,17 +81,17 @@
             display: flex;
             align-items: center;
             gap: 6px;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
 
             i {
               font-size: 0.9em;
-              color: var(--blert-button);
+              color: var(--blert-purple);
               min-width: 14px;
             }
           }
 
           .startTime {
-            color: var(--blert-text-color);
+            color: var(--blert-font-color-primary);
             font-weight: 500;
           }
         }
@@ -101,9 +101,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        background: rgba(var(--blert-button-base), 0.1);
+        background: rgba(var(--blert-purple-base), 0.1);
         border-radius: 8px;
-        border: 2px solid rgba(var(--blert-button-base), 0.3);
+        border: 2px solid rgba(var(--blert-purple-base), 0.3);
         flex-shrink: 0;
 
         img {
@@ -125,10 +125,10 @@
         padding: 6px 8px;
         width: 40px;
         height: 32px;
-        background: var(--nav-bg);
-        border: 1px solid var(--font-color-nav-divider);
+        background: var(--blert-surface-dark);
+        border: 1px solid var(--blert-divider-color);
         border-radius: 6px;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         text-decoration: none;
         font-size: 0.85em;
         font-weight: 500;
@@ -136,8 +136,8 @@
         font-family: var(--font-roboto-mono), monospace;
 
         &:hover {
-          background: var(--blert-button);
-          border-color: var(--blert-button);
+          background: var(--blert-purple);
+          border-color: var(--blert-purple);
           color: #fff;
           transform: translateY(-1px);
         }

--- a/web/app/(challenges)/challenges/inferno/[id]/waves/[number]/style.module.scss
+++ b/web/app/(challenges)/challenges/inferno/[id]/waves/[number]/style.module.scss
@@ -44,10 +44,10 @@
   padding: 16px;
   background: linear-gradient(
     135deg,
-    rgba(var(--nav-bg-base), 0.6) 0%,
-    rgba(var(--nav-bg-lightened-base), 0.4) 100%
+    rgba(var(--blert-surface-dark-base), 0.6) 0%,
+    rgba(var(--blert-surface-light-base), 0.4) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 8px;
   position: relative;
   overflow: hidden;
@@ -62,7 +62,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.7),
+      rgba(var(--blert-purple-base), 0.7),
       transparent
     );
     animation: borderShimmer 3s ease-in-out infinite;
@@ -82,20 +82,20 @@
   padding: 12px 16px;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.8) 0%,
-    rgba(var(--nav-bg-base), 0.6) 100%
+    rgba(var(--blert-panel-background-color-base), 0.8) 0%,
+    rgba(var(--blert-surface-dark-base), 0.6) 100%
   );
-  border: 1px solid rgba(var(--nav-bg-lightened-base), 0.3);
+  border: 1px solid rgba(var(--blert-surface-light-base), 0.3);
   border-radius: 6px;
   transition: all 0.3s ease;
   position: relative;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.4);
+    border-color: rgba(var(--blert-purple-base), 0.4);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 
     .splitTime {
-      background: rgba(var(--blert-button-base), 0.2);
+      background: rgba(var(--blert-purple-base), 0.2);
     }
   }
 
@@ -117,13 +117,13 @@
 .splitLabel {
   font-size: 1.1em;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .splitTick {
   font-size: 0.85em;
   font-family: var(--font-roboto-mono), monospace;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-weight: 500;
 }
 
@@ -135,9 +135,9 @@
   font-family: var(--font-roboto-mono), monospace;
   font-size: 1.1em;
   font-weight: 600;
-  color: var(--blert-button);
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  color: var(--blert-purple);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -154,18 +154,18 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.2),
+      rgba(var(--blert-purple-base), 0.2),
       transparent
     );
     transition: left 0.5s ease;
   }
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.15);
-    border-color: rgba(var(--blert-button-base), 0.5);
-    color: var(--blert-text-color);
+    background: rgba(var(--blert-purple-base), 0.15);
+    border-color: rgba(var(--blert-purple-base), 0.5);
+    color: var(--blert-font-color-primary);
     transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(var(--blert-button-base), 0.3);
+    box-shadow: 0 2px 8px rgba(var(--blert-purple-base), 0.3);
 
     &::before {
       left: 100%;
@@ -174,7 +174,7 @@
 
   &:active {
     transform: translateY(0);
-    box-shadow: 0 1px 4px rgba(var(--blert-button-base), 0.2);
+    box-shadow: 0 1px 4px rgba(var(--blert-purple-base), 0.2);
   }
 
   i {

--- a/web/app/(challenges)/challenges/mokhaiotl/[id]/overview/style.module.scss
+++ b/web/app/(challenges)/challenges/mokhaiotl/[id]/overview/style.module.scss
@@ -18,7 +18,7 @@
   h2 {
     font-size: 1.3em;
     margin: 0 0 20px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .delves {
@@ -38,8 +38,8 @@
 
       &:hover {
         transform: translateY(-2px);
-        background: var(--nav-bg-lightened);
-        outline: 1px solid var(--blert-button);
+        background: var(--blert-surface-light);
+        outline: 1px solid var(--blert-purple);
       }
 
       .delveImg {
@@ -49,7 +49,7 @@
         flex-shrink: 0;
         border-radius: 6px;
         overflow: hidden;
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
       }
 
       .delveDetails {
@@ -66,7 +66,7 @@
         gap: 8px;
         font-size: 1.1em;
         margin: 0;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         font-weight: 500;
 
         .time {
@@ -76,10 +76,10 @@
           margin-left: auto;
           font-size: 1em;
           font-family: var(--font-roboto-mono), monospace;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
 
           i {
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
       }
@@ -100,7 +100,7 @@
         bottom: 56px;
         left: 60px;
         position: absolute;
-        background: var(--blert-button);
+        background: var(--blert-purple);
         opacity: 0.3;
       }
     }

--- a/web/app/(challenges)/filtered-session-list.module.scss
+++ b/web/app/(challenges)/filtered-session-list.module.scss
@@ -29,7 +29,7 @@
         font-size: 1.25rem;
         margin-bottom: 10px;
         font-weight: 500;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       @media (max-width: $LARGE_SCREEN_WIDTH) {

--- a/web/app/(challenges)/raids/style.module.scss
+++ b/web/app/(challenges)/raids/style.module.scss
@@ -93,7 +93,7 @@
   width: 100%;
   height: 100%;
   z-index: 9999;
-  background: rgba(var(--nav-bg-base), 0.75);
+  background: rgba(var(--blert-surface-dark-base), 0.75);
   display: flex;
   justify-content: center;
   align-items: center;

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/bloat/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/bloat/style.module.scss
@@ -6,11 +6,11 @@
   }
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   .arrow {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .walkTime {
@@ -19,7 +19,7 @@
 
   .walkTicks {
     font-size: 14px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-left: 8px;
   }
 }

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/maiden/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/maiden/style.module.scss
@@ -36,7 +36,7 @@
       align-items: center;
       justify-content: center;
       transition: all 0.2s ease;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       &.presentCrab {
         background: rgba(var(--blert-red-base), 0.15);
@@ -59,14 +59,14 @@
       }
 
       &.absentCrab {
-        border: 1px solid rgba(var(--blert-text-color-base), 0.2);
+        border: 1px solid rgba(var(--blert-font-color-primary-base), 0.2);
         opacity: 0.6;
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
 
         &:hover {
           opacity: 0.8;
           transform: translateY(-1px);
-          border-color: rgba(var(--blert-text-color-base), 0.4);
+          border-color: rgba(var(--blert-font-color-primary-base), 0.4);
         }
       }
     }
@@ -80,18 +80,18 @@
   align-items: flex-start;
   gap: 4px;
   font-size: 0.95em;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-family: var(--font-roboto-mono), monospace;
   min-width: 80px;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     margin-right: 6px;
     width: 16px;
   }
 
   .delta {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-left: 14px;
   }
 }

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/page.tsx
@@ -1042,47 +1042,47 @@ function NyloWaveChart({
               >
                 <stop
                   offset="0%"
-                  stopColor="var(--blert-button)"
+                  stopColor="var(--blert-purple)"
                   stopOpacity={0.3}
                 />
                 <stop
                   offset="100%"
-                  stopColor="var(--blert-button)"
+                  stopColor="var(--blert-purple)"
                   stopOpacity={0.05}
                 />
               </linearGradient>
             </defs>
             <CartesianGrid
               strokeDasharray="3 3"
-              stroke="var(--nav-bg-lightened)"
+              stroke="var(--blert-surface-light)"
               opacity={0.9}
             />
             <XAxis
               dataKey="tick"
-              stroke="var(--font-color-nav)"
+              stroke="var(--blert-font-color-secondary)"
               tickLine={false}
-              axisLine={{ stroke: 'var(--nav-bg-lightened)' }}
+              axisLine={{ stroke: 'var(--blert-surface-light)' }}
               hide
             />
             <YAxis
-              stroke="var(--font-color-nav)"
+              stroke="var(--blert-font-color-secondary)"
               tickLine={false}
-              axisLine={{ stroke: 'var(--nav-bg-lightened)' }}
+              axisLine={{ stroke: 'var(--blert-surface-light)' }}
               tickCount={8}
             />
             <Area
               type="monotone"
               dataKey="nylosAlive"
-              stroke="rgba(var(--blert-button-base), 0.7)"
+              stroke="rgba(var(--blert-purple-base), 0.7)"
               strokeWidth={2}
               fill="url(#backgroundGradient)"
             />
             <Tooltip
               contentStyle={{
-                backgroundColor: 'var(--nav-bg)',
-                border: '1px solid var(--nav-bg-lightened)',
+                backgroundColor: 'var(--blert-surface-dark)',
+                border: '1px solid var(--blert-surface-light)',
                 borderRadius: '8px',
-                color: 'var(--blert-text-color)',
+                color: 'var(--blert-font-color-primary)',
                 padding: '8px',
               }}
               formatter={(value: number) => {
@@ -1101,7 +1101,7 @@ function NyloWaveChart({
                 return `Tick: ${tick} (Wave ${waveSpawn.nyloWave.wave})`;
               }}
               cursor={{
-                stroke: 'var(--font-color-nav-divider)',
+                stroke: 'var(--blert-divider-color)',
                 strokeWidth: 1,
               }}
             />
@@ -1119,7 +1119,7 @@ function NyloWaveChart({
             >
               <Label
                 position="top"
-                stroke="rgba(var(--blert-text-color-base), 0.7)"
+                stroke="rgba(var(--blert-font-color-primary-base), 0.7)"
                 style={{ fontWeight: 200 }}
               >
                 Room cap
@@ -1136,7 +1136,7 @@ function NyloWaveChart({
             >
               <Label
                 position="top"
-                stroke="rgba(var(--blert-text-color-base), 0.7)"
+                stroke="rgba(var(--blert-font-color-primary-base), 0.7)"
                 style={{ fontWeight: 200 }}
               >
                 Room cap
@@ -1149,16 +1149,16 @@ function NyloWaveChart({
                   x={evt.tick}
                   stroke={
                     evt.nyloWave.wave === CAP_INCREASE_WAVE
-                      ? 'rgba(var(--blert-text-color-base), 0.75)'
-                      : 'rgba(var(--blert-text-color-base), 0.15)'
+                      ? 'rgba(var(--blert-font-color-primary-base), 0.75)'
+                      : 'rgba(var(--blert-font-color-primary-base), 0.15)'
                   }
                   strokeWidth={1}
                 >
                   <Label
                     stroke={
                       evt.nyloWave.wave === CAP_INCREASE_WAVE
-                        ? 'rgba(var(--blert-text-color-base), 0.8)'
-                        : 'var(--font-color-nav)'
+                        ? 'rgba(var(--blert-font-color-primary-base), 0.8)'
+                        : 'var(--blert-font-color-secondary)'
                     }
                     position="bottom"
                     style={{ fontSize: 13, fontWeight: 100 }}
@@ -1173,7 +1173,7 @@ function NyloWaveChart({
                 <ReferenceLine
                   key={evt.tick}
                   x={evt.tick}
-                  stroke="rgba(var(--blert-text-color-base), 0.5)"
+                  stroke="rgba(var(--blert-font-color-primary-base), 0.5)"
                   strokeWidth={2}
                   strokeDasharray="3 3"
                 >

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/style.module.scss
@@ -123,7 +123,7 @@
     }
 
     .nylos {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
       padding: 4px 8px;
     }
@@ -190,7 +190,7 @@
   position: relative;
   height: 100%;
   width: 800%;
-  border-top: 1px solid var(--blert-text-color);
+  border-top: 1px solid var(--blert-font-color-primary);
   top: -1px;
 
   .entrance {
@@ -207,7 +207,7 @@
   position: relative;
   height: 800%;
   width: 100%;
-  border-left: 1px solid var(--blert-text-color);
+  border-left: 1px solid var(--blert-font-color-primary);
 
   .entrance {
     position: absolute;
@@ -223,7 +223,7 @@
   position: relative;
   height: 100%;
   width: 800%;
-  border-bottom: 1px solid var(--blert-text-color);
+  border-bottom: 1px solid var(--blert-font-color-primary);
   top: 1px;
 
   .entrance {
@@ -240,7 +240,7 @@
   position: relative;
   height: 800%;
   width: 100%;
-  border-right: 1px solid var(--blert-text-color);
+  border-right: 1px solid var(--blert-font-color-primary);
   right: -1px;
 
   .entrance {

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/sotetseg/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/sotetseg/style.module.scss
@@ -24,13 +24,13 @@
         margin-right: 10px;
         width: 16px;
         text-align: center;
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
 }
 
-$disabledMazeTileColor: rgba(var(--blert-text-color-base), 0.5);
+$disabledMazeTileColor: rgba(var(--blert-font-color-primary-base), 0.5);
 $activeMazeTileColor: var(--blert-red);
 
 .mapTile {
@@ -66,7 +66,7 @@ $activeMazeTileColor: var(--blert-red);
     border: 1px solid $disabledMazeTileColor;
     font-size: 14px;
     font-style: italic;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .mazeRow {
@@ -107,7 +107,7 @@ $activeMazeTileColor: var(--blert-red);
       }
 
       .pivot {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 8px;
         font-weight: bold;
       }

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/style.module.scss
@@ -94,7 +94,7 @@
   }
 
   .timeline {
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     border-radius: 5px;
   }
 }

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/verzik/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/verzik/style.module.scss
@@ -44,8 +44,8 @@
     font-family: var(--font-roboto-mono), monospace;
     font-size: 1.1em;
     font-weight: 500;
-    color: var(--blert-button);
-    background: rgba(var(--blert-button-base), 0.1);
+    color: var(--blert-purple);
+    background: rgba(var(--blert-purple-base), 0.1);
     padding: 4px 10px;
     border-radius: 4px;
     border: none;
@@ -53,7 +53,7 @@
     transition: all 0.2s ease;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.2);
+      background: rgba(var(--blert-purple-base), 0.2);
       transform: translateY(-1px);
     }
   }
@@ -77,7 +77,7 @@
     flex-direction: column;
 
     button {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       width: fit-content;
       padding: 2px 0;
       font-size: 0.85em;
@@ -130,7 +130,7 @@
 
   .redCrabInfoLabel {
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -168,7 +168,7 @@
 
       .hpLabel {
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       .hpValue {
@@ -220,8 +220,8 @@
     margin-top: 8px;
     padding: 4px 8px;
     font-size: 0.9em;
-    background: rgba(var(--blert-button-base), 0.1);
-    color: var(--blert-button);
+    background: rgba(var(--blert-purple-base), 0.1);
+    color: var(--blert-purple);
     border: none;
     border-radius: 4px;
     cursor: pointer;
@@ -232,7 +232,7 @@
     gap: 6px;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.2);
+      background: rgba(var(--blert-purple-base), 0.2);
     }
   }
 }

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/xarpus/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/xarpus/style.module.scss
@@ -30,14 +30,14 @@
       font-family: var(--font-roboto-mono), monospace;
       font-size: 1.1em;
       font-weight: 500;
-      color: var(--blert-button);
-      background: rgba(var(--blert-button-base), 0.1);
+      color: var(--blert-purple);
+      background: rgba(var(--blert-purple-base), 0.1);
       padding: 4px 10px;
       border-radius: 4px;
       cursor: pointer;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.2);
+        background: rgba(var(--blert-purple-base), 0.2);
       }
     }
   }
@@ -55,7 +55,7 @@
   }
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -71,11 +71,11 @@
   }
 
   .healingTableHeader {
-    border-bottom: 2px solid var(--font-color-nav-divider);
+    border-bottom: 2px solid var(--blert-divider-color);
     font-weight: 700;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       margin-right: 4px;
     }
   }
@@ -83,7 +83,7 @@
   .healingTableSubHeader {
     font-weight: 400;
     padding-bottom: 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .healingTableAmount {

--- a/web/app/(challenges)/raids/tob/[id]/overview/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/overview/style.module.scss
@@ -13,7 +13,7 @@
   h2 {
     font-size: 1.3em;
     margin: 0 0 20px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -23,7 +23,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: linear-gradient(135deg, var(--panel-bg), var(--nav-bg-lightened));
+  background: linear-gradient(
+    135deg,
+    var(--blert-panel-background-color),
+    var(--blert-surface-light)
+  );
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     flex-direction: column;
@@ -54,14 +58,14 @@
   .value {
     font-size: 1.8em;
     font-weight: 500;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     line-height: 1.2;
     margin-bottom: 8px;
   }
 
   .label {
     font-size: 0.9em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -76,7 +80,7 @@
   h2 {
     font-size: 1.3em;
     margin: 0 0 20px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -97,7 +101,7 @@
     top: 56px;
     bottom: 56px;
     width: 2px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     opacity: 0.3;
   }
 
@@ -126,8 +130,8 @@
 
   &:hover {
     transform: translateY(-2px);
-    background: var(--nav-bg-lightened);
-    outline: 1px solid var(--blert-button);
+    background: var(--blert-surface-light);
+    outline: 1px solid var(--blert-purple);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -150,7 +154,7 @@
   flex-shrink: 0;
   border-radius: 6px;
   overflow: hidden;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     width: 60px;
@@ -172,12 +176,12 @@
   gap: 8px;
   font-size: 1.1em;
   margin: 0;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-weight: 500;
   position: relative;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.9em;
     margin-left: 10px;
   }
@@ -197,9 +201,9 @@
     margin-left: auto;
     padding: 2px 6px;
     border-radius: 4px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     font-size: 0.85em;
-    color: var(--blert-button);
+    color: var(--blert-purple);
 
     i {
       margin-left: 0;

--- a/web/app/components/activity-chart/activity-chart.tsx
+++ b/web/app/components/activity-chart/activity-chart.tsx
@@ -68,12 +68,12 @@ export default function ActivityChart({
             <linearGradient id="activityGradient" x1="0" y1="0" x2="0" y2="1">
               <stop
                 offset="0%"
-                stopColor="var(--blert-button)"
+                stopColor="var(--blert-purple)"
                 stopOpacity={0.3}
               />
               <stop
                 offset="100%"
-                stopColor="var(--blert-button)"
+                stopColor="var(--blert-purple)"
                 stopOpacity={0}
               />
             </linearGradient>
@@ -84,7 +84,7 @@ export default function ActivityChart({
             tickFormatter={(hour) =>
               formatHour(utcToLocal((startHour + hour) % 24))
             }
-            stroke="var(--font-color-nav)"
+            stroke="var(--blert-font-color-secondary)"
             tick={{ fontSize: 10 }}
             tickLine={false}
             minTickGap={20}
@@ -92,7 +92,7 @@ export default function ActivityChart({
           <YAxis hide />
           <Tooltip
             contentStyle={{
-              background: 'var(--nav-bg)',
+              background: 'var(--blert-surface-dark)',
               border: 'none',
               borderRadius: '4px',
               fontSize: '12px',
@@ -106,7 +106,7 @@ export default function ActivityChart({
           <Area
             type="monotone"
             dataKey="count"
-            stroke="var(--blert-button)"
+            stroke="var(--blert-purple)"
             strokeWidth={2}
             fill="url(#activityGradient)"
           />

--- a/web/app/components/activity-chart/style.module.scss
+++ b/web/app/components/activity-chart/style.module.scss
@@ -6,7 +6,7 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 12px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.9em;
 
     .chartTitleMain {
@@ -15,7 +15,7 @@
       gap: 8px;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 
@@ -26,7 +26,7 @@
       gap: 6px;
       font-size: 0.9em;
       padding: 4px 8px;
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
       border-radius: 4px;
 
       i {
@@ -39,10 +39,10 @@
 
   :global(.recharts-cartesian-grid-horizontal line),
   :global(.recharts-cartesian-grid-vertical line) {
-    stroke: var(--font-color-nav-divider);
+    stroke: var(--blert-divider-color);
   }
 
   :global(.recharts-tooltip-cursor) {
-    fill: var(--font-color-nav-divider);
+    fill: var(--blert-divider-color);
   }
 }

--- a/web/app/components/article/style.module.scss
+++ b/web/app/components/article/style.module.scss
@@ -27,10 +27,10 @@ $FIXED_TOC_MARGIN: 40px;
 .article {
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.8) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.8) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.12);
+  border: 1px solid rgba(var(--blert-purple-base), 0.12);
   border-radius: 16px;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.3),
@@ -55,7 +55,7 @@ $FIXED_TOC_MARGIN: 40px;
     background: linear-gradient(
       90deg,
       transparent,
-      var(--blert-button),
+      var(--blert-purple),
       transparent
     );
     animation: borderShimmer 3s ease-in-out infinite;
@@ -71,9 +71,9 @@ $FIXED_TOC_MARGIN: 40px;
     border-radius: 15px;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.05) 0%,
+      rgba(var(--blert-purple-base), 0.05) 0%,
       transparent 50%,
-      rgba(var(--blert-button-base), 0.02) 100%
+      rgba(var(--blert-purple-base), 0.02) 100%
     );
     pointer-events: none;
     z-index: 0;
@@ -124,9 +124,9 @@ $FIXED_TOC_MARGIN: 40px;
     margin: 0 0 2rem 0;
     background: linear-gradient(
       135deg,
-      var(--blert-text-color) 0%,
-      rgba(var(--blert-text-color-base), 0.9) 70%,
-      rgba(var(--blert-button-base), 0.8) 100%
+      var(--blert-font-color-primary) 0%,
+      rgba(var(--blert-font-color-primary-base), 0.9) 70%,
+      rgba(var(--blert-purple-base), 0.8) 100%
     );
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -147,7 +147,7 @@ $FIXED_TOC_MARGIN: 40px;
     font-size: 1.875rem;
     font-weight: 600;
     margin: 3rem 0 1.25rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     position: relative;
     padding-bottom: 0.75rem;
 
@@ -160,8 +160,8 @@ $FIXED_TOC_MARGIN: 40px;
       height: 3px;
       background: linear-gradient(
         90deg,
-        var(--blert-button),
-        rgba(var(--blert-button-base), 0.6)
+        var(--blert-purple),
+        rgba(var(--blert-purple-base), 0.6)
       );
       border-radius: 2px;
     }
@@ -175,7 +175,7 @@ $FIXED_TOC_MARGIN: 40px;
     font-size: 1.5rem;
     font-weight: 600;
     margin: 2.5rem 0 1rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     position: relative;
     padding-left: 1.25rem;
 
@@ -189,8 +189,8 @@ $FIXED_TOC_MARGIN: 40px;
       height: 1.5em;
       background: linear-gradient(
         180deg,
-        var(--blert-button),
-        rgba(var(--blert-button-base), 0.5)
+        var(--blert-purple),
+        rgba(var(--blert-purple-base), 0.5)
       );
       border-radius: 2px;
     }
@@ -200,27 +200,27 @@ $FIXED_TOC_MARGIN: 40px;
     font-size: 1.25rem;
     font-weight: 600;
     margin: 2rem 0 0.875rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   h5 {
     font-size: 1.125rem;
     font-weight: 600;
     margin: 1.5rem 0 0.75rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   h6 {
     font-size: 1rem;
     font-weight: 600;
     margin: 1.25rem 0 0.5rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   p {
     margin: 1.25rem 0;
     line-height: 1.75;
-    color: rgba(var(--blert-text-color-base), 0.95);
+    color: rgba(var(--blert-font-color-primary-base), 0.95);
     font-size: 1rem;
 
     &:first-child {
@@ -240,8 +240,8 @@ $FIXED_TOC_MARGIN: 40px;
     th {
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.1) 0%,
-        rgba(var(--blert-button-base), 0.05) 100%
+        rgba(var(--blert-purple-base), 0.1) 0%,
+        rgba(var(--blert-purple-base), 0.05) 100%
       );
     }
 
@@ -249,9 +249,9 @@ $FIXED_TOC_MARGIN: 40px;
     td {
       padding: 0.5rem 1rem;
       text-align: center;
-      border: 1px solid rgba(var(--blert-button-base), 0.15);
+      border: 1px solid rgba(var(--blert-purple-base), 0.15);
       font-size: 0.9rem;
-      color: rgba(var(--blert-text-color-base), 0.95);
+      color: rgba(var(--blert-font-color-primary-base), 0.95);
     }
   }
 
@@ -263,7 +263,7 @@ $FIXED_TOC_MARGIN: 40px;
     li {
       padding: 0.4rem 0;
       line-height: 1.7;
-      color: rgba(var(--blert-text-color-base), 0.95);
+      color: rgba(var(--blert-font-color-primary-base), 0.95);
       position: relative;
 
       p:first-child {
@@ -275,7 +275,7 @@ $FIXED_TOC_MARGIN: 40px;
       }
 
       &::marker {
-        color: rgba(var(--blert-button-base), 0.7);
+        color: rgba(var(--blert-purple-base), 0.7);
       }
     }
 
@@ -286,15 +286,15 @@ $FIXED_TOC_MARGIN: 40px;
   }
 
   *:not(h1, h2, h3, h4, h5, h6) a {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     text-decoration: none;
     border-bottom: 1px solid transparent;
     transition: all 0.2s ease;
     font-weight: 500;
 
     &:hover {
-      border-bottom-color: var(--blert-button);
-      color: rgba(var(--blert-button-base), 0.8);
+      border-bottom-color: var(--blert-purple);
+      color: rgba(var(--blert-purple-base), 0.8);
 
       & > i:last-child {
         transform: translateX(0.2rem);
@@ -326,11 +326,11 @@ $FIXED_TOC_MARGIN: 40px;
     position: relative;
     padding-right: 0.8rem;
     cursor: help;
-    border-bottom: 1px dotted rgba(var(--blert-button-base), 0.5);
+    border-bottom: 1px dotted rgba(var(--blert-purple-base), 0.5);
     transition: all 0.2s ease;
 
     &:hover {
-      border-bottom-color: var(--blert-button);
+      border-bottom-color: var(--blert-purple);
     }
 
     i {
@@ -339,7 +339,7 @@ $FIXED_TOC_MARGIN: 40px;
       top: 0.2rem;
       right: 0.2rem;
       opacity: 0.7;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       transition: all 0.2s ease;
     }
 
@@ -366,12 +366,12 @@ $FIXED_TOC_MARGIN: 40px;
       border-radius: 6px;
       opacity: 0;
       transition: all 0.3s ease;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1rem;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.1);
-        color: rgba(var(--blert-button-base), 0.8);
+        background: rgba(var(--blert-purple-base), 0.1);
+        color: rgba(var(--blert-purple-base), 0.8);
         transform: translateY(-50%) scale(1.1);
       }
 
@@ -414,15 +414,15 @@ $FIXED_TOC_MARGIN: 40px;
   padding: 1.5rem;
   background: linear-gradient(
     135deg,
-    rgba(var(--nav-bg-base), 0.98) 0%,
-    rgba(var(--nav-bg-lightened-base), 0.95) 100%
+    rgba(var(--blert-surface-dark-base), 0.98) 0%,
+    rgba(var(--blert-surface-light-base), 0.95) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 16px;
   backdrop-filter: blur(12px);
   box-shadow:
     0 10px 25px rgba(0, 0, 0, 0.15),
-    0 0 0 1px rgba(var(--blert-button-base), 0.1);
+    0 0 0 1px rgba(var(--blert-purple-base), 0.1);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 100;
   @include styledScrollbar;
@@ -430,7 +430,7 @@ $FIXED_TOC_MARGIN: 40px;
   &:hover {
     box-shadow:
       0 15px 35px rgba(0, 0, 0, 0.2),
-      0 0 0 1px rgba(var(--blert-button-base), 0.2);
+      0 0 0 1px rgba(var(--blert-purple-base), 0.2);
     transform: translateY(-2px);
   }
 
@@ -455,9 +455,9 @@ $FIXED_TOC_MARGIN: 40px;
     font-size: 1.1rem;
     font-weight: 700;
     margin: 0 0 1.25rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     padding-bottom: 0.75rem;
-    border-bottom: 2px solid rgba(var(--blert-button-base), 0.2);
+    border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }
@@ -466,7 +466,7 @@ $FIXED_TOC_MARGIN: 40px;
     display: block;
     width: 100%;
     padding: 0.3rem 1rem 0.3rem 0;
-    color: rgba(var(--blert-text-color-base), 0.8);
+    color: rgba(var(--blert-font-color-primary-base), 0.8);
     text-decoration: none;
     border: none;
     background: none;
@@ -491,14 +491,14 @@ $FIXED_TOC_MARGIN: 40px;
       transform: translateY(-50%);
       width: 3px;
       height: 0;
-      background: var(--blert-button);
+      background: var(--blert-purple);
       transition: height 0.2s cubic-bezier(0.4, 0, 0.2, 1);
       border-radius: 0 2px 2px 0;
     }
 
     &:hover {
-      color: var(--blert-text-color);
-      background: rgba(var(--blert-button-base), 0.08);
+      color: var(--blert-font-color-primary);
+      background: rgba(var(--blert-purple-base), 0.08);
       transform: translateX(2px);
 
       &::before {
@@ -507,11 +507,11 @@ $FIXED_TOC_MARGIN: 40px;
     }
 
     &.active {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.15) 0%,
-        rgba(var(--blert-button-base), 0.08) 100%
+        rgba(var(--blert-purple-base), 0.15) 0%,
+        rgba(var(--blert-purple-base), 0.08) 100%
       );
       font-weight: 600;
       transform: translateX(4px);
@@ -524,22 +524,22 @@ $FIXED_TOC_MARGIN: 40px;
 }
 
 .appendixRef {
-  color: var(--blert-button);
+  color: var(--blert-purple);
   text-decoration: none;
   border-bottom: 1px solid transparent;
   transition: all 0.2s ease;
   font-weight: 500;
 
   &:hover {
-    border-bottom-color: var(--blert-button);
-    color: rgba(var(--blert-button-base), 0.8);
+    border-bottom-color: var(--blert-purple);
+    color: rgba(var(--blert-purple-base), 0.8);
   }
 }
 
 .appendix {
   margin-top: 3rem;
   padding-top: 1rem;
-  border-top: 1px solid rgba(var(--blert-button-base), 0.15);
+  border-top: 1px solid rgba(var(--blert-purple-base), 0.15);
 
   .appendixItem {
     margin-top: 1.5rem;
@@ -562,10 +562,10 @@ $FIXED_TOC_MARGIN: 40px;
   margin: 2rem 0;
   background: linear-gradient(
     135deg,
-    rgba(var(--nav-bg-darkened-base), 1) 0%,
-    rgba(var(--nav-bg-base), 0.95) 100%
+    rgba(var(--blert-surface-darker-base), 1) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 12px;
   overflow: hidden;
   box-shadow:
@@ -580,10 +580,10 @@ $FIXED_TOC_MARGIN: 40px;
     padding: 1.25rem 1.5rem;
     background: linear-gradient(
       135deg,
-      rgba(var(--nav-bg-base), 1) 0%,
-      rgba(var(--nav-bg-lightened-base), 0.9) 100%
+      rgba(var(--blert-surface-dark-base), 1) 0%,
+      rgba(var(--blert-surface-light-base), 0.9) 100%
     );
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.25);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.25);
 
     .codeInfo {
       display: flex;
@@ -597,32 +597,32 @@ $FIXED_TOC_MARGIN: 40px;
         gap: 0.5rem;
         font-size: 0.85rem;
         font-weight: 600;
-        color: rgba(var(--blert-text-color-base), 0.9);
-        background: rgba(var(--nav-bg-darkened-base), 0.6);
+        color: rgba(var(--blert-font-color-primary-base), 0.9);
+        background: rgba(var(--blert-surface-darker-base), 0.6);
         padding: 0.4rem 0.8rem;
         border-radius: 6px;
-        border: 1px solid rgba(var(--blert-button-base), 0.2);
+        border: 1px solid rgba(var(--blert-purple-base), 0.2);
 
         i {
           font-size: 0.8rem;
-          color: rgba(var(--blert-button-base), 0.8);
+          color: rgba(var(--blert-purple-base), 0.8);
         }
       }
 
       .language {
         font-size: 0.8rem;
         font-weight: 700;
-        color: var(--blert-button);
+        color: var(--blert-purple);
         text-transform: uppercase;
         letter-spacing: 0.8px;
         background: linear-gradient(
           135deg,
-          rgba(var(--blert-button-base), 0.2) 0%,
-          rgba(var(--blert-button-base), 0.1) 100%
+          rgba(var(--blert-purple-base), 0.2) 0%,
+          rgba(var(--blert-purple-base), 0.1) 100%
         );
         padding: 0.4rem 0.8rem;
         border-radius: 6px;
-        border: 1px solid rgba(var(--blert-button-base), 0.3);
+        border: 1px solid rgba(var(--blert-purple-base), 0.3);
       }
 
       .lineCount {
@@ -630,11 +630,11 @@ $FIXED_TOC_MARGIN: 40px;
         align-items: center;
         gap: 0.4rem;
         font-size: 0.75rem;
-        color: rgba(var(--blert-text-color-base), 0.7);
+        color: rgba(var(--blert-font-color-primary-base), 0.7);
 
         i {
           font-size: 0.7rem;
-          color: rgba(var(--blert-button-base), 0.6);
+          color: rgba(var(--blert-purple-base), 0.6);
         }
       }
     }
@@ -644,13 +644,13 @@ $FIXED_TOC_MARGIN: 40px;
       align-items: center;
       gap: 0.5rem;
       padding: 0.6rem 1rem;
-      color: rgba(var(--blert-text-color-base), 0.8);
+      color: rgba(var(--blert-font-color-primary-base), 0.8);
       background: linear-gradient(
         135deg,
-        rgba(var(--nav-bg-darkened-base), 0.9) 0%,
-        rgba(var(--nav-bg-base), 0.7) 100%
+        rgba(var(--blert-surface-darker-base), 0.9) 0%,
+        rgba(var(--blert-surface-dark-base), 0.7) 100%
       );
-      border: 1px solid rgba(var(--blert-button-base), 0.25);
+      border: 1px solid rgba(var(--blert-purple-base), 0.25);
       border-radius: 8px;
       cursor: pointer;
       transition: all 0.3s ease;
@@ -658,13 +658,13 @@ $FIXED_TOC_MARGIN: 40px;
       font-weight: 500;
 
       &:hover:not(:disabled) {
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         background: linear-gradient(
           135deg,
-          rgba(var(--blert-button-base), 0.15) 0%,
-          rgba(var(--blert-button-base), 0.08) 100%
+          rgba(var(--blert-purple-base), 0.15) 0%,
+          rgba(var(--blert-purple-base), 0.08) 100%
         );
-        border-color: rgba(var(--blert-button-base), 0.5);
+        border-color: rgba(var(--blert-purple-base), 0.5);
         transform: translateY(-1px);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
       }
@@ -672,11 +672,11 @@ $FIXED_TOC_MARGIN: 40px;
       &:disabled {
         background: linear-gradient(
           135deg,
-          rgba(var(--blert-button-base), 0.2) 0%,
-          rgba(var(--blert-button-base), 0.1) 100%
+          rgba(var(--blert-purple-base), 0.2) 0%,
+          rgba(var(--blert-purple-base), 0.1) 100%
         );
-        border-color: rgba(var(--blert-button-base), 0.4);
-        color: var(--blert-text-color);
+        border-color: rgba(var(--blert-purple-base), 0.4);
+        color: var(--blert-font-color-primary);
         cursor: default;
       }
 
@@ -690,7 +690,7 @@ $FIXED_TOC_MARGIN: 40px;
       }
 
       &:disabled i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -712,7 +712,7 @@ $FIXED_TOC_MARGIN: 40px;
         monospace;
       font-size: 0.9em;
       line-height: 1.7;
-      color: rgba(var(--blert-text-color-base), 0.96);
+      color: rgba(var(--blert-font-color-primary-base), 0.96);
     }
   }
 }
@@ -724,13 +724,13 @@ $FIXED_TOC_MARGIN: 40px;
       monospace;
     font-size: 0.875em;
     font-weight: 600;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.15) 0%,
-      rgba(var(--blert-button-base), 0.08) 100%
+      rgba(var(--blert-purple-base), 0.15) 0%,
+      rgba(var(--blert-purple-base), 0.08) 100%
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.25);
+    border: 1px solid rgba(var(--blert-purple-base), 0.25);
     border-radius: 4px;
     padding: 0.2em 0.5em;
     margin: 0 0.1em;
@@ -742,10 +742,10 @@ $FIXED_TOC_MARGIN: 40px;
     &:hover {
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.22) 0%,
-        rgba(var(--blert-button-base), 0.12) 100%
+        rgba(var(--blert-purple-base), 0.22) 0%,
+        rgba(var(--blert-purple-base), 0.12) 100%
       );
-      border-color: rgba(var(--blert-button-base), 0.4);
+      border-color: rgba(var(--blert-purple-base), 0.4);
       transform: translateY(-1px);
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     }
@@ -784,8 +784,8 @@ $FIXED_TOC_MARGIN: 40px;
   padding: 1.25rem;
   margin: 1.5rem 0;
   border-radius: 12px;
-  background: rgba(var(--blert-button-base), 0.05);
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  background: rgba(var(--blert-purple-base), 0.05);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: all 0.2s ease;
 
@@ -799,7 +799,7 @@ $FIXED_TOC_MARGIN: 40px;
     flex: 1;
     font-size: 1rem;
     line-height: 1.5;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     p {
       margin: 0;
@@ -850,25 +850,25 @@ $FIXED_TOC_MARGIN: 40px;
 
 .tabs {
   margin: 1.5rem 0;
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   border-radius: 12px;
   overflow: hidden;
-  background: rgba(var(--blert-button-base), 0.02);
+  background: rgba(var(--blert-purple-base), 0.02);
 }
 
 .tabList {
   display: flex;
   gap: 1px;
-  background: rgba(var(--blert-button-base), 0.1);
+  background: rgba(var(--blert-purple-base), 0.1);
   padding: 0.5rem 0.5rem 0;
-  border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
 }
 
 .tab {
   padding: 0.75rem 1.25rem;
   border: none;
   background: transparent;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.9375rem;
   font-weight: 500;
   cursor: pointer;
@@ -879,13 +879,13 @@ $FIXED_TOC_MARGIN: 40px;
 
   &:hover {
     opacity: 0.9;
-    background: rgba(var(--blert-button-base), 0.05);
+    background: rgba(var(--blert-purple-base), 0.05);
   }
 
   &.active {
     opacity: 1;
-    background: rgba(var(--blert-button-base), 0.05);
-    color: var(--blert-button);
+    background: rgba(var(--blert-purple-base), 0.05);
+    color: var(--blert-purple);
 
     &::after {
       content: '';
@@ -894,7 +894,7 @@ $FIXED_TOC_MARGIN: 40px;
       left: 0;
       right: 0;
       height: 2px;
-      background: var(--blert-button);
+      background: var(--blert-purple);
       border-radius: 2px 2px 0 0;
     }
   }
@@ -902,7 +902,7 @@ $FIXED_TOC_MARGIN: 40px;
 
 .tabContent {
   padding: 1.5rem;
-  background: rgba(var(--blert-button-base), 0.02);
+  background: rgba(var(--blert-purple-base), 0.02);
 
   pre {
     margin: 0;

--- a/web/app/components/attack-timeline/attack-timeline.tsx
+++ b/web/app/components/attack-timeline/attack-timeline.tsx
@@ -790,7 +790,8 @@ const buildTickCell = (
           style.outline = '1px solid rgba(var(--blert-red-base), 0.5)';
         }
       } else {
-        style.outline = '1px solid rgba(var(--blert-text-color-base), 0.2)';
+        style.outline =
+          '1px solid rgba(var(--blert-font-color-primary-base), 0.2)';
       }
     }
 

--- a/web/app/components/attack-timeline/style.module.scss
+++ b/web/app/components/attack-timeline/style.module.scss
@@ -41,7 +41,7 @@
 .attackTimeline__ColumnActiveIndicator {
   position: absolute;
   height: 100%;
-  border: 2px solid var(--blert-button);
+  border: 2px solid var(--blert-purple);
   border-radius: 5px;
   opacity: 0.5;
   left: 0;
@@ -81,10 +81,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     border-radius: 4px;
     font-size: 0.9em;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 500;
     width: calc(100% - 10px);
     opacity: 1;
@@ -93,14 +93,14 @@
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--blert-button);
+      background: var(--blert-purple);
       color: white;
       transform: translateY(-1px);
     }
 
     &.npc {
       background: rgba(var(--blert-red-base), 0.1);
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       &:hover {
         background: rgba(var(--blert-red-base), 0.3);
@@ -109,7 +109,7 @@
     }
 
     &.selected {
-      background: var(--blert-button);
+      background: var(--blert-purple);
       color: white;
 
       &.npc {
@@ -129,11 +129,11 @@
   position: relative;
   top: -3px;
   font-size: 0.9em;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   transition: color 0.2s ease;
 
   &:hover {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -150,9 +150,9 @@
   }
 
   span {
-    border: 1px solid var(--blert-button);
+    border: 1px solid var(--blert-purple);
     cursor: pointer;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     border-radius: 5px;
     padding: 4px 8px;
     text-align: center;
@@ -162,11 +162,11 @@
     left: 50%;
     font-size: 1.1em;
     transform: translateX(-50%);
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
       transform: translateX(-50%) scale(1.05);
     }
   }
@@ -180,9 +180,9 @@
       bottom: -58px;
       height: 10px;
       width: 100%;
-      border-left: 2px solid var(--blert-button);
-      border-right: 2px solid var(--blert-button);
-      border-top: 2px solid var(--blert-button);
+      border-left: 2px solid var(--blert-purple);
+      border-right: 2px solid var(--blert-purple);
+      border-top: 2px solid var(--blert-purple);
       border-bottom-left-radius: 6px;
       border-bottom-right-radius: 6px;
       opacity: 0.5;
@@ -192,20 +192,20 @@
       bottom: -49px;
       height: 5px;
       position: absolute;
-      border-left: 2px solid var(--blert-button);
+      border-left: 2px solid var(--blert-purple);
       opacity: 0.5;
     }
   }
 }
 
 .cell {
-  background: var(--nav-bg-lightened);
+  background: var(--blert-surface-light);
   border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 45px;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-weight: bold;
   text-align: center;
   opacity: 0.3;
@@ -215,7 +215,7 @@
   border: 1px solid transparent;
 
   &:hover {
-    border-color: var(--blert-button);
+    border-color: var(--blert-purple);
     opacity: 0.7;
   }
 
@@ -233,10 +233,10 @@
   &.attackTimeline__CellOffCooldown {
     opacity: 1;
     background: rgba(48, 51, 73, 0.5);
-    color: rgba(var(--blert-button-base), 0.9);
+    color: rgba(var(--blert-purple-base), 0.9);
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.3);
+      background: rgba(var(--blert-purple-base), 0.3);
       opacity: 0.9;
     }
   }
@@ -261,7 +261,7 @@
     bottom: 0;
     right: 0;
     padding: 2px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -271,7 +271,7 @@
   button {
     padding: 1px;
     font-size: 0.9rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     margin-bottom: 1px;
     transition: all 0.2s ease;
 
@@ -299,21 +299,21 @@
   .playerName {
     font-size: 1rem;
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .tickInfo {
     font-family: var(--font-roboto-mono), monospace;
     font-weight: 500;
     font-size: 0.8rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .timeInfo {
     font-family: var(--font-roboto-mono), monospace;
     font-weight: 500;
     font-size: 0.8rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -335,12 +335,12 @@
   gap: 0.5rem;
   font-weight: 600;
   font-size: 0.85rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin-bottom: 0.5rem;
   padding-bottom: 0.25rem;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.75rem;
   }
 }
@@ -348,7 +348,7 @@
 .sectionDivider {
   width: 100%;
   height: 1px;
-  background: rgba(var(--nav-bg-lightened-base), 0.4);
+  background: rgba(var(--blert-surface-light-base), 0.4);
   margin: 0.75rem 0;
 }
 
@@ -361,7 +361,7 @@
   }
 
   .distanceInfo {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.8rem;
   }
 
@@ -433,13 +433,13 @@
 
 .customStateLabel {
   font-size: 0.8rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-weight: 500;
 }
 
 .noContent {
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 }
 
 .npcTooltip {
@@ -467,7 +467,7 @@
 
   .letter {
     font-size: 24px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .customState {
@@ -480,7 +480,7 @@
     right: -1px;
     font-size: 8px;
     pointer-events: none;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -490,14 +490,14 @@
   bottom: -1px;
   right: -1px;
   cursor: pointer;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   font-size: 0.8em;
 }
 
 .attackTimeline__Nothing {
   height: 100%;
   width: 100%;
-  background: var(--nav-bg-lightened);
+  background: var(--blert-surface-light);
   opacity: 0.15;
   border-radius: 4px;
 }

--- a/web/app/components/badge/style.module.scss
+++ b/web/app/components/badge/style.module.scss
@@ -4,29 +4,29 @@
   gap: 6px;
   padding: 6px 10px;
   border-radius: 4px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   font-size: 0.85em;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   transition: all 0.2s ease;
   text-decoration: none;
 
   &.link {
     &:hover {
       transform: translateY(-1px);
-      background: var(--nav-bg-lightened);
-      outline: 1px solid var(--blert-button);
+      background: var(--blert-surface-light);
+      outline: 1px solid var(--blert-purple);
     }
   }
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.9em;
   }
 
   strong {
     display: flex;
     align-items: center;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-weight: 500;
   }
 }

--- a/web/app/components/boss-fight-overview/style.module.scss
+++ b/web/app/components/boss-fight-overview/style.module.scss
@@ -8,7 +8,11 @@
   padding: 20px;
   width: 100%;
   max-width: 1400px;
-  background: linear-gradient(135deg, var(--panel-bg), var(--nav-bg-lightened));
+  background: linear-gradient(
+    135deg,
+    var(--blert-panel-background-color),
+    var(--blert-surface-light)
+  );
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     width: 100%;
@@ -47,7 +51,7 @@
   flex-shrink: 0;
   border-radius: 8px;
   overflow: hidden;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     width: 80px;
@@ -68,7 +72,7 @@
   h1 {
     font-size: 1.4em;
     margin: 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 500;
   }
 
@@ -77,10 +81,10 @@
     align-items: center;
     gap: 8px;
     font-family: var(--font-roboto-mono), monospace;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 }
@@ -97,20 +101,20 @@
 }
 
 .section {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   padding: 16px;
 
   h3 {
     font-size: 1em;
     margin: 0 0 12px 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-weight: 500;
   }
 }
 
 .sectionContent {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.95em;
   line-height: 1.4;
 }

--- a/web/app/components/boss-page-attack-timeline/styles.module.scss
+++ b/web/app/components/boss-page-attack-timeline/styles.module.scss
@@ -13,7 +13,7 @@
       width: 100px;
       font-size: 16px;
       transition: all 0.2s ease;
-      color: var(--blert-button);
+      color: var(--blert-purple);
 
       &:hover {
         cursor: pointer;

--- a/web/app/components/boss-page-controls/styles.module.scss
+++ b/web/app/components/boss-page-controls/styles.module.scss
@@ -3,8 +3,8 @@
 
 .controls {
   position: fixed;
-  background: var(--nav-bg);
-  border-top: 1px solid var(--nav-bg-lightened);
+  background: var(--blert-surface-dark);
+  border-top: 1px solid var(--blert-surface-light);
   box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.2);
   bottom: 0;
   left: $LEFT_NAV_WIDTH;
@@ -60,9 +60,9 @@
     gap: 8px;
 
     .controls__tickInput {
-      background: var(--panel-bg);
-      color: var(--blert-text-color);
-      border: 1px solid var(--nav-bg-lightened);
+      background: var(--blert-panel-background-color);
+      color: var(--blert-font-color-primary);
+      border: 1px solid var(--blert-surface-light);
       border-radius: 5px;
       width: 60px;
       height: 32px;
@@ -74,7 +74,7 @@
       transition: all 0.2s ease;
 
       &:focus {
-        border-color: var(--blert-button);
+        border-color: var(--blert-purple);
         outline: none;
       }
 
@@ -86,7 +86,7 @@
     .controls__tickInputLabel {
       font-size: 0.9em;
       font-weight: 500;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       display: flex;
       align-items: center;
     }
@@ -105,7 +105,7 @@
   gap: 8px;
   font-size: 0.9em;
   margin: 0 12px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     padding: 0 0 12px 0;
@@ -113,7 +113,7 @@
 
   .time {
     &:first-child {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
     font-family: var(--font-roboto-mono), monospace;
     text-align: center;
@@ -149,13 +149,13 @@
   }
 
   input[type='range']::-webkit-slider-runnable-track {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     height: 4px;
     border-radius: 2px;
   }
 
   input[type='range']::-moz-range-track {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     height: 4px;
     border-radius: 2px;
   }
@@ -164,7 +164,7 @@
     -webkit-appearance: none;
     appearance: none;
     margin-top: -6px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     border-radius: 50%;
     height: 16px;
     width: 16px;
@@ -176,7 +176,7 @@
   }
 
   input[type='range']::-moz-range-thumb {
-    background: var(--blert-button);
+    background: var(--blert-purple);
     border: none;
     border-radius: 50%;
     height: 16px;
@@ -198,7 +198,7 @@
   opacity: 0.8;
   height: 8px;
   width: 2px;
-  background: var(--blert-button);
+  background: var(--blert-purple);
   top: 14px;
   transition: all 0.2s ease;
 
@@ -228,16 +228,16 @@
     font-size: 0.8em;
     padding: 4px 8px;
     border-radius: 6px;
-    background: var(--panel-bg);
-    color: var(--blert-text-color);
-    border: 1px solid rgba(var(--blert-button-base), 0.5);
+    background: var(--blert-panel-background-color);
+    color: var(--blert-font-color-primary);
+    border: 1px solid rgba(var(--blert-purple-base), 0.5);
     top: 8px;
     white-space: nowrap;
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
-      border: 1px solid rgba(var(--blert-button-base), 0.8);
+      background: var(--blert-surface-light);
+      border: 1px solid rgba(var(--blert-purple-base), 0.8);
       transform: translateX(-50%) translateY(-1px);
     }
   }
@@ -253,14 +253,14 @@
   border: none;
   outline: none;
   border-radius: 8px;
-  background: var(--panel-bg);
-  color: var(--blert-text-color);
+  background: var(--blert-panel-background-color);
+  color: var(--blert-font-color-primary);
   cursor: pointer;
   transition: all 0.2s ease;
   position: relative;
 
   &:hover:not(:disabled) {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     transform: translateY(-1px);
   }
 
@@ -274,7 +274,7 @@
   }
 
   .icon {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     position: relative;
     top: 1px;
   }

--- a/web/app/components/boss-page-dps-timeline/boss-page-dps-timeline.tsx
+++ b/web/app/components/boss-page-dps-timeline/boss-page-dps-timeline.tsx
@@ -50,20 +50,20 @@ export function BossPageDPSTimeline(props: BossPageDPSTimelineProps) {
           </defs>
           <CartesianGrid
             strokeDasharray="3 3"
-            stroke="var(--nav-bg-lightened)"
+            stroke="var(--blert-surface-light)"
             opacity={0.9}
           />
           <XAxis
             dataKey="tick"
-            stroke="var(--font-color-nav)"
+            stroke="var(--blert-font-color-secondary)"
             tickLine={false}
-            axisLine={{ stroke: 'var(--nav-bg-lightened)' }}
+            axisLine={{ stroke: 'var(--blert-surface-light)' }}
           />
           <YAxis
             unit="%"
-            stroke="var(--font-color-nav)"
+            stroke="var(--blert-font-color-secondary)"
             tickLine={false}
-            axisLine={{ stroke: 'var(--nav-bg-lightened)' }}
+            axisLine={{ stroke: 'var(--blert-surface-light)' }}
           />
           <Area
             type="monotone"
@@ -74,17 +74,20 @@ export function BossPageDPSTimeline(props: BossPageDPSTimelineProps) {
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: 'var(--nav-bg)',
-              border: '1px solid var(--nav-bg-lightened)',
+              backgroundColor: 'var(--blert-surface-dark)',
+              border: '1px solid var(--blert-surface-light)',
               borderRadius: '8px',
-              color: 'var(--blert-text-color)',
+              color: 'var(--blert-font-color-primary)',
               padding: '8px',
             }}
             formatter={(value: number) => {
               return [`${value.toFixed(2)}%`, 'Health'];
             }}
             labelFormatter={(value: number) => `Tick: ${value}`}
-            cursor={{ stroke: 'var(--font-color-nav-divider)', strokeWidth: 1 }}
+            cursor={{
+              stroke: 'var(--blert-divider-color)',
+              strokeWidth: 1,
+            }}
           />
           <ReferenceLine
             x={props.currentTick}

--- a/web/app/components/boss-page-dps-timeline/styles.module.scss
+++ b/web/app/components/boss-page-dps-timeline/styles.module.scss
@@ -10,7 +10,7 @@
 .dpsChart {
   margin: 24px 0;
   width: 100%;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 8px;
   padding: 16px;
 }
@@ -26,7 +26,7 @@
 
   h3 {
     font-size: 1.1em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin: 0 0 16px 0;
     text-align: center;
   }

--- a/web/app/components/boss-page-party/style.module.scss
+++ b/web/app/components/boss-page-party/style.module.scss
@@ -21,8 +21,8 @@
 
   .actor {
     cursor: pointer;
-    background: var(--panel-bg);
-    border: 1px solid var(--nav-bg-lightened);
+    background: var(--blert-panel-background-color);
+    border: 1px solid var(--blert-surface-light);
     border-radius: 8px;
     display: flex;
     flex-direction: column;
@@ -44,10 +44,10 @@
       white-space: nowrap;
       text-align: center;
       font-size: 1.1em;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 500;
-      background: var(--nav-bg);
-      border-bottom: 1px solid var(--nav-bg-lightened);
+      background: var(--blert-surface-dark);
+      border-bottom: 1px solid var(--blert-surface-light);
 
       @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
         font-size: 1em;
@@ -56,15 +56,15 @@
     }
 
     .prayers {
-      background: rgba(var(--nav-bg-base), 0.5);
-      border-bottom: 1px solid var(--nav-bg-lightened);
+      background: rgba(var(--blert-surface-dark-base), 0.5);
+      border-bottom: 1px solid var(--blert-surface-light);
       display: flex;
       justify-content: center;
       width: 100%;
     }
 
     .equipment {
-      background: var(--panel-bg);
+      background: var(--blert-panel-background-color);
       display: flex;
       justify-content: center;
       width: 100%;
@@ -72,8 +72,8 @@
     }
 
     .skills {
-      background: rgba(var(--nav-bg-base), 0.5);
-      border-top: 1px solid var(--nav-bg-lightened);
+      background: rgba(var(--blert-surface-dark-base), 0.5);
+      border-top: 1px solid var(--blert-surface-light);
       margin-top: 0;
       flex-grow: 1;
       width: 100%;
@@ -84,12 +84,12 @@
     }
 
     &.selected {
-      border-color: var(--blert-button);
+      border-color: var(--blert-purple);
     }
 
     &:hover {
       transform: translateY(-1px);
-      border-color: rgba(var(--blert-button-base), 0.5);
+      border-color: rgba(var(--blert-purple-base), 0.5);
     }
   }
 }

--- a/web/app/components/boss-page-replay/styles.module.scss
+++ b/web/app/components/boss-page-replay/styles.module.scss
@@ -19,7 +19,7 @@
 
 .noticeText {
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   line-height: 1.3;
   white-space: nowrap;
 
@@ -30,10 +30,10 @@
 
 .legacyButton {
   padding: 4px 8px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 4px;
-  background: var(--nav-bg);
-  color: var(--font-color-nav);
+  background: var(--blert-surface-dark);
+  color: var(--blert-font-color-secondary);
   font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
@@ -42,15 +42,15 @@
   white-space: nowrap;
 
   &:hover:not(:disabled) {
-    background: var(--panel-bg);
-    border-color: var(--blert-button);
-    color: var(--blert-button);
+    background: var(--blert-panel-background-color);
+    border-color: var(--blert-purple);
+    color: var(--blert-purple);
   }
 
   &:focus {
     outline: none;
-    border-color: var(--blert-button);
-    box-shadow: 0 0 0 2px rgba(var(--blert-button-base), 0.2);
+    border-color: var(--blert-purple);
+    box-shadow: 0 0 0 2px rgba(var(--blert-purple-base), 0.2);
   }
 
   &:disabled {
@@ -72,7 +72,7 @@
   margin: 0;
   padding: 0;
   border-radius: 0;
-  background: var(--page-bg);
+  background: var(--blert-panel-background-color);
   box-shadow: none;
   display: flex;
   align-items: center;

--- a/web/app/components/button/style.module.scss
+++ b/web/app/components/button/style.module.scss
@@ -2,14 +2,14 @@
   font-size: 16px;
   border-radius: 5px;
   padding: 8px 10px;
-  background-color: var(--blert-button);
+  background-color: var(--blert-purple);
   color: white;
   font-weight: 600;
-  border: 1px solid var(--blert-button);
+  border: 1px solid var(--blert-purple);
 
   &.simple {
     background: none;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   &:disabled {

--- a/web/app/components/card/style.module.scss
+++ b/web/app/components/card/style.module.scss
@@ -4,7 +4,7 @@
   @include panel;
   flex-direction: column;
   padding: 20px;
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 12px;
   transition: all 0.3s ease;
 
@@ -13,7 +13,7 @@
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
   }
 
@@ -24,8 +24,8 @@
   &.primary {
     background: linear-gradient(
       to bottom right,
-      var(--panel-bg),
-      var(--nav-bg-lightened)
+      var(--blert-panel-background-color),
+      var(--blert-surface-light)
     );
   }
 
@@ -39,7 +39,7 @@
     h2 {
       font-size: 1.3em;
       margin: 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
   }
 
@@ -47,7 +47,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     text-decoration: none;
     margin-top: auto;
     padding: 8px;
@@ -55,7 +55,7 @@
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
 
       i {
         transform: translateX(4px);

--- a/web/app/components/carousel/style.module.scss
+++ b/web/app/components/carousel/style.module.scss
@@ -17,8 +17,8 @@
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: var(--nav-bg);
-    color: var(--font-color-nav);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-secondary);
     transition: all 0.2s ease;
     cursor: pointer;
 
@@ -28,11 +28,11 @@
     }
 
     &:not(:disabled) {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     &:hover:not(:disabled) {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
     }
 
     &:disabled {
@@ -73,17 +73,17 @@
       width: 10px;
       height: 10px;
       border-radius: 50%;
-      background: rgba(var(--blert-button-base), 0.3);
+      background: rgba(var(--blert-purple-base), 0.3);
       transition: all 0.2s ease;
       cursor: pointer;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.6);
+        background: rgba(var(--blert-purple-base), 0.6);
       }
 
       &.active {
         transform: scale(1.1);
-        background: var(--blert-button);
+        background: var(--blert-purple);
       }
     }
   }

--- a/web/app/components/challenge-load-error/style.module.scss
+++ b/web/app/components/challenge-load-error/style.module.scss
@@ -13,8 +13,8 @@
   max-width: 420px;
   width: 100%;
   text-align: center;
-  background-color: var(--panel-bg);
-  border: 1px solid var(--nav-bg-lightened);
+  background-color: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-surface-light);
   border-radius: 12px;
   padding: 1.5rem;
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
@@ -31,13 +31,13 @@
 }
 
 .message {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 1.1rem;
   font-weight: 600;
   margin-bottom: 0.5rem;
 }
 
 .details {
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.95rem;
 }

--- a/web/app/components/challenge-nav/style.module.scss
+++ b/web/app/components/challenge-nav/style.module.scss
@@ -2,8 +2,8 @@
 
 .nav {
   width: calc(100vw - $LEFT_NAV_WIDTH);
-  background: var(--nav-bg);
-  border-bottom: 1px solid var(--nav-bg-lightened);
+  background: var(--blert-surface-dark);
+  border-bottom: 1px solid var(--blert-surface-light);
   padding: 0 20px;
   position: fixed;
   top: 0;
@@ -27,7 +27,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.9em;
   text-decoration: none;
   border-radius: 4px;
@@ -35,55 +35,55 @@
 
   i {
     font-size: 0.9em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   svg {
-    fill: var(--font-color-nav);
-    stroke: var(--font-color-nav);
+    fill: var(--blert-font-color-secondary);
+    stroke: var(--blert-font-color-secondary);
   }
 
   path {
-    fill: var(--font-color-nav);
-    stroke: var(--font-color-nav);
+    fill: var(--blert-font-color-secondary);
+    stroke: var(--blert-font-color-secondary);
   }
 
   &:hover:not(.disabled) {
-    background: var(--nav-bg-lightened);
-    color: var(--blert-text-color);
+    background: var(--blert-surface-light);
+    color: var(--blert-font-color-primary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     svg {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
 
     path {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
   }
 
   &.active {
-    background: var(--nav-bg-lightened);
-    color: var(--blert-text-color);
+    background: var(--blert-surface-light);
+    color: var(--blert-font-color-primary);
     font-weight: 500;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     svg {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
 
     path {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
   }
 
@@ -102,20 +102,20 @@
   font-weight: 600;
   font-size: 0.95em;
   font-family: var(--font-cinzel);
-  color: var(--font-color-nav);
-  background: var(--nav-bg);
+  color: var(--blert-font-color-secondary);
+  background: var(--blert-surface-dark);
   border-radius: 4px;
   padding: 0 4px;
   transition: all 0.2s ease;
 
   .navItem:hover:not(.disabled) & {
-    color: var(--blert-button);
-    background: var(--nav-bg-lightened);
+    color: var(--blert-purple);
+    background: var(--blert-surface-light);
   }
 
   .navItem.active & {
-    color: var(--blert-button);
-    background: var(--nav-bg-lightened);
+    color: var(--blert-purple);
+    background: var(--blert-surface-light);
   }
 }
 
@@ -134,8 +134,8 @@
   left: 0;
   z-index: 1000;
   min-width: 180px;
-  background: var(--panel-bg);
-  border: 1px solid var(--nav-bg-lightened);
+  background: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-surface-light);
   border-radius: 6px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
   padding: 8px 0;
@@ -148,7 +148,7 @@
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.85em;
   text-decoration: none;
   transition: all 0.2s ease;
@@ -156,55 +156,55 @@
 
   i {
     font-size: 0.85em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   svg {
-    fill: var(--font-color-nav);
-    stroke: var(--font-color-nav);
+    fill: var(--blert-font-color-secondary);
+    stroke: var(--blert-font-color-secondary);
   }
 
   path {
-    fill: var(--font-color-nav);
-    stroke: var(--font-color-nav);
+    fill: var(--blert-font-color-secondary);
+    stroke: var(--blert-font-color-secondary);
   }
 
   &:hover:not(.disabled) {
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     svg {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
 
     path {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
   }
 
   &.active {
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
     font-weight: 500;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     svg {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
 
     path {
-      fill: var(--blert-button);
-      stroke: var(--blert-button);
+      fill: var(--blert-purple);
+      stroke: var(--blert-purple);
     }
   }
 
@@ -218,7 +218,7 @@
     height: 20px;
     font-size: 0.8em;
     font-weight: 600;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 3px;
     padding: 0 2px;
   }
@@ -237,8 +237,8 @@
     left: 0;
     top: $TOPBAR_HEIGHT;
     padding: 0;
-    background: var(--panel-bg);
-    border-bottom: 1px solid var(--nav-bg);
+    background: var(--blert-panel-background-color);
+    border-bottom: 1px solid var(--blert-surface-dark);
     z-index: 20;
   }
 
@@ -266,12 +266,20 @@
 
     &::before {
       left: 0;
-      background: linear-gradient(to right, var(--panel-bg) 40%, transparent);
+      background: linear-gradient(
+        to right,
+        var(--blert-panel-background-color) 40%,
+        transparent
+      );
     }
 
     &::after {
       right: 0;
-      background: linear-gradient(to left, var(--panel-bg) 40%, transparent);
+      background: linear-gradient(
+        to left,
+        var(--blert-panel-background-color) 40%,
+        transparent
+      );
     }
 
     &::-webkit-scrollbar {
@@ -288,7 +296,7 @@
       background: linear-gradient(
         to right,
         transparent 0%,
-        var(--blert-button) 50%,
+        var(--blert-purple) 50%,
         transparent 100%
       );
       opacity: 0.3;

--- a/web/app/components/challenge-overview/style.module.scss
+++ b/web/app/components/challenge-overview/style.module.scss
@@ -4,7 +4,11 @@
   @include panel;
   display: flex;
   gap: 32px;
-  background: linear-gradient(135deg, var(--panel-bg), var(--nav-bg-lightened));
+  background: linear-gradient(
+    135deg,
+    var(--blert-panel-background-color),
+    var(--blert-surface-light)
+  );
   padding: 20px;
   width: 100%;
 
@@ -18,7 +22,7 @@
     font-size: 1.1em;
     margin: 0 0 12px 0;
     font-weight: 500;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -43,13 +47,13 @@
     justify-content: center;
     gap: 6px;
     padding: 6px 12px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 4px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     i {
       font-size: 0.9em;
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 }
@@ -79,13 +83,13 @@
     align-items: center;
     text-align: center;
     padding: 12px 8px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
   }
 
   .statLabel {
     font-size: 0.8em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-bottom: 6px;
   }
 
@@ -98,7 +102,7 @@
     padding: 0 4px;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1em;
       flex-shrink: 0;
     }
@@ -106,7 +110,7 @@
     & > span {
       font-size: 1.1em;
       font-weight: 500;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       line-height: 1.2;
       overflow-wrap: break-word;
       word-break: break-word;
@@ -137,7 +141,7 @@
     align-items: center;
     gap: 6px;
     padding: 6px 8px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     text-decoration: none;
     color: inherit;
@@ -145,8 +149,8 @@
 
     &:hover {
       transform: translateY(-2px);
-      background: var(--nav-bg-lightened);
-      outline: 1px solid var(--blert-button);
+      background: var(--blert-surface-light);
+      outline: 1px solid var(--blert-purple);
     }
   }
 
@@ -174,7 +178,7 @@
   .playerName {
     font-weight: 500;
     font-size: 0.9em;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     max-width: 120px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -184,7 +188,7 @@
   .playerRole {
     font-size: 0.75em;
     width: fit-content;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     text-transform: capitalize;
     padding: 1px 0;
     display: inline-flex;
@@ -196,7 +200,7 @@
     margin-left: auto;
     padding-left: 6px;
     gap: 2px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
 
     i {
       font-size: 0.8em;

--- a/web/app/components/checkbox/style.module.scss
+++ b/web/app/components/checkbox/style.module.scss
@@ -6,7 +6,7 @@
   &.button {
     padding: 12px;
     border-radius: 5px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
 
     &:hover {
       background: rgba(47, 39, 79, 0.4) !important;
@@ -32,7 +32,7 @@
     background: none;
     margin: 0;
     font-family: 'Font Awesome 6 Free';
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 18px;
 
     &::before {

--- a/web/app/components/confirmation-modal/style.module.scss
+++ b/web/app/components/confirmation-modal/style.module.scss
@@ -14,18 +14,18 @@
     justify-content: space-between;
     align-items: center;
     padding: 16px 24px;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.15);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
     background: linear-gradient(
       135deg,
-      var(--panel-bg) 0%,
-      rgba(var(--nav-bg-base), 0.8) 100%
+      var(--blert-panel-background-color) 0%,
+      rgba(var(--blert-surface-dark-base), 0.8) 100%
     );
 
     h2 {
       margin: 0;
       font-size: 1.25rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     button {
@@ -37,7 +37,7 @@
       border-radius: 6px;
       border: none;
       background: transparent;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       cursor: pointer;
       transition: all 0.2s ease;
 
@@ -62,13 +62,13 @@
 
     p {
       margin: 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       line-height: 1.6;
       font-size: 0.95rem;
     }
 
     strong {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 600;
     }
   }
@@ -78,7 +78,7 @@
     justify-content: flex-end;
     gap: 12px;
     padding: 16px 24px;
-    border-top: 1px solid rgba(var(--blert-button-base), 0.1);
+    border-top: 1px solid rgba(var(--blert-purple-base), 0.1);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       padding: 16px 20px;

--- a/web/app/components/date-picker/date-picker.css
+++ b/web/app/components/date-picker/date-picker.css
@@ -1,11 +1,11 @@
 .blert-datepicker .react-datepicker {
   font-family: 'Inter', sans-serif;
-  background-color: var(--panel-bg);
-  border: 1px solid var(--font-color-nav);
+  background-color: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-font-color-secondary);
 }
 
 .blert-datepicker .react-datepicker__header {
-  background-color: var(--nav-bg);
+  background-color: var(--blert-surface-dark);
 }
 
 .blert-datepicker .react-datepicker__current-month {
@@ -13,11 +13,11 @@
 }
 
 .blert-datepicker .react-datepicker__day-name {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .blert-datepicker .react-datepicker__day {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .blert-datepicker .react-datepicker__day--disabled {
@@ -25,13 +25,13 @@
 }
 
 .blert-datepicker .react-datepicker__day:not([aria-disabled='true']):hover {
-  background-color: var(--blert-text-color);
-  color: var(--panel-bg);
+  background-color: var(--blert-font-color-primary);
+  color: var(--blert-panel-background-color);
 }
 
 .blert-datepicker .react-datepicker__day--selected,
 .blert-datepicker .react-datepicker__day--keyboard-selected {
-  background-color: var(--blert-button);
+  background-color: var(--blert-purple);
   color: #fff;
   font-weight: 700;
 }
@@ -40,7 +40,7 @@
   top: calc(50% - 1px);
   left: 2px;
   transform: translateY(-50%);
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 }
 
 .blert-datepicker-wrapper .react-datepicker__close-icon {
@@ -48,7 +48,7 @@
 }
 
 .blert-datepicker-wrapper .react-datepicker__close-icon::after {
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-family: 'Font Awesome 6 Free';
   content: '\f057';
   background: none;
@@ -56,7 +56,7 @@
 }
 
 .blert-datepicker-wrapper .react-datepicker__close-icon:hover::after {
-  color: var(--blert-button);
+  color: var(--blert-purple);
 }
 
 .blert-datepicker-wrapper .react-datepicker__view-calendar-icon input {

--- a/web/app/components/date-picker/style.module.scss
+++ b/web/app/components/date-picker/style.module.scss
@@ -4,21 +4,21 @@
   line-height: 16px;
   height: 42px;
   padding: 12px 15px;
-  border: 1px solid var(--font-color-nav);
+  border: 1px solid var(--blert-font-color-secondary);
   border-radius: 5px;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   transition: border-color 0.2s ease-in-out;
 
   &:focus {
     outline: none;
-    border-color: var(--blert-button);
+    border-color: var(--blert-purple);
   }
 
   &:hover {
-    border-color: var(--blert-button);
+    border-color: var(--blert-purple);
   }
 
   &::placeholder {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }

--- a/web/app/components/editable-text-field/style.module.scss
+++ b/web/app/components/editable-text-field/style.module.scss
@@ -9,7 +9,7 @@
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-base), 0.4);
+    background: rgba(var(--blert-surface-dark-base), 0.4);
   }
 
   .text {
@@ -25,8 +25,8 @@
     border: 1px solid transparent;
 
     &:hover {
-      background: rgba(var(--nav-bg-lightened-base), 0.4);
-      border-color: rgba(var(--blert-button-base), 0.15);
+      background: rgba(var(--blert-surface-light-base), 0.4);
+      border-color: rgba(var(--blert-purple-base), 0.15);
     }
   }
 
@@ -35,12 +35,12 @@
     height: 35px;
     background: linear-gradient(
       145deg,
-      rgba(var(--nav-bg-base), 0.6),
-      rgba(var(--nav-bg-darkened-base), 0.4)
+      rgba(var(--blert-surface-dark-base), 0.6),
+      rgba(var(--blert-surface-darker-base), 0.4)
     );
     margin: 0;
     outline: none;
-    border: 1px solid rgba(var(--blert-button-base), 0.3);
+    border: 1px solid rgba(var(--blert-purple-base), 0.3);
     border-radius: 4px;
     color: inherit;
     font-size: inherit;
@@ -49,12 +49,12 @@
     transition: all 0.2s ease;
 
     &:focus {
-      border-color: rgba(var(--blert-button-base), 0.6);
-      box-shadow: 0 0 0 2px rgba(var(--blert-button-base), 0.15);
+      border-color: rgba(var(--blert-purple-base), 0.6);
+      box-shadow: 0 0 0 2px rgba(var(--blert-purple-base), 0.15);
       background: linear-gradient(
         145deg,
-        rgba(var(--nav-bg-base), 0.8),
-        rgba(var(--nav-bg-darkened-base), 0.6)
+        rgba(var(--blert-surface-dark-base), 0.8),
+        rgba(var(--blert-surface-darker-base), 0.6)
       );
     }
   }
@@ -84,18 +84,18 @@
     background-color: transparent;
     border: 1px solid transparent;
     border-radius: 4px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     transition: all 0.2s ease;
     cursor: pointer;
     flex-shrink: 0;
 
     &:hover {
-      background-color: var(--nav-bg-lightened);
-      border-color: rgba(var(--blert-button-base), 0.3);
-      color: var(--blert-text-color);
+      background-color: var(--blert-surface-light);
+      border-color: rgba(var(--blert-purple-base), 0.3);
+      color: var(--blert-font-color-primary);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 

--- a/web/app/components/equipment-viewer/style.module.scss
+++ b/web/app/components/equipment-viewer/style.module.scss
@@ -4,11 +4,11 @@
   .empty {
     position: absolute;
     text-align: center;
-    background: var(--nav-bg);
-    border: 1px solid var(--nav-bg-lightened);
+    background: var(--blert-surface-dark);
+    border: 1px solid var(--blert-surface-light);
     border-radius: 8px;
     padding: 8px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.9em;
     width: 160px;
     left: 50%;
@@ -16,15 +16,15 @@
   }
 
   .missing {
-    background: var(--nav-bg);
-    border: 1px solid var(--nav-bg-lightened);
+    background: var(--blert-surface-dark);
+    border: 1px solid var(--blert-surface-light);
     border-radius: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     font-size: 12px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     padding: 4px;
   }
 }

--- a/web/app/components/input/input.tsx
+++ b/web/app/components/input/input.tsx
@@ -31,7 +31,8 @@ export type InputProps = {
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   function Input(props, ref) {
-    const labelBackground = props.labelBg ?? 'var(--panel-bg)';
+    const labelBackground =
+      props.labelBg ?? 'var(--blert-panel-background-color)';
     const style: React.CSSProperties = {
       width: props.fluid ? '100%' : (props.width ?? 240),
     };

--- a/web/app/components/input/style.module.scss
+++ b/web/app/components/input/style.module.scss
@@ -14,24 +14,24 @@
   }
 
   input {
-    border: 1px solid var(--font-color-nav-divider);
+    border: 1px solid var(--blert-divider-color);
     border-radius: 5px;
     background: none;
     font-size: 16px;
     line-height: 16px;
     height: 42px;
     box-sizing: border-box;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     &:focus {
       outline: none;
-      border-color: rgba(var(--blert-button-base), 0.9);
+      border-color: rgba(var(--blert-purple-base), 0.9);
     }
 
     &:not(:placeholder-shown) + label,
     &:focus + label {
       font-size: 12px;
-      color: rgba(var(--blert-button-base), 0.9);
+      color: rgba(var(--blert-purple-base), 0.9);
       top: 2px;
     }
 
@@ -45,15 +45,15 @@
     }
 
     &:disabled + label {
-      color: rgb(var(--blert-text-color), 0.5);
+      color: rgb(var(--blert-font-color-primary), 0.5);
     }
 
     &:-webkit-autofill {
       -webkit-background-clip: text;
-      -webkit-text-fill-color: var(--blert-text-color);
+      -webkit-text-fill-color: var(--blert-font-color-primary);
       transition: background-color 5000s ease-in-out 0s;
       box-shadow: inset 0 0 20px 20px #23232329;
-      caret-color: var(--blert-text-color);
+      caret-color: var(--blert-font-color-primary);
     }
   }
 
@@ -62,7 +62,7 @@
     right: 12px;
     top: 50%;
     transform: translateY(-50%);
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 16px;
     pointer-events: none;
   }

--- a/web/app/components/item-search/style.module.scss
+++ b/web/app/components/item-search/style.module.scss
@@ -25,19 +25,19 @@ $MAX_MENU_HEIGHT: ($ITEM_HEIGHT + $ITEM_PADDING * 2) * $MAX_ITEMS;
   input {
     padding: 8px 12px;
     border-radius: 5px;
-    border: 1px solid rgba(var(--blert-text-color-base), 0.3);
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
+    border: 1px solid rgba(var(--blert-font-color-primary-base), 0.3);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
     font-size: 14px;
     transition: border-color 0.2s;
 
     &:focus {
       outline: none;
-      border-color: rgba(var(--blert-button-base), 0.6);
+      border-color: rgba(var(--blert-purple-base), 0.6);
     }
 
     &::placeholder {
-      color: rgba(var(--blert-text-color-base), 0.5);
+      color: rgba(var(--blert-font-color-primary-base), 0.5);
     }
 
     &:disabled {
@@ -55,16 +55,16 @@ $MAX_MENU_HEIGHT: ($ITEM_HEIGHT + $ITEM_PADDING * 2) * $MAX_ITEMS;
     right: 8px;
     top: calc(50%);
     transform: translateY(-50%);
-    color: rgba(var(--blert-text-color-base), 0.5);
-    border: 1px solid rgba(var(--blert-text-color-base), 0.3);
+    color: rgba(var(--blert-font-color-primary-base), 0.5);
+    border: 1px solid rgba(var(--blert-font-color-primary-base), 0.3);
     border-radius: 4px;
     padding: 3px 8px;
     font-size: 12px;
     font-family: monospace;
     background: linear-gradient(
       145deg,
-      rgba(var(--panel-bg-base), 0.6),
-      rgba(var(--nav-bg-darkened-base), 0.4)
+      rgba(var(--blert-panel-background-color-base), 0.6),
+      rgba(var(--blert-surface-darker-base), 0.4)
     );
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
     transition: opacity 0.2s ease;
@@ -76,11 +76,11 @@ $MAX_MENU_HEIGHT: ($ITEM_HEIGHT + $ITEM_PADDING * 2) * $MAX_ITEMS;
   max-height: $MAX_MENU_HEIGHT;
   display: flex;
   flex-direction: column;
-  border-color: rgba(var(--blert-button-base), 0.6);
+  border-color: rgba(var(--blert-purple-base), 0.6);
   background: linear-gradient(
     145deg,
-    rgba(var(--panel-bg-base), 1),
-    rgba(var(--nav-bg-base), 1)
+    rgba(var(--blert-panel-background-color-base), 1),
+    rgba(var(--blert-surface-dark-base), 1)
   );
 }
 
@@ -99,12 +99,12 @@ $MAX_MENU_HEIGHT: ($ITEM_HEIGHT + $ITEM_PADDING * 2) * $MAX_ITEMS;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .id {
     font-size: 12px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-family: monospace;
     padding-top: 5px;
   }

--- a/web/app/components/key-prayers/style.module.scss
+++ b/web/app/components/key-prayers/style.module.scss
@@ -31,7 +31,7 @@
     justify-content: center;
     align-items: center;
     font-size: 0.9em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     padding: 4px;
     backdrop-filter: blur(2px);
   }

--- a/web/app/components/left-nav/styles.module.scss
+++ b/web/app/components/left-nav/styles.module.scss
@@ -19,7 +19,11 @@
   @include panel;
   display: flex;
   height: 100%;
-  background: linear-gradient(to bottom, var(--panel-bg), var(--nav-bg));
+  background: linear-gradient(
+    to bottom,
+    var(--blert-panel-background-color),
+    var(--blert-surface-dark)
+  );
   flex-direction: column;
   overflow-y: scroll;
   transition: all 0.2s ease;
@@ -43,14 +47,14 @@
 
     .userWrapper {
       padding: 12px;
-      background: var(--nav-bg);
-      border: 1px solid var(--font-color-nav-divider);
+      background: var(--blert-surface-dark);
+      border: 1px solid var(--blert-divider-color);
       border-radius: 8px;
       transition: all 0.2s ease;
 
       &:hover {
-        border-color: var(--blert-button);
-        background: var(--nav-bg-lightened);
+        border-color: var(--blert-purple);
+        background: var(--blert-surface-light);
       }
 
       .userInfo {
@@ -58,17 +62,17 @@
         align-items: center;
         gap: 12px;
         padding-bottom: 12px;
-        border-bottom: 1px solid var(--font-color-nav-divider);
+        border-bottom: 1px solid var(--blert-divider-color);
 
         .avatar {
           width: 36px;
           height: 36px;
           border-radius: 50%;
-          background: var(--nav-bg-lightened);
+          background: var(--blert-surface-light);
           display: flex;
           align-items: center;
           justify-content: center;
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 16px;
           flex-shrink: 0;
         }
@@ -76,12 +80,12 @@
         .details {
           .label {
             font-size: 0.85em;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
             margin-bottom: 2px;
           }
 
           .username {
-            color: var(--blert-text-color);
+            color: var(--blert-font-color-primary);
             font-weight: 500;
             font-size: 0.95em;
           }
@@ -100,7 +104,7 @@
           gap: 8px;
           padding: 6px 8px;
           border-radius: 6px;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           font-size: 0.9em;
           font-weight: 500;
           transition: all 0.2s ease;
@@ -117,8 +121,8 @@
           }
 
           &:hover {
-            background: var(--nav-bg-darkened);
-            color: var(--blert-text-color);
+            background: var(--blert-surface-darker);
+            color: var(--blert-font-color-primary);
           }
         }
       }
@@ -145,21 +149,21 @@
         }
 
         &.login {
-          background: var(--nav-bg);
-          border: 1px solid var(--font-color-nav-divider);
-          color: var(--font-color-nav);
+          background: var(--blert-surface-dark);
+          border: 1px solid var(--blert-divider-color);
+          color: var(--blert-font-color-secondary);
 
           &:hover {
-            background: var(--nav-bg-lightened);
-            border-color: var(--blert-button);
-            color: var(--blert-text-color);
+            background: var(--blert-surface-light);
+            border-color: var(--blert-purple);
+            color: var(--blert-font-color-primary);
           }
         }
 
         &.signup {
-          background: var(--blert-button);
-          color: var(--blert-text-color);
-          border: 1px solid var(--blert-button);
+          background: var(--blert-purple);
+          color: var(--blert-font-color-primary);
+          border: 1px solid var(--blert-purple);
 
           &:hover {
             opacity: 0.9;
@@ -176,13 +180,13 @@
     padding: 0;
 
     .link {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
       font-weight: 500;
       transition: color 0.2s ease;
 
       &:hover {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -193,7 +197,7 @@
     padding: 3px;
     margin: 1px 0;
     border-radius: 4px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
 
     .wave {
       width: 20%;
@@ -202,13 +206,13 @@
       border-radius: 3px;
       text-align: center;
       font-size: 0.85em;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       transition: all 0.2s ease;
 
       &:hover,
       &.active {
-        background: var(--nav-bg-darkened);
-        color: var(--blert-text-color);
+        background: var(--blert-surface-darker);
+        color: var(--blert-font-color-primary);
       }
     }
   }
@@ -221,21 +225,21 @@
   .shortcut {
     font-size: 0.85em;
     text-align: center;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-top: -2px;
 
     kbd {
       background: linear-gradient(
         145deg,
-        var(--panel-bg),
-        var(--nav-bg-darkened)
+        var(--blert-panel-background-color),
+        var(--blert-surface-darker)
       );
-      border: 1px solid rgba(var(--blert-text-color-base), 0.3);
+      border: 1px solid rgba(var(--blert-font-color-primary-base), 0.3);
       border-radius: 3px;
       padding: 3px 6px;
       font-family: var(--font-roboto-mono), monospace;
       font-size: 13px;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       box-shadow:
         0 2px 0 rgba(0, 0, 0, 0.3),
         inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -257,7 +261,7 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 16px;
-  border-bottom: 1px solid var(--font-color-nav-divider);
+  border-bottom: 1px solid var(--blert-divider-color);
 }
 
 .leftNav__menu {
@@ -290,9 +294,9 @@
   margin: 0 8px 8px;
   padding: 6px;
   position: relative;
-  background: rgba(var(--nav-bg-lightened-base), 0.4);
+  background: rgba(var(--blert-surface-light-base), 0.4);
   border-radius: 6px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
 
   a {
     width: 100%;
@@ -304,21 +308,21 @@
   padding: 4px 8px;
   font-size: 0.85em;
   border-radius: 4px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-weight: 500;
   transition: all 0.2s ease;
   text-align: center;
   margin: 1px 0;
 
   &:hover {
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
   }
 }
 
 .leftNav__subMenuItemActive {
-  background: var(--nav-bg-darkened);
-  color: var(--blert-text-color);
+  background: var(--blert-surface-darker);
+  color: var(--blert-font-color-primary);
 }
 
 .leftNav__menuItemInner {
@@ -337,7 +341,7 @@
   span {
     user-select: none;
     font-size: 0.95em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-weight: 500;
     margin-left: 12px;
 
@@ -348,30 +352,30 @@
   }
 
   &:hover {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
 
     span {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .leftNav__menuItemIcon {
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
 }
 
 .leftNav__menuItemInnerActive {
-  background: var(--nav-bg-lightened);
+  background: var(--blert-surface-light);
 
   span {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .leftNav__menuItemIcon {
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 }
@@ -402,7 +406,7 @@
 
   i {
     font-size: 16px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     transition: color 0.2s ease;
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -421,7 +425,7 @@
   height: 1px;
   width: calc(100% - 24px);
   margin: 8px 12px;
-  background: var(--font-color-nav-divider);
+  background: var(--blert-divider-color);
 }
 
 .leftNav__menuDivider {
@@ -451,15 +455,15 @@
   font-size: 20px;
   height: 40px;
   width: 40px;
-  color: var(--font-color-nav);
-  border: 1px solid var(--font-color-nav-divider);
+  color: var(--blert-font-color-secondary);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 6px;
   transition: all 0.2s ease;
 
   &:hover {
-    background: var(--nav-bg-lightened);
-    border-color: var(--blert-button);
-    color: var(--blert-button);
+    background: var(--blert-surface-light);
+    border-color: var(--blert-purple);
+    color: var(--blert-purple);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {

--- a/web/app/components/map-renderer/dev-console.module.scss
+++ b/web/app/components/map-renderer/dev-console.module.scss
@@ -5,7 +5,7 @@
   width: 400px;
   max-height: 300px;
   background: rgba(0, 0, 0, 0.7);
-  border: 1px solid rgba(var(--blert-text-color-base), 0.1);
+  border: 1px solid rgba(var(--blert-font-color-primary-base), 0.1);
   border-radius: 4px;
   display: flex;
   flex-direction: column;
@@ -22,7 +22,7 @@
   background: transparent;
 
   scrollbar-width: thin;
-  scrollbar-color: rgba(var(--blert-text-color-base), 0.3) transparent;
+  scrollbar-color: rgba(var(--blert-font-color-primary-base), 0.3) transparent;
 
   &::-webkit-scrollbar {
     width: 6px;
@@ -33,12 +33,12 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(var(--blert-text-color-base), 0.3);
+    background: rgba(var(--blert-font-color-primary-base), 0.3);
     border-radius: 3px;
   }
 
   &::-webkit-scrollbar-thumb:hover {
-    background: rgba(var(--blert-text-color-base), 0.5);
+    background: rgba(var(--blert-font-color-primary-base), 0.5);
   }
 }
 
@@ -48,7 +48,7 @@
   line-height: 1.3;
 
   &.info {
-    color: rgba(var(--blert-text-color-base), 0.9);
+    color: rgba(var(--blert-font-color-primary-base), 0.9);
   }
 
   &.warn {
@@ -67,20 +67,20 @@
 .input {
   width: 100%;
   background: rgba(0, 0, 0, 0.5);
-  border: 1px solid rgba(var(--blert-text-color-base), 0.1);
+  border: 1px solid rgba(var(--blert-font-color-primary-base), 0.1);
   border-radius: 0 0 4px 4px;
   padding: 8px;
-  color: rgba(var(--blert-text-color-base), 0.9);
+  color: rgba(var(--blert-font-color-primary-base), 0.9);
   font-family: inherit;
   font-size: 0.8rem;
   outline: none;
   transition: border-color 0.2s ease;
 
   &:focus {
-    border-color: rgba(var(--blert-text-color-base), 0.3);
+    border-color: rgba(var(--blert-font-color-primary-base), 0.3);
   }
 
   &::placeholder {
-    color: rgba(var(--blert-text-color-base), 0.5);
+    color: rgba(var(--blert-font-color-primary-base), 0.5);
   }
 }

--- a/web/app/components/map-renderer/map-canvas.tsx
+++ b/web/app/components/map-renderer/map-canvas.tsx
@@ -343,8 +343,8 @@ function LoadingFallback() {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: 'var(--panel-bg)',
-        color: 'var(--font-color-nav)',
+        background: 'var(--blert-panel-background-color)',
+        color: 'var(--blert-font-color-secondary)',
         fontSize: '0.9rem',
       }}
     >
@@ -519,7 +519,7 @@ export default function MapCanvas({
         style={{
           background: '#000',
           borderRadius: '8px',
-          border: '1px solid var(--nav-bg-lightened)',
+          border: '1px solid var(--blert-surface-light)',
           cursor: interactionState.hoveredActorId ? 'pointer' : 'default',
         }}
       >

--- a/web/app/components/map-renderer/map-settings.module.scss
+++ b/web/app/components/map-renderer/map-settings.module.scss
@@ -5,7 +5,7 @@
 
 .chevronIcon {
   font-size: 0.75rem !important;
-  color: var(--font-color-nav) !important;
+  color: var(--blert-font-color-secondary) !important;
   transition: transform 0.2s ease;
   margin-left: auto;
 
@@ -21,10 +21,10 @@
   margin-top: 0.5rem;
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.95) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 8px;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.3),
@@ -53,7 +53,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.6),
+      rgba(var(--blert-purple-base), 0.6),
       transparent
     );
   }
@@ -74,16 +74,16 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 6px;
   margin-bottom: 1rem;
   font-size: 0.8rem;
-  color: var(--blert-button);
+  color: var(--blert-purple);
 
   i {
     font-size: 0.75rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   span {
@@ -105,17 +105,17 @@
 .settingLabel {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin: 0;
   margin-bottom: 0.25rem;
 }
 
 .settingGroup :global(.checkbox) {
   font-size: 0.875rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   input:checked + & {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 

--- a/web/app/components/map-renderer/style.module.scss
+++ b/web/app/components/map-renderer/style.module.scss
@@ -23,10 +23,10 @@
     align-items: center;
     justify-content: center;
     padding: 0.5rem;
-    background: rgba(var(--nav-bg-base), 0.85);
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    background: rgba(var(--blert-surface-dark-base), 0.85);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 6px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.875rem;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -34,23 +34,23 @@
     z-index: 10;
 
     &:hover {
-      background: rgba(var(--nav-bg-lightened-base), 0.95);
-      border-color: rgba(var(--blert-button-base), 0.4);
+      background: rgba(var(--blert-surface-light-base), 0.95);
+      border-color: rgba(var(--blert-purple-base), 0.4);
     }
 
     &:focus {
       outline: none;
-      border-color: var(--blert-button);
-      box-shadow: 0 0 0 2px rgba(var(--blert-button-base), 0.2);
+      border-color: var(--blert-purple);
+      box-shadow: 0 0 0 2px rgba(var(--blert-purple-base), 0.2);
     }
 
     &.playing {
       opacity: 0.8;
-      border-color: rgba(var(--blert-button-base), 0.3);
+      border-color: rgba(var(--blert-purple-base), 0.3);
     }
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.875rem;
     }
   }

--- a/web/app/components/map/style.module.scss
+++ b/web/app/components/map/style.module.scss
@@ -2,7 +2,7 @@
   position: relative;
   display: inline-flex;
   flex-direction: column;
-  border: 2px solid rgba(var(--blert-text-color-base), 0.7);
+  border: 2px solid rgba(var(--blert-font-color-primary-base), 0.7);
   overflow: hidden;
 
   .mapRow {
@@ -14,7 +14,7 @@
       box-sizing: border-box;
 
       &:hover {
-        border: 1px solid rgba(var(--blert-text-color-base), 0.4);
+        border: 1px solid rgba(var(--blert-font-color-primary-base), 0.4);
         opacity: 0.95;
       }
     }
@@ -58,12 +58,12 @@
     display: flex;
     flex-direction: column;
     padding: 0.5em 1em;
-    background-color: var(--nav-bg);
+    background-color: var(--blert-surface-dark);
     border-radius: 5px;
     white-space: nowrap;
 
     button {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       text-align: left;
 
       &:hover {
@@ -76,7 +76,7 @@
         text-transform: uppercase;
         font-size: 9px;
         width: 45px;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
     }
   }

--- a/web/app/components/markdown-editor/style.module.scss
+++ b/web/app/components/markdown-editor/style.module.scss
@@ -3,10 +3,10 @@
 .editor {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 6px;
   overflow: hidden;
-  background-color: var(--panel-bg);
+  background-color: var(--blert-panel-background-color);
 }
 
 .toolbar {
@@ -15,8 +15,8 @@
   justify-content: space-between;
   gap: 0.5rem;
   padding: 0.5rem;
-  background-color: var(--nav-bg);
-  border-bottom: 1px solid var(--font-color-nav-divider);
+  background-color: var(--blert-surface-dark);
+  border-bottom: 1px solid var(--blert-divider-color);
   flex-wrap: wrap;
 }
 
@@ -30,7 +30,7 @@
 .toolbarDivider {
   width: 1px;
   height: 24px;
-  background-color: var(--font-color-nav-divider);
+  background-color: var(--blert-divider-color);
   opacity: 0.5;
   margin: 0 0.5rem;
 }
@@ -40,15 +40,15 @@
   background-color: transparent;
   border: 1px solid transparent;
   border-radius: 4px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   cursor: pointer;
   transition: all 0.2s ease;
   font-size: 0.9rem;
 
   &:hover {
-    background-color: var(--nav-bg-lightened);
-    border-color: rgba(var(--blert-button-base), 0.3);
-    color: var(--blert-text-color);
+    background-color: var(--blert-surface-light);
+    border-color: rgba(var(--blert-purple-base), 0.3);
+    color: var(--blert-font-color-primary);
   }
 
   &:active {
@@ -56,9 +56,9 @@
   }
 
   &.active {
-    background-color: rgba(var(--blert-button-base), 0.1);
-    color: var(--blert-button);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background-color: rgba(var(--blert-purple-base), 0.1);
+    color: var(--blert-purple);
+    border-color: rgba(var(--blert-purple-base), 0.3);
   }
 
   &:disabled {
@@ -66,12 +66,12 @@
     cursor: not-allowed;
     background-color: transparent;
     border-color: transparent;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     &:hover {
       background-color: transparent;
       border-color: transparent;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
 
     &:active {
@@ -92,8 +92,8 @@
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
-  background-color: var(--panel-bg);
-  border: 1px solid var(--font-color-nav-divider);
+  background-color: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 6px;
   padding: 0.75rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -111,11 +111,11 @@
 .tableCell {
   width: 20px;
   height: 20px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 2px;
   cursor: pointer;
   transition: all 0.1s ease;
-  background-color: var(--nav-bg);
+  background-color: var(--blert-surface-dark);
   position: relative;
 
   // Extend clickable area to cover gaps.
@@ -130,15 +130,15 @@
   }
 
   &.headerRow {
-    background-color: rgba(var(--blert-button-base), 0.08);
+    background-color: rgba(var(--blert-purple-base), 0.08);
     border-bottom-width: 2px;
     font-weight: 600;
   }
 
   &:hover,
   &.selected {
-    background-color: rgba(var(--blert-button-base), 0.4);
-    border-color: var(--blert-button);
+    background-color: rgba(var(--blert-purple-base), 0.4);
+    border-color: var(--blert-purple);
     z-index: 2;
   }
 }
@@ -146,7 +146,7 @@
 .tableLabel {
   text-align: center;
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   padding: 0.25rem;
   min-height: 1.5rem;
 }
@@ -163,9 +163,9 @@
   gap: 0.4rem;
   padding: 0.4rem 0.8rem;
   background-color: transparent;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 4px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   cursor: pointer;
   transition: all 0.2s ease;
   font-size: 0.85rem;
@@ -177,15 +177,15 @@
   }
 
   &:hover {
-    background-color: var(--nav-bg-lightened);
-    color: var(--blert-text-color);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background-color: var(--blert-surface-light);
+    color: var(--blert-font-color-primary);
+    border-color: rgba(var(--blert-purple-base), 0.3);
   }
 
   &.active {
-    background-color: rgba(var(--blert-button-base), 0.1);
-    color: var(--blert-button);
-    border-color: var(--blert-button);
+    background-color: rgba(var(--blert-purple-base), 0.1);
+    color: var(--blert-purple);
+    border-color: var(--blert-purple);
   }
 
   i {
@@ -195,15 +195,15 @@
 
 .helpPanel {
   padding: 1rem;
-  background-color: rgba(var(--nav-bg-base), 0.5);
-  border-bottom: 1px solid var(--font-color-nav-divider);
+  background-color: rgba(var(--blert-surface-dark-base), 0.5);
+  border-bottom: 1px solid var(--blert-divider-color);
 }
 
 .helpContent {
   h4 {
     margin: 0 0 0.75rem 0;
     font-size: 0.95rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -221,16 +221,16 @@
   font-size: 0.85rem;
 
   code {
-    background-color: rgba(var(--nav-bg-base), 0.8);
+    background-color: rgba(var(--blert-surface-dark-base), 0.8);
     padding: 0.2rem 0.4rem;
     border-radius: 3px;
     font-family: var(--font-roboto-mono), monospace;
     font-size: 0.8rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   span {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.8rem;
   }
 }
@@ -238,17 +238,17 @@
 .helpNote {
   margin: 0;
   padding: 0.5rem;
-  background-color: rgba(var(--blert-button-base), 0.1);
-  border-left: 3px solid var(--blert-button);
+  background-color: rgba(var(--blert-purple-base), 0.1);
+  border-left: 3px solid var(--blert-purple);
   border-radius: 4px;
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     margin-top: 0.1rem;
   }
 }
@@ -266,8 +266,8 @@
   min-height: 200px;
   padding: 1rem;
   border: none;
-  background-color: var(--panel-bg);
-  color: var(--blert-text-color);
+  background-color: var(--blert-panel-background-color);
+  color: var(--blert-font-color-primary);
   font-family: var(--font-roboto-mono), monospace;
   font-size: 0.9rem;
   line-height: 1.6;
@@ -280,7 +280,7 @@
   field-sizing: content;
 
   &::placeholder {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.6;
   }
 }
@@ -294,7 +294,7 @@
 }
 
 .emptyPreview {
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-style: italic;
   text-align: center;
   padding: 3rem 1rem;
@@ -304,13 +304,13 @@
   display: flex;
   justify-content: flex-end;
   padding: 0.5rem 1rem;
-  background-color: var(--nav-bg);
-  border-top: 1px solid var(--font-color-nav-divider);
+  background-color: var(--blert-surface-dark);
+  border-top: 1px solid var(--blert-divider-color);
 }
 
 .characterCount {
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-family: var(--font-roboto-mono), monospace;
 
   &.warning {

--- a/web/app/components/markdown-renderer/style.module.scss
+++ b/web/app/components/markdown-renderer/style.module.scss
@@ -1,5 +1,5 @@
 .markdown {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   line-height: 1.6;
   word-wrap: break-word;
   user-select: text !important;
@@ -16,7 +16,7 @@
     margin-bottom: 0.5em;
     font-weight: 600;
     line-height: 1.3;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     &:first-child {
       margin-top: 0;
@@ -25,7 +25,7 @@
 
   h3 {
     font-size: 1.5em;
-    border-bottom: 1px solid var(--font-color-nav-divider);
+    border-bottom: 1px solid var(--blert-divider-color);
     padding-bottom: 0.3em;
   }
 
@@ -39,7 +39,7 @@
 
   h6 {
     font-size: 1em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   p {
@@ -52,7 +52,7 @@
   }
 
   a {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     text-decoration: none;
     transition: opacity 0.2s ease;
 
@@ -94,7 +94,7 @@
     background: none;
     margin: 0;
     font-family: 'Font Awesome 6 Free';
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 18px;
     cursor: default;
     position: relative;
@@ -125,18 +125,18 @@
   }
 
   .inlineCode {
-    background-color: rgba(var(--nav-bg-base), 0.8);
+    background-color: rgba(var(--blert-surface-dark-base), 0.8);
     border-radius: 3px;
     padding: 0.2em 0.4em;
     font-family: var(--font-roboto-mono), monospace;
     font-size: 0.9em;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   pre {
-    background-color: var(--nav-bg);
+    background-color: var(--blert-surface-dark);
     border-radius: 6px;
-    border: 1px solid var(--font-color-nav-divider);
+    border: 1px solid var(--blert-divider-color);
     padding: 1em;
     overflow-x: auto;
     margin-bottom: 1em;
@@ -147,16 +147,16 @@
       font-family: var(--font-roboto-mono), monospace;
       font-size: 0.9em;
       line-height: 1.45;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
   }
 
   blockquote {
     margin: 0 0 1em 0;
     padding: 0 1em;
-    border-left: 4px solid rgba(var(--blert-button-base), 0.3);
-    color: var(--font-color-nav);
-    background: rgba(var(--nav-bg-base), 0.3);
+    border-left: 4px solid rgba(var(--blert-purple-base), 0.3);
+    color: var(--blert-font-color-secondary);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
     border-radius: 0 4px 4px 0;
 
     > :first-child {
@@ -172,7 +172,7 @@
     overflow-x: auto;
     margin-bottom: 1em;
     border-radius: 6px;
-    border: 1px solid var(--font-color-nav-divider);
+    border: 1px solid var(--blert-divider-color);
   }
 
   table {
@@ -182,28 +182,28 @@
     th,
     td {
       padding: 0.5em 0.75em;
-      border: 1px solid var(--font-color-nav-divider);
+      border: 1px solid var(--blert-divider-color);
       text-align: left;
     }
 
     th {
-      background-color: var(--nav-bg);
+      background-color: var(--blert-surface-dark);
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     td {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     tr:nth-child(even) {
-      background-color: rgba(var(--nav-bg-base), 0.3);
+      background-color: rgba(var(--blert-surface-dark-base), 0.3);
     }
   }
 
   hr {
     border: none;
-    border-top: 1px solid var(--font-color-nav-divider);
+    border-top: 1px solid var(--blert-divider-color);
     margin: 1.5em 0;
   }
 
@@ -220,11 +220,11 @@
 
     &:hover {
       transform: translateY(-2px);
-      border-color: rgba(var(--blert-button-base), 0.5);
+      border-color: rgba(var(--blert-purple-base), 0.5);
     }
 
     &:focus {
-      outline: 1px solid rgba(var(--blert-button-base), 0.5);
+      outline: 1px solid rgba(var(--blert-purple-base), 0.5);
       outline-offset: 2px;
       border-radius: 6px;
     }
@@ -235,7 +235,7 @@
     height: auto;
     border-radius: 6px;
     display: block;
-    border: 1px solid var(--font-color-nav-divider);
+    border: 1px solid var(--blert-divider-color);
     pointer-events: none;
   }
 
@@ -252,12 +252,12 @@
 
   del {
     text-decoration: line-through;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   strong {
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   em {
@@ -266,7 +266,7 @@
 
   :global(.katex) {
     font-size: 1.1em;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   :global(.katex-display) {
@@ -358,7 +358,7 @@
   }
 
   &:focus {
-    outline: 2px solid var(--blert-button);
+    outline: 2px solid var(--blert-purple);
     outline-offset: 2px;
   }
 }

--- a/web/app/components/menu/style.module.scss
+++ b/web/app/components/menu/style.module.scss
@@ -5,8 +5,8 @@
 
 .menu {
   position: fixed;
-  background-color: var(--nav-bg);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  background-color: var(--blert-surface-dark);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 2px 8px rgba(0, 0, 0, 0.2);
@@ -25,7 +25,7 @@
     align-items: center;
     justify-content: flex-start;
     transition: all 0.2s ease;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     position: relative;
 
     &:not(.wrap) {
@@ -35,7 +35,7 @@
     &:disabled,
     &.inactive {
       opacity: 0.5;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
 
     &.info {
@@ -46,8 +46,8 @@
     &.active {
       background: linear-gradient(
         90deg,
-        rgba(var(--blert-button-base), 0.15) 0%,
-        rgba(var(--blert-button-base), 0.08) 100%
+        rgba(var(--blert-purple-base), 0.15) 0%,
+        rgba(var(--blert-purple-base), 0.08) 100%
       );
       color: #fff;
 
@@ -58,7 +58,7 @@
         top: 0;
         bottom: 0;
         width: 3px;
-        background: var(--blert-button);
+        background: var(--blert-purple);
         border-radius: 0 2px 2px 0;
       }
 
@@ -67,7 +67,7 @@
       }
 
       & > .icon {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
 
       .secondary {
@@ -77,7 +77,7 @@
 
     &:not(.inactive):not(.active):hover {
       cursor: pointer;
-      background: rgba(var(--blert-button-base), 0.08);
+      background: rgba(var(--blert-purple-base), 0.08);
 
       .icon:not(.subMenuIcon) {
         transform: translateX(2px);
@@ -100,12 +100,12 @@
       transition:
         transform 0.2s ease,
         color 0.2s ease;
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     .secondary {
       margin-left: auto;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.85rem;
       font-family: var(--font-roboto-mono), monospace;
       white-space: nowrap;
@@ -120,9 +120,9 @@
     margin: 0 auto;
     background: linear-gradient(
       90deg,
-      rgba(var(--blert-button-base), 0.05),
-      rgba(var(--blert-button-base), 0.25),
-      rgba(var(--blert-button-base), 0.05)
+      rgba(var(--blert-purple-base), 0.05),
+      rgba(var(--blert-purple-base), 0.25),
+      rgba(var(--blert-purple-base), 0.05)
     );
   }
 }

--- a/web/app/components/modal/style.module.scss
+++ b/web/app/components/modal/style.module.scss
@@ -17,7 +17,7 @@
   }
 
   .modal {
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 5px;
     transform: scale(1);
     opacity: 1;

--- a/web/app/components/player-search/style.module.scss
+++ b/web/app/components/player-search/style.module.scss
@@ -8,18 +8,18 @@
     &.open {
       border-radius: 5px 5px 0 0;
       border-bottom: none;
-      border-color: rgba(var(--blert-button-base), 0.9);
+      border-color: rgba(var(--blert-purple-base), 0.9);
       box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
     }
   }
 }
 
 .suggestions {
-  border-color: rgba(var(--blert-button-base), 0.9) !important;
+  border-color: rgba(var(--blert-purple-base), 0.9) !important;
   background: linear-gradient(
     180deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.98) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.98) 100%
   );
   box-shadow:
     0 8px 24px rgba(0, 0, 0, 0.3),
@@ -27,18 +27,18 @@
 
   .suggestion {
     padding: 8px 12px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 400;
     transition: all 0.15s ease;
     position: relative;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.1);
+      background: rgba(var(--blert-purple-base), 0.1);
       padding-left: 16px;
     }
 
     &.active {
-      background: rgba(var(--blert-button-base), 0.15);
+      background: rgba(var(--blert-purple-base), 0.15);
       font-weight: 500;
       padding-left: 16px;
 
@@ -49,7 +49,7 @@
         top: 0;
         bottom: 0;
         width: 3px;
-        background: var(--blert-button);
+        background: var(--blert-purple);
         border-radius: 0 2px 2px 0;
       }
     }

--- a/web/app/components/progress-bar/style.module.css
+++ b/web/app/components/progress-bar/style.module.css
@@ -46,7 +46,7 @@
     position: absolute;
     width: 1px;
     top: -5px;
-    background-color: var(--blert-text-color);
+    background-color: var(--blert-font-color-primary);
     border-radius: 1px;
     height: calc(100% + 10px);
 
@@ -56,7 +56,7 @@
       bottom: -27px;
       font-size: 14px;
       transform: translateX(-50%);
-      border: 1px solid var(--blert-text-color);
+      border: 1px solid var(--blert-font-color-primary);
       border-radius: 4px;
       white-space: nowrap;
     }

--- a/web/app/components/radio-input/style.module.scss
+++ b/web/app/components/radio-input/style.module.scss
@@ -13,8 +13,8 @@
     gap: 0;
     border-radius: 8px;
     overflow: hidden;
-    border: 1px solid rgba(var(--nav-bg-lightened-base), 0.3);
-    background: rgba(var(--nav-bg-base), 0.3);
+    border: 1px solid rgba(var(--blert-surface-light-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
 
     .radioOption {
       border-radius: 0;
@@ -22,7 +22,7 @@
       background: transparent;
 
       &:not(:last-child) {
-        border-right: 1px solid rgba(var(--nav-bg-lightened-base), 0.3);
+        border-right: 1px solid rgba(var(--blert-surface-light-base), 0.3);
       }
 
       label {
@@ -61,38 +61,38 @@
     .radioOption {
       border: none;
       background: none;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       label {
-        border: 1px solid rgba(var(--font-color-nav-divider), 0.5);
+        border: 1px solid rgba(var(--blert-divider-color), 0.5);
         border-radius: 8px;
-        background: rgba(var(--panel-bg-base), 0.3);
+        background: rgba(var(--blert-panel-background-color-base), 0.3);
         transition: all 0.2s ease;
         backdrop-filter: blur(2px);
       }
 
       label:hover {
-        border: 1px solid rgba(var(--blert-button-base), 0.5);
-        color: var(--blert-text-color);
-        background: rgba(var(--blert-button-base), 0.05);
+        border: 1px solid rgba(var(--blert-purple-base), 0.5);
+        color: var(--blert-font-color-primary);
+        background: rgba(var(--blert-purple-base), 0.05);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
       }
 
       input:checked + label {
         border-radius: 8px;
-        border: 1px solid rgba(var(--blert-button-base), 0.8);
-        color: var(--blert-text-color);
-        background: rgba(var(--blert-button-base), 0.1);
+        border: 1px solid rgba(var(--blert-purple-base), 0.8);
+        color: var(--blert-font-color-primary);
+        background: rgba(var(--blert-purple-base), 0.1);
         box-shadow:
-          0 2px 8px rgba(var(--blert-button-base), 0.2),
-          inset 0 1px 0 rgba(var(--blert-button-base), 0.1);
+          0 2px 8px rgba(var(--blert-purple-base), 0.2),
+          inset 0 1px 0 rgba(var(--blert-purple-base), 0.1);
       }
 
       input:checked + label:hover {
-        background: rgba(var(--blert-button-base), 0.15);
+        background: rgba(var(--blert-purple-base), 0.15);
         box-shadow:
-          0 6px 16px rgba(var(--blert-button-base), 0.25),
-          inset 0 1px 0 rgba(var(--blert-button-base), 0.15);
+          0 6px 16px rgba(var(--blert-purple-base), 0.25),
+          inset 0 1px 0 rgba(var(--blert-purple-base), 0.15);
       }
     }
   }
@@ -100,14 +100,14 @@
   .radioOption {
     flex-grow: 1;
     flex-basis: 0;
-    background: rgba(var(--nav-bg-base), 0.6);
-    border: 1px solid rgba(var(--nav-bg-lightened-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.6);
+    border: 1px solid rgba(var(--blert-surface-light-base), 0.3);
     border-radius: 8px;
     overflow: hidden;
     transition: all 0.2s ease;
 
     &:hover {
-      border-color: rgba(var(--blert-button-base), 0.3);
+      border-color: rgba(var(--blert-purple-base), 0.3);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     }
 
@@ -117,15 +117,15 @@
       text-align: center;
       cursor: pointer;
       font-weight: 500;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       transition: all 0.2s ease;
       background: transparent;
       border-radius: 7px;
       user-select: none;
 
       &:hover {
-        color: var(--blert-text-color);
-        background: rgba(var(--blert-button-base), 0.08);
+        color: var(--blert-font-color-primary);
+        background: rgba(var(--blert-purple-base), 0.08);
       }
     }
 
@@ -139,10 +139,10 @@
     input:disabled + label {
       opacity: 0.5;
       cursor: not-allowed;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       &:hover {
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         background: transparent;
         transform: none;
       }
@@ -151,20 +151,20 @@
     input:checked + label {
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.9) 0%,
-        rgba(var(--blert-button-base), 0.8) 100%
+        rgba(var(--blert-purple-base), 0.9) 0%,
+        rgba(var(--blert-purple-base), 0.8) 100%
       );
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
       box-shadow:
         inset 0 1px 0 rgba(255, 255, 255, 0.1),
-        0 2px 8px rgba(var(--blert-button-base), 0.3);
+        0 2px 8px rgba(var(--blert-purple-base), 0.3);
 
       &:hover {
         background: linear-gradient(
           135deg,
-          rgba(var(--blert-button-base), 1) 0%,
-          rgba(var(--blert-button-base), 0.9) 100%
+          rgba(var(--blert-purple-base), 1) 0%,
+          rgba(var(--blert-purple-base), 0.9) 100%
         );
         color: white;
         cursor: default;
@@ -172,8 +172,8 @@
     }
 
     &:focus-within {
-      border-color: rgba(var(--blert-button-base), 0.5);
-      box-shadow: 0 0 0 2px rgba(var(--blert-button-base), 0.2);
+      border-color: rgba(var(--blert-purple-base), 0.5);
+      box-shadow: 0 0 0 2px rgba(var(--blert-purple-base), 0.2);
     }
   }
 

--- a/web/app/components/section-title/style.module.scss
+++ b/web/app/components/section-title/style.module.scss
@@ -5,9 +5,9 @@
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0 1.5rem 0;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid rgba(var(--blert-button-base), 0.2);
+  border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
   position: relative;
 
   &::after {
@@ -17,11 +17,11 @@
     left: 0;
     width: 60px;
     height: 2px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
   }
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1.2rem;
   }
 }

--- a/web/app/components/session-history/style.module.scss
+++ b/web/app/components/session-history/style.module.scss
@@ -9,15 +9,15 @@
     justify-content: center;
     gap: 12px;
     padding: 2rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     text-align: center;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 8px;
-    border: 1px solid rgba(var(--blert-button-base), 0.1);
+    border: 1px solid rgba(var(--blert-purple-base), 0.1);
 
     i {
       font-size: 2rem;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       opacity: 0.6;
     }
 
@@ -30,10 +30,10 @@
 .sessionCard {
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.8) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.8) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 12px;
   margin-bottom: 16px;
   overflow: hidden;
@@ -41,7 +41,7 @@
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
   }
@@ -53,8 +53,8 @@
   background: linear-gradient(
     135deg,
     rgba(var(--blert-green-base), 0.02) 0%,
-    var(--panel-bg) 30%,
-    rgba(var(--nav-bg-base), 0.8) 100%
+    var(--blert-panel-background-color) 30%,
+    rgba(var(--blert-surface-dark-base), 0.8) 100%
   );
   box-shadow:
     0 4px 16px rgba(0, 0, 0, 0.2),
@@ -109,7 +109,7 @@
   transition: background-color 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-lightened-base), 0.5);
+    background: rgba(var(--blert-surface-light-base), 0.5);
   }
 }
 
@@ -134,8 +134,8 @@
   font-size: 1.25rem;
   font-weight: 600;
   margin: 0 0 8px 0;
-  color: var(--blert-text-color);
-  text-shadow: 0 0 3px rgba(var(--blert-button-base), 0.4);
+  color: var(--blert-font-color-primary);
+  text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.4);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     font-size: 1.1rem;
@@ -147,7 +147,7 @@
   align-items: center;
   gap: 8px;
   font-size: 0.9rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   i {
     margin-right: 4px;
@@ -159,7 +159,7 @@
 }
 
 .separator {
-  color: var(--font-color-nav-divider);
+  color: var(--blert-divider-color);
 }
 
 .sessionActions {
@@ -194,11 +194,11 @@
 }
 
 .expandButton {
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 8px;
   padding: 8px 12px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   cursor: pointer;
   transition: all 0.2s ease;
   display: flex;
@@ -207,7 +207,7 @@
   min-width: 40px;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.2);
+    background: rgba(var(--blert-purple-base), 0.2);
     transform: scale(1.05);
   }
 
@@ -234,15 +234,15 @@
   align-items: center;
   gap: 8px;
   padding: 12px;
-  background: rgba(var(--nav-bg-base), 0.6);
+  background: rgba(var(--blert-surface-dark-base), 0.6);
   border-radius: 8px;
   font-size: 0.9rem;
-  color: var(--blert-text-color);
-  border: 1px solid rgba(var(--font-color-nav-divider), 0.3);
+  color: var(--blert-font-color-primary);
+  border: 1px solid rgba(var(--blert-divider-color), 0.3);
   transition: all 0.2s ease;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 16px;
     width: 16px;
     text-align: center;
@@ -264,8 +264,8 @@
 }
 
 .sessionChallenges {
-  border-top: 1px solid rgba(var(--font-color-nav-divider), 0.3);
-  background: rgba(var(--nav-bg-darkened-base), 0.4);
+  border-top: 1px solid rgba(var(--blert-divider-color), 0.3);
+  background: rgba(var(--blert-surface-darker-base), 0.4);
 }
 
 .challengesList {
@@ -279,8 +279,8 @@
   display: flex;
   flex-direction: column;
   padding: 12px;
-  background: rgba(var(--panel-bg-base), 0.8);
-  border: 1px solid rgba(var(--font-color-nav-divider), 0.2);
+  background: rgba(var(--blert-panel-background-color-base), 0.8);
+  border: 1px solid rgba(var(--blert-divider-color), 0.2);
   border-radius: 8px;
   text-decoration: none;
   color: inherit;
@@ -298,15 +298,15 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.1),
+      rgba(var(--blert-purple-base), 0.1),
       transparent
     );
     transition: left 0.5s ease;
   }
 
   &:hover {
-    background: rgba(var(--nav-bg-base), 0.8);
-    border-color: rgba(var(--blert-button-base), 0.4);
+    background: rgba(var(--blert-surface-dark-base), 0.8);
+    border-color: rgba(var(--blert-purple-base), 0.4);
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 
@@ -329,7 +329,7 @@
   .challengeIndex {
     font-size: 0.85rem;
     font-weight: 600;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       font-size: 0.8rem;
@@ -366,7 +366,7 @@
     width: 16px;
     text-align: center;
     font-size: 12px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -393,7 +393,7 @@
 }
 
 .skeleton {
-  background: var(--nav-bg-lightened);
+  background: var(--blert-surface-light);
   border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
 }

--- a/web/app/components/statistic/style.module.scss
+++ b/web/app/components/statistic/style.module.scss
@@ -15,20 +15,24 @@
     position: absolute;
     top: 8px;
     right: 8px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 12px;
   }
 
   &:not(.simple) {
-    background: linear-gradient(145deg, var(--nav-bg), var(--nav-bg-lightened));
-    border: 1px solid var(--nav-bg-lightened);
+    background: linear-gradient(
+      145deg,
+      var(--blert-surface-dark),
+      var(--blert-surface-light)
+    );
+    border: 1px solid var(--blert-surface-light);
 
     &:hover {
       transform: translateY(-2px);
-      border-color: var(--blert-button);
+      border-color: var(--blert-purple);
 
       .value {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
 
       .label i {
@@ -40,7 +44,7 @@
   .value {
     font-size: 28px;
     font-weight: 700;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     transition: color 0.2s ease;
     font-variant-numeric: tabular-nums;
     display: flex;
@@ -50,13 +54,13 @@
 
   .label {
     font-size: 13px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     text-align: center;
     line-height: 1.4;
 
     .icon {
       display: block;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 18px;
       transition: transform 0.2s ease;
 

--- a/web/app/components/tabs/style.module.scss
+++ b/web/app/components/tabs/style.module.scss
@@ -33,7 +33,7 @@
     position: relative;
 
     .tab {
-      border-bottom: 2px solid var(--blert-text-color);
+      border-bottom: 2px solid var(--blert-font-color-primary);
       padding: 10px 20px;
       transition: color 0.2s ease-in-out;
       display: flex;

--- a/web/app/components/tag-list/style.module.scss
+++ b/web/app/components/tag-list/style.module.scss
@@ -11,19 +11,19 @@
     padding: 6px 10px 6px 12px;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.12) 0%,
-      rgba(var(--blert-button-base), 0.08) 100%
+      rgba(var(--blert-purple-base), 0.12) 0%,
+      rgba(var(--blert-purple-base), 0.08) 100%
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.25);
+    border: 1px solid rgba(var(--blert-purple-base), 0.25);
     border-radius: 6px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.9rem;
     font-weight: 500;
     transition: all 0.2s ease;
     animation: tagSlideIn 0.2s ease-out;
 
     &:hover {
-      border-color: rgba(var(--blert-button-base), 0.4);
+      border-color: rgba(var(--blert-purple-base), 0.4);
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 
       button {
@@ -43,10 +43,10 @@
       padding: 2px;
       width: 18px;
       height: 18px;
-      background: rgba(var(--nav-bg-base), 0.4);
+      background: rgba(var(--blert-surface-dark-base), 0.4);
       border: none;
       border-radius: 3px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 11px;
       transition: all 0.2s ease;
       cursor: pointer;

--- a/web/app/components/tick-input/style.module.scss
+++ b/web/app/components/tick-input/style.module.scss
@@ -19,19 +19,19 @@
     flex-direction: column;
     justify-content: space-evenly;
     align-items: center;
-    border-left: 1px solid var(--content-area-bg);
+    border-left: 1px solid rgba(var(--blert-purple-base), 0.1);
 
     button {
       padding: 2px 6px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       &:disabled {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
 
       &:not(:disabled):hover {
         cursor: pointer;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
   }

--- a/web/app/components/toast/style.module.scss
+++ b/web/app/components/toast/style.module.scss
@@ -19,17 +19,17 @@
 .toast {
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.95) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
   );
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 8px;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 2px 8px rgba(0, 0, 0, 0.2),
     inset 0 1px 0 rgba(255, 255, 255, 0.08);
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   padding: 16px 20px;
   font-size: 0.9rem;
   font-weight: 500;
@@ -53,7 +53,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      var(--blert-button),
+      var(--blert-purple),
       transparent
     );
     animation: borderShimmer 3s ease-in-out infinite;
@@ -77,10 +77,10 @@
   }
 
   &.info {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
 
     .toastIcon {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 
@@ -130,7 +130,7 @@
   font-size: 1.1rem;
   margin-right: 4px;
   flex-shrink: 0;
-  color: var(--blert-button);
+  color: var(--blert-purple);
 }
 
 .toastMessage {
@@ -142,7 +142,7 @@
   background: none;
   border: none;
   padding: 6px;
-  color: rgba(var(--blert-text-color-base), 0.7);
+  color: rgba(var(--blert-font-color-primary-base), 0.7);
   cursor: pointer;
   transition: all 0.2s ease;
   display: flex;
@@ -154,8 +154,8 @@
   margin-left: 4px;
 
   &:hover {
-    color: var(--blert-text-color);
-    background: rgba(var(--nav-bg-lightened-base), 0.6);
+    color: var(--blert-font-color-primary);
+    background: rgba(var(--blert-surface-light-base), 0.6);
     transform: scale(1.1);
   }
 

--- a/web/app/components/tooltip/style.module.scss
+++ b/web/app/components/tooltip/style.module.scss
@@ -1,7 +1,7 @@
 @use '../../mixins.scss' as *;
 
 .tooltip {
-  color: var(--blert-text-color) !important;
+  color: var(--blert-font-color-primary) !important;
   font-size: 0.9rem;
   font-weight: 500;
   letter-spacing: 0.025em;

--- a/web/app/components/tooltip/tooltip.tsx
+++ b/web/app/components/tooltip/tooltip.tsx
@@ -55,7 +55,7 @@ export function Tooltip(props: TooltipProps) {
     offset = 10,
     delayShow,
     delayHide,
-    border = '1px solid rgba(var(--blert-button-base), 0.15)',
+    border = '1px solid rgba(var(--blert-purple-base), 0.15)',
     opacity = 1,
   } = props;
   const [ready, setReady] = useState(false);
@@ -101,10 +101,10 @@ export function Tooltip(props: TooltipProps) {
       opacity={opacity}
       render={props.render}
       border={border}
-      arrowColor="rgba(var(--nav-bg-base), 0.95)"
+      arrowColor="rgba(var(--blert-surface-dark-base), 0.95)"
       style={{
         background:
-          'linear-gradient(135deg, var(--panel-bg) 0%, rgba(var(--nav-bg-base), 0.95) 100%)',
+          'linear-gradient(135deg, var(--blert-panel-background-color) 0%, rgba(var(--blert-surface-dark-base), 0.95) 100%)',
         borderRadius: '8px',
         boxShadow:
           '0 8px 32px rgba(0, 0, 0, 0.3), 0 2px 8px rgba(0, 0, 0, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.05)',

--- a/web/app/components/topbar/style.module.scss
+++ b/web/app/components/topbar/style.module.scss
@@ -5,7 +5,7 @@
   width: 100vw;
   height: $TOPBAR_HEIGHT;
   z-index: 48;
-  background-color: var(--nav-bg);
+  background-color: var(--blert-surface-dark);
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: space-between;

--- a/web/app/docs/api/style.module.scss
+++ b/web/app/docs/api/style.module.scss
@@ -7,7 +7,7 @@
 
 :global(.swagger-ui) {
   font-family: 'Inter', sans-serif;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   width: 100%;
 
   .wrapper {
@@ -26,7 +26,7 @@
     }
 
     .title small {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
   }
 
@@ -61,11 +61,11 @@
       background: none;
 
       .opblock-summary-method {
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
       }
 
       .opblock-summary-path {
-        color: var(--font-color-nav-active);
+        color: var(--blert-font-color-secondary-active);
       }
     }
 
@@ -76,7 +76,7 @@
     }
 
     pre {
-      background: var(--nav-bg) !important;
+      background: var(--blert-surface-dark) !important;
       margin-bottom: 1em !important;
     }
   }
@@ -100,7 +100,7 @@
   .tab-header .tab-item,
   .response-control-media-type__accept-message,
   .download-contents {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .parameter__name {
@@ -108,14 +108,14 @@
   }
 
   .model {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     .property {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .property-type {
-      color: var(--font-color-nav-active);
+      color: var(--blert-font-color-secondary-active);
     }
 
     .model-title {
@@ -128,9 +128,9 @@
   }
 
   input {
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
-    border: 1px solid var(--blert-text-color);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
+    border: 1px solid var(--blert-font-color-primary);
 
     &:focus {
       border: 1px solid #fff;
@@ -140,25 +140,25 @@
   table {
     thead tr th {
       color: #fff;
-      border-bottom: 1px solid var(--font-color-nav);
+      border-bottom: 1px solid var(--blert-font-color-secondary);
       background: none;
     }
 
     tbody tr td {
-      color: var(--blert-text-color);
-      border-bottom: 1px solid var(--font-color-nav);
+      color: var(--blert-font-color-primary);
+      border-bottom: 1px solid var(--blert-font-color-secondary);
       background: none;
     }
   }
 
   .btn {
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
-    border: 1px solid var(--font-color-nav);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
+    border: 1px solid var(--blert-font-color-secondary);
     box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
 
     &:hover {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
     }
   }
 
@@ -186,7 +186,7 @@
   }
 
   .prop-type {
-    color: var(--font-color-nav-active);
+    color: var(--blert-font-color-secondary-active);
   }
 
   .prop-format {
@@ -195,5 +195,5 @@
 }
 
 :global(svg.arrow) {
-  fill: var(--blert-text-color);
+  fill: var(--blert-font-color-primary);
 }

--- a/web/app/globals.scss
+++ b/web/app/globals.scss
@@ -7,48 +7,39 @@
   --blert-blue-base: 59, 130, 246;
   --blert-green-base: 45, 199, 112;
   --blert-yellow-base: 222, 200, 88;
-  --blert-text-color-base: 195, 199, 201;
-  --blert-button-base: 88, 101, 242;
+  --blert-purple-base: 88, 101, 242;
   --blert-gold-base: 255, 215, 0;
   --blert-silver-base: 192, 192, 192;
   --blert-bronze-base: 205, 127, 50;
 
-  --nav-bg-base: 23, 24, 33;
-  --nav-bg-darkened-base: 17, 18, 33;
-  --nav-bg-lightened-base: 33, 35, 48;
-  --panel-bg-base: 27, 28, 37;
+  --blert-font-color-primary-base: 195, 199, 201;
+  --blert-font-color-secondary-base: 94, 98, 136;
+
+  --blert-surface-dark-base: 23, 24, 33;
+  --blert-surface-darker-base: 17, 18, 33;
+  --blert-surface-light-base: 33, 35, 48;
+  --blert-page-background-color-base: 33, 34, 41;
+  --blert-panel-background-color-base: 27, 28, 37;
 
   --blert-red: rgb(var(--blert-red-base));
   --blert-blue: rgb(var(--blert-blue-base));
   --blert-green: rgb(var(--blert-green-base));
   --blert-yellow: rgb(var(--blert-yellow-base));
-  --blert-text-color: rgb(var(--blert-text-color-base));
-  --blert-button: rgb(var(--blert-button-base));
+  --blert-purple: rgb(var(--blert-purple-base));
   --blert-gold: rgb(var(--blert-gold-base));
   --blert-silver: rgb(var(--blert-silver-base));
   --blert-bronze: rgb(var(--blert-bronze-base));
 
-  --nav-bg: rgb(var(--nav-bg-base));
-  --nav-bg-darkened: rgb(var(--nav-bg-darkened-base));
-  --nav-bg-lightened: rgb(var(--nav-bg-lightened-base));
-  --page-bg: #171821;
-  --content-area-bg: #212229;
-  --panel-bg: #1b1c25;
+  --blert-font-color-primary: rgb(var(--blert-font-color-primary-base));
+  --blert-font-color-secondary: rgb(var(--blert-font-color-secondary-base));
+  --blert-font-color-secondary-active: #acafc6;
+  --blert-divider-color: #4b4e6d;
 
-  --highlight-bg: #303349;
-
-  --font-color-nav: #5e6288;
-  --font-color-nav-active: #acafc6;
-  --font-color-nav-divider: #4b4e6d;
-
-  --font-size-title: 25px;
-  --font-color-title: #000;
-
-  --font-size-subtitle: 20px;
-  --font-color-subtitle: #fff;
-
-  --font-size-normal: 15px;
-  --font-color-normal: #000;
+  --blert-surface-dark: rgb(var(--blert-surface-dark-base));
+  --blert-surface-darker: rgb(var(--blert-surface-darker-base));
+  --blert-surface-light: rgb(var(--blert-surface-light-base));
+  --blert-page-background-color: rgb(var(--blert-page-background-color-base));
+  --blert-panel-background-color: rgb(var(--blert-panel-background-color-base));
 
   --blert-gold-text-shadow:
     0 0 8px rgba(255, 215, 0, 0.6), 0 0 16px rgba(255, 215, 0, 0.3),
@@ -77,18 +68,18 @@ body {
 }
 
 body {
-  color: var(--blert-text-color);
-  background-color: var(--page-bg);
+  color: var(--blert-font-color-primary);
+  background-color: var(--blert-page-background-color);
   display: flex;
 }
 
 a {
   text-decoration: none;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 button {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   background: none;
   border: none;
   font-family: 'Inter', sans-serif;

--- a/web/app/guides/blert/style.module.scss
+++ b/web/app/guides/blert/style.module.scss
@@ -2,6 +2,6 @@
 
 .blertGuide {
   li i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }

--- a/web/app/guides/style.module.scss
+++ b/web/app/guides/style.module.scss
@@ -25,7 +25,7 @@
       }
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -45,12 +45,12 @@
     gap: 10px;
     margin-top: 20px;
     padding: 12px 16px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     font-size: 0.9em;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1.2em;
     }
   }
@@ -75,7 +75,7 @@
   .usageLink {
     display: block;
     text-decoration: none;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 8px;
     padding: 16px 20px;
     transition:
@@ -87,8 +87,8 @@
     &:hover {
       transform: translateY(-2px);
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-      background: var(--panel-bg);
-      border-color: rgba(var(--blert-button-base), 0.3);
+      background: var(--blert-panel-background-color);
+      border-color: rgba(var(--blert-purple-base), 0.3);
     }
 
     .usageLinkContent {
@@ -98,7 +98,7 @@
 
       i {
         font-size: 1.4em;
-        color: var(--blert-button);
+        color: var(--blert-purple);
         margin-top: 2px;
         flex-shrink: 0;
       }
@@ -117,7 +117,7 @@
           margin: 0;
           font-size: 0.85em;
           line-height: 1.4;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
         }
       }
     }
@@ -135,18 +135,18 @@
         box-shadow 0.2s ease-in-out;
       text-decoration: none;
       cursor: pointer;
-      background: var(--panel-bg);
+      background: var(--blert-panel-background-color);
 
       &:hover {
         transform: translateY(-4px);
         box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
-        outline: 1px solid rgba(var(--blert-button-base), 0.5);
+        outline: 1px solid rgba(var(--blert-purple-base), 0.5);
       }
 
       .guideThumbnail {
         margin: -10px -30px 10px;
         padding: 20px;
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
         border-radius: 6px 6px 0 0;
         text-align: center;
       }
@@ -160,7 +160,7 @@
           margin: 0;
           font-size: 0.9em;
           line-height: 1.5;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
         }
       }
     }
@@ -169,9 +169,9 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: var(--nav-bg);
-      border: 2px dashed var(--font-color-nav-divider);
-      color: var(--font-color-nav);
+      background: var(--blert-surface-dark);
+      border: 2px dashed var(--blert-divider-color);
+      color: var(--blert-font-color-secondary);
       opacity: 0.8;
 
       p {
@@ -198,7 +198,7 @@
     text-decoration: none;
 
     &:hover {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 
@@ -209,7 +209,7 @@
 
     & > li {
       line-height: 2em;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       ul {
         list-style: none;
@@ -225,9 +225,9 @@
           top: 0px;
           content: '';
           display: block;
-          border-left: 1px solid var(--font-color-nav-divider);
+          border-left: 1px solid var(--blert-divider-color);
           height: 1em;
-          border-bottom: 1px solid var(--font-color-nav-divider);
+          border-bottom: 1px solid var(--blert-divider-color);
           width: 10px;
         }
 
@@ -237,7 +237,7 @@
           bottom: -7px;
           content: '';
           display: block;
-          border-left: 1px solid var(--font-color-nav-divider);
+          border-left: 1px solid var(--blert-divider-color);
           height: 100%;
         }
 
@@ -254,7 +254,7 @@
   padding: 0.5em 0;
   display: flex;
   border-radius: 5px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   width: fit-content;
 
   .tag {
@@ -262,12 +262,12 @@
     padding: 0 12px;
 
     &:not(:first-child) {
-      border-left: 2px solid var(--content-area-bg);
+      border-left: 2px solid rgba(var(--blert-purple-base), 0.1);
     }
 
     i {
       margin-right: 8px;
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 }
@@ -275,7 +275,7 @@
 .authorCredits {
   display: block;
   margin-bottom: 1em;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.9em;
   font-style: italic;
 }

--- a/web/app/guides/tob/nylocas/4s/style.module.scss
+++ b/web/app/guides/tob/nylocas/4s/style.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   border-radius: 10px;
   overflow: hidden;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     width: 100%;
@@ -27,22 +27,22 @@
       width: 50%;
 
       &:nth-child(even) {
-        border-left: 2px solid var(--content-area-bg);
+        border-left: 2px solid rgba(var(--blert-purple-base), 0.1);
       }
 
       &:nth-child(-n + 2) {
-        border-bottom: 2px solid var(--content-area-bg);
+        border-bottom: 2px solid rgba(var(--blert-purple-base), 0.1);
       }
     }
 
     @media (min-width: $COMPACT_WIDTH_THRESHOLD) {
       &:not(:last-child) {
-        border-right: 2px solid var(--content-area-bg);
+        border-right: 2px solid rgba(var(--blert-purple-base), 0.1);
       }
     }
 
     &.active {
-      background: var(--nav-bg-darkened);
+      background: var(--blert-surface-darker);
       color: #fff;
 
       &:hover {
@@ -51,7 +51,7 @@
     }
 
     &:not(.active):hover {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
       color: #fff;
     }
 

--- a/web/app/guides/tob/nylocas/mechanics/style.module.scss
+++ b/web/app/guides/tob/nylocas/mechanics/style.module.scss
@@ -2,7 +2,7 @@
   table-layout: fixed;
 
   .emptySpawn {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -79,7 +79,7 @@
 
 .cycleTable {
   .spawnTick {
-    background: rgba(var(--blert-button-base), 0.2);
+    background: rgba(var(--blert-purple-base), 0.2);
     color: white;
     font-weight: 700;
   }

--- a/web/app/guides/tob/style.module.scss
+++ b/web/app/guides/tob/style.module.scss
@@ -11,7 +11,7 @@
 
 .subtitle {
   margin-top: 0;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-style: italic;
   font-size: 0.9em;
 }
@@ -29,10 +29,10 @@
     align-items: center;
     gap: 12px;
     margin-bottom: 0.5em;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 }
@@ -47,14 +47,14 @@
   display: flex;
   justify-content: center;
   padding: 1em;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 6px;
 }
 
 .guideGroup {
   h3 {
     margin: 1em 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 1.25rem;
   }
 
@@ -78,14 +78,14 @@
         }
 
         &:hover {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
 
       .guideDesc {
         margin: 0.25em 0 0 0;
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       ul {
@@ -101,8 +101,8 @@
             top: 50%;
             content: '';
             display: block;
-            border-left: 1px solid var(--font-color-nav-divider);
-            border-bottom: 1px solid var(--font-color-nav-divider);
+            border-left: 1px solid var(--blert-divider-color);
+            border-bottom: 1px solid var(--blert-divider-color);
             width: 12px;
           }
 
@@ -112,7 +112,7 @@
             top: 0;
             content: '';
             display: block;
-            border-left: 1px solid var(--font-color-nav-divider);
+            border-left: 1px solid var(--blert-divider-color);
             height: 150%;
           }
 
@@ -122,7 +122,7 @@
 
           a {
             &:hover {
-              color: var(--blert-button);
+              color: var(--blert-purple);
             }
           }
         }

--- a/web/app/home.module.scss
+++ b/web/app/home.module.scss
@@ -21,7 +21,7 @@
 .filters {
   width: 200px !important;
   font-size: 0.9em;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 }
 
 .statsGrid {
@@ -48,14 +48,14 @@
   .value {
     font-size: 2em;
     font-weight: 500;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     line-height: 1.2;
     margin-bottom: auto;
   }
 
   .label {
     font-size: 0.9em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-top: 6px;
     white-space: nowrap;
   }
@@ -75,7 +75,7 @@
     transition: background-color 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
     }
 
     &:not(:last-child) {
@@ -86,7 +86,7 @@
 
 .guideType {
   font-size: 0.85em;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   margin-top: 2px;
 }
 
@@ -98,7 +98,7 @@
 
   .rank {
     font-weight: 500;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     width: 24px;
   }
 
@@ -107,7 +107,7 @@
   }
 
   .score {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -120,7 +120,7 @@
 
     .statusCard {
       padding: 12px;
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
       border-radius: 6px;
 
       .statusHeading {
@@ -138,7 +138,7 @@
       .statusTimestamp {
         display: block;
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         margin-bottom: 12px;
       }
 
@@ -176,7 +176,7 @@
     h2 {
       font-size: 1.3em;
       margin: 0 0 12px 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       &:not(:first-child) {
         margin-top: 24px;
@@ -189,7 +189,7 @@
     }
 
     a {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       text-decoration: none;
 
       &:hover {
@@ -216,7 +216,11 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: linear-gradient(135deg, var(--panel-bg), var(--nav-bg-lightened));
+  background: linear-gradient(
+    135deg,
+    var(--blert-panel-background-color),
+    var(--blert-surface-light)
+  );
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     flex-direction: column;
@@ -228,14 +232,14 @@
     h1 {
       font-size: 2.4em;
       margin: 0 0 16px 0;
-      background: linear-gradient(to right, #fff, var(--blert-button));
+      background: linear-gradient(to right, #fff, var(--blert-purple));
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
     }
 
     p {
       font-size: 1.1em;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       max-width: 500px;
       line-height: 1.6;
     }
@@ -273,22 +277,22 @@
 }
 
 .primaryButton {
-  background: var(--blert-button);
+  background: var(--blert-purple);
   color: #fff;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.8);
+    background: rgba(var(--blert-purple-base), 0.8);
   }
 }
 
 .secondaryButton {
-  background: var(--nav-bg);
-  color: var(--blert-text-color);
-  border: 1px solid var(--font-color-nav-divider);
+  background: var(--blert-surface-dark);
+  color: var(--blert-font-color-primary);
+  border: 1px solid var(--blert-divider-color);
 
   &:hover {
-    background: var(--panel-bg);
-    border-color: var(--blert-button);
+    background: var(--blert-panel-background-color);
+    border-color: var(--blert-purple);
   }
 }
 
@@ -296,23 +300,23 @@
   display: flex;
   gap: 2px;
   padding: 2px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 4px;
 
   button {
     padding: 4px 12px;
     border-radius: 3px;
     font-size: 0.9em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     transition: all 0.2s ease;
     cursor: pointer;
 
     &:hover {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     &.active {
-      background: var(--panel-bg);
+      background: var(--blert-panel-background-color);
       color: #fff;
     }
   }
@@ -324,7 +328,7 @@
   gap: 8px;
   margin-bottom: 20px;
   padding: 12px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 6px;
 }
 
@@ -332,11 +336,11 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.9em;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     width: 16px;
     text-align: center;
   }
@@ -351,7 +355,7 @@
 
 .guideDate {
   font-size: 0.85em;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 }
 
 .playerStats {
@@ -361,7 +365,7 @@
 
   .count {
     font-size: 0.85em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -376,7 +380,7 @@
       align-items: center;
       gap: 12px;
       padding: 12px;
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
       border-radius: 6px;
       transition: all 0.2s ease;
       transform-origin: top;
@@ -396,7 +400,7 @@
       }
 
       a {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         text-decoration: none;
 
         &:hover {
@@ -413,7 +417,7 @@
         font-size: 1.2em;
 
         &.skeleton {
-          background: var(--panel-bg);
+          background: var(--blert-panel-background-color);
           border-radius: 4px;
           animation: pulse 1.5s ease-in-out infinite;
         }
@@ -431,12 +435,12 @@
 
       .feedTime {
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
 
         &.skeleton {
           width: 60px;
           height: 16px;
-          background: var(--panel-bg);
+          background: var(--blert-panel-background-color);
           border-radius: 3px;
           animation: pulse 1.5s ease-in-out infinite;
         }
@@ -450,7 +454,7 @@
     align-items: center;
     text-align: center;
     padding: 32px 20px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     gap: 16px;
 
@@ -463,13 +467,13 @@
     .errorContent {
       h3 {
         margin: 0 0 8px 0;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         font-size: 1.1em;
       }
 
       p {
         margin: 0;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-size: 0.9em;
       }
     }
@@ -480,14 +484,14 @@
       gap: 8px;
       padding: 8px 16px;
       border-radius: 4px;
-      background: var(--panel-bg);
-      color: var(--blert-text-color);
+      background: var(--blert-panel-background-color);
+      color: var(--blert-font-color-primary);
       font-size: 0.9em;
       transition: all 0.2s ease;
       cursor: pointer;
 
       &:hover {
-        background: var(--nav-bg-lightened);
+        background: var(--blert-surface-light);
 
         i {
           transform: rotate(180deg);
@@ -533,7 +537,7 @@
 
 .skeletonLine {
   height: 16px;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 3px;
   animation: pulse 1.5s ease-in-out infinite;
 }
@@ -556,7 +560,7 @@
 
 .carouselTitle {
   font-size: 1.1em;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin: 0 0 16px 0;
   font-weight: 500;
 }
@@ -572,20 +576,20 @@
   display: flex;
   flex-direction: column;
   padding: 16px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 6px;
   text-decoration: none;
   transition: all 0.2s ease;
 
   &:hover {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     transform: translateY(-2px);
   }
 
   .guideTitle {
     font-size: 1.1em;
     font-weight: 500;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     margin-bottom: 8px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -599,10 +603,10 @@
     align-items: center;
     margin-bottom: 8px;
     font-size: 0.85em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     .guideType {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     .guideAuthor {
@@ -614,7 +618,7 @@
     margin: 0;
     font-size: 0.9em;
     line-height: 1.5;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-bottom: 12px;
   }
 
@@ -623,7 +627,7 @@
     gap: 16px;
     margin-top: auto;
     padding-top: 12px;
-    border-top: 1px solid var(--font-color-nav-divider);
+    border-top: 1px solid var(--blert-divider-color);
     font-size: 0.9em;
 
     .score,
@@ -631,7 +635,7 @@
       display: flex;
       align-items: center;
       gap: 6px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       i {
         font-size: 0.9em;
@@ -640,7 +644,7 @@
 
     .score {
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -667,9 +671,9 @@
   justify-content: center;
   gap: 12px;
   padding: 32px 16px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 6px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   height: 260px;
 
   i {
@@ -690,14 +694,14 @@
   flex-direction: column;
   gap: 8px;
   padding: 12px 16px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 6px;
   text-decoration: none;
   transition: all 0.2s ease;
   width: 100%;
 
   &:hover {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     transform: translateX(4px);
   }
 
@@ -706,7 +710,7 @@
     top: 12px;
     right: 16px;
     font-size: 0.85em;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.8;
   }
 
@@ -718,7 +722,7 @@
 
   .rank {
     font-weight: 500;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     display: flex;
     align-items: center;
     gap: 4px;
@@ -744,7 +748,7 @@
 
   .time {
     font-family: var(--font-roboto-mono);
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     width: 80px;
   }
 
@@ -754,7 +758,7 @@
     gap: 4px;
 
     .party {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
       line-height: 1.4;
     }

--- a/web/app/leaderboards/[challenge]/[[...options]]/style.module.scss
+++ b/web/app/leaderboards/[challenge]/[[...options]]/style.module.scss
@@ -48,9 +48,9 @@
       padding: 8px 12px;
       border-radius: 6px;
       font-weight: 500;
-      background: rgba(var(--nav-bg-base), 0.4);
-      border: 1px solid var(--font-color-nav-divider);
-      color: var(--font-color-nav);
+      background: rgba(var(--blert-surface-dark-base), 0.4);
+      border: 1px solid var(--blert-divider-color);
+      color: var(--blert-font-color-secondary);
       transition: all 0.2s ease;
       white-space: nowrap;
 
@@ -61,28 +61,28 @@
       }
 
       &:hover {
-        background: var(--nav-bg);
-        border-color: var(--blert-button);
-        color: var(--blert-text-color);
+        background: var(--blert-surface-dark);
+        border-color: var(--blert-purple);
+        color: var(--blert-font-color-primary);
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
 
       &.active {
-        background: var(--nav-bg);
-        color: var(--blert-text-color);
-        border-color: var(--blert-button);
+        background: var(--blert-surface-dark);
+        color: var(--blert-font-color-primary);
+        border-color: var(--blert-purple);
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
 
       i {
         font-size: 0.9em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         transition: color 0.2s ease;
       }
     }
@@ -104,9 +104,9 @@
       padding: 6px 12px;
       border-radius: 6px;
       font-size: 0.9em;
-      background: rgba(var(--nav-bg-base), 0.4);
-      border: 1px solid var(--font-color-nav-divider);
-      color: var(--font-color-nav);
+      background: rgba(var(--blert-surface-dark-base), 0.4);
+      border: 1px solid var(--blert-divider-color);
+      color: var(--blert-font-color-secondary);
       transition: all 0.2s ease;
 
       @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -115,15 +115,15 @@
       }
 
       &:hover {
-        background: var(--nav-bg);
-        border-color: var(--blert-button);
-        color: var(--blert-text-color);
+        background: var(--blert-surface-dark);
+        border-color: var(--blert-purple);
+        color: var(--blert-font-color-primary);
       }
 
       &.active {
-        background: var(--nav-bg);
-        color: var(--blert-text-color);
-        border-color: var(--blert-button);
+        background: var(--blert-surface-dark);
+        color: var(--blert-font-color-primary);
+        border-color: var(--blert-purple);
       }
 
       i {
@@ -148,9 +148,9 @@
     padding: 6px 12px;
     border-radius: 6px;
     font-size: 0.9em;
-    background: rgba(var(--nav-bg-base), 0.4);
-    border: 1px solid var(--font-color-nav-divider);
-    color: var(--font-color-nav);
+    background: rgba(var(--blert-surface-dark-base), 0.4);
+    border: 1px solid var(--blert-divider-color);
+    color: var(--blert-font-color-secondary);
     transition: all 0.2s ease;
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -160,15 +160,15 @@
     }
 
     &:hover {
-      background: var(--nav-bg);
-      border-color: var(--blert-button);
-      color: var(--blert-text-color);
+      background: var(--blert-surface-dark);
+      border-color: var(--blert-purple);
+      color: var(--blert-font-color-primary);
     }
 
     &.active {
-      background: var(--nav-bg);
-      color: var(--blert-text-color);
-      border-color: var(--blert-button);
+      background: var(--blert-surface-dark);
+      color: var(--blert-font-color-primary);
+      border-color: var(--blert-purple);
     }
   }
 }
@@ -191,12 +191,12 @@
 
   .boardHeader {
     padding: 16px;
-    border-bottom: 1px solid var(--nav-bg);
+    border-bottom: 1px solid var(--blert-surface-dark);
 
     h3 {
       margin: 0;
       font-size: 1.2rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
   }
 }
@@ -215,7 +215,7 @@
     border-radius: 5px;
 
     &:hover {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
       transform: translateX(4px);
     }
 
@@ -226,7 +226,7 @@
       font-weight: 500;
       align-items: center;
       gap: 4px;
-      color: var(--blert-button);
+      color: var(--blert-purple);
 
       .medal {
         &.gold {
@@ -262,13 +262,13 @@
 
         .time {
           font-family: var(--font-roboto-mono);
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           width: 80px;
         }
 
         .date {
           font-size: 0.85rem;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           opacity: 0.8;
           font-variant-numeric: tabular-nums;
           white-space: nowrap;
@@ -277,7 +277,7 @@
 
       .party {
         font-size: 0.9rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
     }
   }

--- a/web/app/mixins.scss
+++ b/web/app/mixins.scss
@@ -1,6 +1,6 @@
 @mixin panel {
   display: flex;
-  background-color: var(--panel-bg);
+  background-color: var(--blert-panel-background-color);
   box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.5);
   border-radius: 5px;
 }
@@ -25,7 +25,7 @@
   }
 
   &::-webkit-scrollbar-thumb {
-    background: var(--font-color-nav);
+    background: var(--blert-font-color-secondary);
     border-radius: 4px;
   }
 }

--- a/web/app/network/components/network-controls-overlay.module.scss
+++ b/web/app/network/components/network-controls-overlay.module.scss
@@ -23,11 +23,11 @@
   padding: 12px 20px;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.95) 0%,
-    rgba(var(--nav-bg-base), 0.9) 100%
+    rgba(var(--blert-panel-background-color-base), 0.95) 0%,
+    rgba(var(--blert-surface-dark-base), 0.9) 100%
   );
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 8px 8px 0 0;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
@@ -47,14 +47,14 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.6),
+      rgba(var(--blert-purple-base), 0.6),
       transparent
     );
     animation: borderShimmer 3s ease-in-out infinite;
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.25);
+    border-color: rgba(var(--blert-purple-base), 0.25);
     box-shadow:
       0 12px 40px rgba(0, 0, 0, 0.5),
       0 4px 12px rgba(0, 0, 0, 0.3),
@@ -107,13 +107,13 @@
   flex-shrink: 0;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1.1rem;
   }
 
   .title {
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.95rem;
   }
 
@@ -142,22 +142,22 @@
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
-  background: rgba(var(--nav-bg-base), 0.6);
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  background: rgba(var(--blert-surface-dark-base), 0.6);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   border-radius: 6px;
   font-size: 0.85rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   white-space: nowrap;
   transition: all 0.2s ease;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.8rem;
   }
 
   &:hover {
-    background: rgba(var(--nav-bg-lightened-base), 0.8);
-    border-color: rgba(var(--blert-button-base), 0.2);
+    background: rgba(var(--blert-surface-light-base), 0.8);
+    border-color: rgba(var(--blert-purple-base), 0.2);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -225,11 +225,11 @@
   align-items: center;
   gap: 4px;
   font-size: 0.85rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-weight: 500;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.75rem;
   }
 
@@ -244,16 +244,16 @@
   justify-content: center;
   width: 36px;
   height: 36px;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 8px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover:not(:disabled) {
-    background: rgba(var(--blert-button-base), 0.2);
-    border-color: rgba(var(--blert-button-base), 0.4);
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.4);
     transform: translateY(-1px);
   }
 
@@ -279,17 +279,17 @@
   justify-content: center;
   width: 36px;
   height: 36px;
-  background: rgba(var(--nav-bg-base), 0.8);
-  border: 1px solid rgba(var(--blert-button-base), 0.15);
+  background: rgba(var(--blert-surface-dark-base), 0.8);
+  border: 1px solid rgba(var(--blert-purple-base), 0.15);
   border-radius: 8px;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-lightened-base), 0.9);
-    border-color: rgba(var(--blert-button-base), 0.3);
-    color: var(--blert-button);
+    background: rgba(var(--blert-surface-light-base), 0.9);
+    border-color: rgba(var(--blert-purple-base), 0.3);
+    color: var(--blert-purple);
     transform: translateY(-1px);
   }
 
@@ -309,11 +309,11 @@
   padding: 24px;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.98) 0%,
-    rgba(var(--nav-bg-base), 0.95) 100%
+    rgba(var(--blert-panel-background-color-base), 0.98) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
   );
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-top: none;
   border-radius: 0 0 12px 12px;
   box-shadow:
@@ -361,7 +361,7 @@
   display: block;
   font-size: 0.9rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin-bottom: 12px;
 
   &.focusLabel {
@@ -382,7 +382,7 @@
     justify-content: center;
     width: 42px;
     height: 42px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     border: none;
     border-radius: 6px;
     color: white;
@@ -391,7 +391,7 @@
     flex-shrink: 0;
 
     &:hover:not(:disabled) {
-      background: rgba(var(--blert-button-base), 0.8);
+      background: rgba(var(--blert-purple-base), 0.8);
       transform: translateY(-1px);
     }
 
@@ -422,7 +422,7 @@
   .slider {
     width: 100%;
     height: 6px;
-    background: rgba(var(--blert-button-base), 0.2);
+    background: rgba(var(--blert-purple-base), 0.2);
     border-radius: 3px;
     outline: none;
     margin: 8px 0;
@@ -433,7 +433,7 @@
       appearance: none;
       width: 18px;
       height: 18px;
-      background: var(--blert-button);
+      background: var(--blert-purple);
       border-radius: 50%;
       cursor: pointer;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
@@ -448,7 +448,7 @@
     &::-moz-range-thumb {
       width: 18px;
       height: 18px;
-      background: var(--blert-button);
+      background: var(--blert-purple);
       border: none;
       border-radius: 50%;
       cursor: pointer;
@@ -466,7 +466,7 @@
     display: flex;
     justify-content: space-between;
     font-size: 0.8rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-top: 4px;
   }
 }

--- a/web/app/network/components/network-graph.module.scss
+++ b/web/app/network/components/network-graph.module.scss
@@ -12,22 +12,22 @@
   }
 
   :global(.sigma-control) {
-    background: rgba(var(--panel-bg-base), 0.9) !important;
-    border: 1px solid rgba(var(--blert-button-base), 0.3) !important;
+    background: rgba(var(--blert-panel-background-color-base), 0.9) !important;
+    border: 1px solid rgba(var(--blert-purple-base), 0.3) !important;
     border-radius: 6px !important;
-    color: var(--blert-button) !important;
+    color: var(--blert-purple) !important;
     backdrop-filter: blur(8px);
     transition: all 0.2s ease !important;
 
     &:hover {
-      background: rgba(var(--panel-bg-base), 1) !important;
-      border-color: rgba(var(--blert-button-base), 0.5) !important;
+      background: rgba(var(--blert-panel-background-color-base), 1) !important;
+      border-color: rgba(var(--blert-purple-base), 0.5) !important;
       transform: translateY(-1px) !important;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3) !important;
     }
 
     svg {
-      fill: var(--blert-button) !important;
+      fill: var(--blert-purple) !important;
     }
   }
 
@@ -41,8 +41,8 @@
   min-height: 400px;
   border-radius: 8px;
   overflow: hidden;
-  background: var(--nav-bg);
-  border: 1px solid var(--nav-bg-lightened);
+  background: var(--blert-surface-dark);
+  border: 1px solid var(--blert-surface-light);
   position: relative;
   padding-top: 70px; // Space for collapsed filter bar
 
@@ -59,7 +59,7 @@
   align-items: center;
   justify-content: center;
   height: 400px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: center;
   gap: 16px;
 
@@ -71,21 +71,21 @@
 
 .loadingSpinner i {
   font-size: 2rem;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   margin-bottom: 8px;
 }
 
 .emptyState {
   i {
     font-size: 3rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.6;
     margin-bottom: 8px;
   }
 
   h3 {
     margin: 0 0 8px 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 1.25rem;
   }
 
@@ -102,7 +102,7 @@
   gap: 16px;
   margin-top: 12px;
   padding-top: 12px;
-  border-top: 1px solid var(--nav-bg-lightened);
+  border-top: 1px solid var(--blert-surface-light);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     flex-wrap: wrap;
@@ -115,7 +115,7 @@
   align-items: center;
   gap: 6px;
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   .legendColor {
     width: 12px;
@@ -129,10 +129,10 @@
   position: absolute;
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.95) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 8px;
   padding: 12px;
   z-index: 1000;
@@ -150,10 +150,10 @@
     gap: 6px;
     font-size: 0.8rem;
     font-weight: 600;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     margin-bottom: 8px;
     padding-bottom: 6px;
-    border-bottom: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
+    border-bottom: 1px solid rgba(var(--blert-surface-light-base), 0.6);
 
     i {
       font-size: 0.75rem;
@@ -174,7 +174,7 @@
 
     .playerName {
       font-weight: 500;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -183,7 +183,7 @@
     }
 
     i {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.7rem;
       flex-shrink: 0;
     }
@@ -194,10 +194,10 @@
     align-items: center;
     gap: 6px;
     font-size: 0.8rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.75rem;
       width: 12px;
       text-align: center;
@@ -241,21 +241,21 @@
   padding: 8px 12px;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.95) 0%,
-    rgba(var(--nav-bg-base), 0.9) 100%
+    rgba(var(--blert-panel-background-color-base), 0.95) 0%,
+    rgba(var(--blert-surface-dark-base), 0.9) 100%
   );
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 6px;
   box-shadow:
     0 4px 16px rgba(0, 0, 0, 0.3),
     0 2px 4px rgba(0, 0, 0, 0.1);
   animation: fadeInTooltip 0.2s ease-out;
   font-size: 0.85rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.8rem;
   }
 

--- a/web/app/network/components/network-info.module.scss
+++ b/web/app/network/components/network-info.module.scss
@@ -52,10 +52,10 @@
 .infoCard {
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.95) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.4),
     0 2px 8px rgba(0, 0, 0, 0.2);
@@ -79,7 +79,7 @@
   gap: 12px;
   margin-bottom: 16px;
   padding-bottom: 12px;
-  border-bottom: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
+  border-bottom: 1px solid rgba(var(--blert-surface-light-base), 0.6);
 }
 
 .playerInfo {
@@ -93,11 +93,11 @@
     margin: 0 0 8px 0;
     font-size: 1.2rem;
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     word-break: break-word;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1rem;
       flex-shrink: 0;
     }
@@ -108,10 +108,10 @@
     align-items: center;
     gap: 6px;
     font-size: 0.85rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.8rem;
       width: 12px;
       text-align: center;
@@ -154,13 +154,13 @@
 }
 
 .focusButton {
-  background: rgba(var(--blert-button-base), 0.1);
-  border-color: rgba(var(--blert-button-base), 0.3);
-  color: var(--blert-button);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border-color: rgba(var(--blert-purple-base), 0.3);
+  color: var(--blert-purple);
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.2);
-    border-color: rgba(var(--blert-button-base), 0.5);
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.5);
   }
 }
 
@@ -191,18 +191,18 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 6px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   text-decoration: none;
   font-size: 0.9rem;
   font-weight: 500;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.2);
-    border-color: rgba(var(--blert-button-base), 0.5);
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.5);
   }
 
   i {
@@ -218,10 +218,10 @@
     margin: 0 0 12px 0;
     font-size: 1rem;
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.9rem;
       width: 14px;
       text-align: center;
@@ -241,14 +241,14 @@
   align-items: center;
   gap: 8px;
   padding: 8px;
-  background: rgba(var(--nav-bg-base), 0.6);
-  border: 1px solid rgba(var(--font-color-nav-divider), 0.3);
+  background: rgba(var(--blert-surface-dark-base), 0.6);
+  border: 1px solid rgba(var(--blert-divider-color), 0.3);
   border-radius: 6px;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-lightened-base), 0.7);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background: rgba(var(--blert-surface-light-base), 0.7);
+    border-color: rgba(var(--blert-purple-base), 0.3);
   }
 }
 
@@ -259,7 +259,7 @@
   min-width: 0;
 
   &:hover .neighborName {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -272,7 +272,7 @@
   .neighborName {
     font-size: 0.9rem;
     font-weight: 500;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     transition: color 0.2s ease;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -281,7 +281,7 @@
 
   .neighborCount {
     font-size: 0.75rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-variant-numeric: tabular-nums;
   }
 }
@@ -292,18 +292,18 @@
   justify-content: center;
   width: 24px;
   height: 24px;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 4px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   cursor: pointer;
   transition: all 0.2s ease;
   flex-shrink: 0;
   position: relative;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.2);
-    border-color: rgba(var(--blert-button-base), 0.5);
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.5);
     transform: scale(1.1);
   }
 
@@ -320,10 +320,10 @@
   justify-content: center;
   gap: 8px;
   padding: 8px 12px;
-  background: rgba(var(--nav-bg-base), 0.4);
-  border: 1px dashed rgba(var(--font-color-nav-divider), 0.5);
+  background: rgba(var(--blert-surface-dark-base), 0.4);
+  border: 1px dashed rgba(var(--blert-divider-color), 0.5);
   border-radius: 6px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.8rem;
   font-style: italic;
 
@@ -339,7 +339,7 @@
   justify-content: center;
   padding: 24px 16px;
   text-align: center;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   gap: 8px;
 
   i {

--- a/web/app/network/network-content.module.scss
+++ b/web/app/network/network-content.module.scss
@@ -26,7 +26,7 @@
   .errorContent {
     text-align: center;
     padding: 48px;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     border: 1px solid rgba(var(--blert-red-base), 0.2);
     border-radius: 12px;
     max-width: 400px;
@@ -39,13 +39,13 @@
 
     h3 {
       margin: 0 0 12px 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 1.5rem;
     }
 
     p {
       margin: 0 0 24px 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       line-height: 1.5;
     }
 
@@ -54,18 +54,18 @@
       align-items: center;
       gap: 8px;
       padding: 12px 24px;
-      background: rgba(var(--blert-button-base), 0.1);
-      border: 1px solid rgba(var(--blert-button-base), 0.3);
+      background: rgba(var(--blert-purple-base), 0.1);
+      border: 1px solid rgba(var(--blert-purple-base), 0.3);
       border-radius: 8px;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-weight: 500;
       cursor: pointer;
       transition: all 0.2s ease;
       margin: 0 auto;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.2);
-        border-color: rgba(var(--blert-button-base), 0.5);
+        background: rgba(var(--blert-purple-base), 0.2);
+        border-color: rgba(var(--blert-purple-base), 0.5);
         transform: translateY(-2px);
       }
 

--- a/web/app/network/style.module.scss
+++ b/web/app/network/style.module.scss
@@ -23,7 +23,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      var(--blert-button),
+      var(--blert-purple),
       transparent
     );
     animation: borderShimmer 3s ease-in-out infinite;
@@ -64,10 +64,14 @@
     justify-content: center;
     width: 64px;
     height: 64px;
-    background: linear-gradient(145deg, var(--nav-bg), var(--nav-bg-lightened));
-    border: 2px solid rgba(var(--blert-button-base), 0.3);
+    background: linear-gradient(
+      145deg,
+      var(--blert-surface-dark),
+      var(--blert-surface-light)
+    );
+    border: 2px solid rgba(var(--blert-purple-base), 0.3);
     border-radius: 16px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 28px;
     flex-shrink: 0;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
@@ -75,7 +79,7 @@
 
     &:hover {
       transform: translateY(-2px);
-      border-color: rgba(var(--blert-button-base), 0.5);
+      border-color: rgba(var(--blert-purple-base), 0.5);
       box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
     }
 
@@ -103,7 +107,7 @@
 
     p {
       font-size: 1rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       margin: 0;
       line-height: 1.5;
 
@@ -136,14 +140,14 @@
 
   .skeletonControls {
     height: 80px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 8px;
     animation: pulse 1.5s ease-in-out infinite;
   }
 
   .skeletonGraph {
     flex: 1;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 8px;
     animation: pulse 1.5s ease-in-out infinite;
     animation-delay: 0.2s;

--- a/web/app/not-found.module.scss
+++ b/web/app/not-found.module.scss
@@ -27,7 +27,7 @@
       font-size: 64px;
       font-weight: 700;
       margin: 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     }
 
@@ -35,14 +35,14 @@
       font-size: 24px;
       font-weight: 600;
       margin: 8px 0 24px;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     p {
       font-size: 16px;
       line-height: 1.6;
       margin: 0 0 32px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
 
     .homeButton {
@@ -50,7 +50,7 @@
       align-items: center;
       gap: 8px;
       padding: 12px 24px;
-      background-color: var(--blert-button);
+      background-color: var(--blert-purple);
       color: #fff;
       text-decoration: none;
       border-radius: 4px;
@@ -58,7 +58,7 @@
       transition: background-color 0.2s ease;
 
       &:hover {
-        background-color: rgba(var(--blert-button-base), 0.8);
+        background-color: rgba(var(--blert-purple-base), 0.8);
       }
 
       i {

--- a/web/app/players/[username]/overview-content.tsx
+++ b/web/app/players/[username]/overview-content.tsx
@@ -30,7 +30,7 @@ const ACTIVITY_THRESHOLDS = [
   { threshold: 0.25, color: '#2c2f5a' },
   { threshold: 0.5, color: '#3b4286' },
   { threshold: 0.75, color: '#4a55b2' },
-  { threshold: 1, color: 'var(--blert-button)' },
+  { threshold: 1, color: 'var(--blert-purple)' },
 ] as const;
 
 const HEATMAP_TOOLTIP_ID = 'calendar-heatmap-tooltip';
@@ -632,7 +632,7 @@ export default function PlayerOverviewContent({
                         innerRadius="100%"
                         startAngle={180}
                         endAngle={0}
-                        stroke="var(--nav-bg)"
+                        stroke="var(--blert-surface-dark)"
                       >
                         {statuses.map((v, i) => (
                           <Cell key={`cell-${i}`} fill={v.color} />
@@ -682,7 +682,7 @@ export default function PlayerOverviewContent({
                         innerRadius="100%"
                         startAngle={180}
                         endAngle={0}
-                        stroke="var(--nav-bg)"
+                        stroke="var(--blert-surface-dark)"
                       >
                         {scales.map((v, i) => (
                           <Cell key={`cell-${i}`} fill={v.color} />

--- a/web/app/players/[username]/personal-bests/style.module.scss
+++ b/web/app/players/[username]/personal-bests/style.module.scss
@@ -59,9 +59,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     border-radius: 8px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
 
     svg {
       position: relative;
@@ -84,7 +84,7 @@
     p {
       font-size: 13px;
       margin: 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       line-height: 1.3;
     }
   }
@@ -116,10 +116,10 @@
 .achievementCard {
   background: linear-gradient(
     135deg,
-    var(--nav-bg) 0%,
-    var(--nav-bg-lightened) 100%
+    var(--blert-surface-dark) 0%,
+    var(--blert-surface-light) 100%
   );
-  border: 1px solid var(--nav-bg-lightened);
+  border: 1px solid var(--blert-surface-light);
   border-radius: 8px;
   padding: 16px;
   display: flex;
@@ -133,15 +133,15 @@
 
     &:hover {
       transform: translateY(-2px);
-      border-color: var(--blert-button);
+      border-color: var(--blert-purple);
       background: linear-gradient(
         135deg,
-        var(--nav-bg-lightened) 0%,
-        rgba(var(--blert-button-base), 0.1) 100%
+        var(--blert-surface-light) 0%,
+        rgba(var(--blert-purple-base), 0.1) 100%
       );
 
       .achievementValue {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -153,9 +153,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(var(--blert-button-base), 0.1);
+    background: rgba(var(--blert-purple-base), 0.1);
     border-radius: 8px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     flex-shrink: 0;
   }
 
@@ -166,7 +166,7 @@
       font-size: 0.8rem;
       font-weight: 500;
       margin-bottom: 2px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
 
     .achievementValue {
@@ -179,14 +179,14 @@
 
     .achievementDate {
       font-size: 0.7rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
   }
 }
 
 .pbCard {
-  background: var(--nav-bg);
-  border: 1px solid var(--nav-bg-lightened);
+  background: var(--blert-surface-dark);
+  border: 1px solid var(--blert-surface-light);
   border-radius: 6px;
   padding: 12px;
   display: flex;
@@ -195,18 +195,18 @@
   text-align: center;
   transition: all 0.2s ease;
   text-decoration: none;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   &.hasTime {
     cursor: pointer;
 
     &:hover {
       transform: translateY(-2px);
-      border-color: var(--blert-button);
-      background: var(--nav-bg-lightened);
+      border-color: var(--blert-purple);
+      background: var(--blert-surface-light);
 
       .pbTime {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -215,7 +215,7 @@
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 4px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .pbTime {
@@ -228,7 +228,7 @@
 
   .pbDate {
     font-size: 11px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 

--- a/web/app/players/[username]/statistics/page.tsx
+++ b/web/app/players/[username]/statistics/page.tsx
@@ -225,10 +225,10 @@ export default function PlayerStatistics() {
                     tickFormatter={(date: string) =>
                       new Date(date).toLocaleDateString()
                     }
-                    stroke="var(--font-color-nav)"
+                    stroke="var(--blert-font-color-secondary)"
                     dy={5}
                   />
-                  <YAxis stroke="var(--font-color-nav)" />
+                  <YAxis stroke="var(--blert-font-color-secondary)" />
                   {selectedStats.map((stat, index) => (
                     <Line
                       key={stat.key}
@@ -241,15 +241,15 @@ export default function PlayerStatistics() {
                   <Tooltip
                     cursor={false}
                     contentStyle={{
-                      backgroundColor: 'var(--nav-bg)',
-                      borderColor: 'var(--font-color-nav-divider)',
+                      backgroundColor: 'var(--blert-surface-dark)',
+                      borderColor: 'var(--blert-divider-color)',
                       borderRadius: '4px',
                     }}
                     labelFormatter={(date: string) => (
                       <span
                         style={{
                           display: 'block',
-                          color: 'var(--blert-text-color)',
+                          color: 'var(--blert-font-color-primary)',
                           fontWeight: 500,
                           marginBottom: 8,
                         }}

--- a/web/app/players/[username]/style.module.scss
+++ b/web/app/players/[username]/style.module.scss
@@ -31,8 +31,8 @@ $NAV_MARGIN: 10px;
   padding: 24px;
   background: linear-gradient(
     to bottom right,
-    var(--panel-bg),
-    var(--nav-bg-lightened)
+    var(--blert-panel-background-color),
+    var(--blert-surface-light)
   );
 
   .playerImgWrapper {
@@ -42,7 +42,7 @@ $NAV_MARGIN: 10px;
     flex-shrink: 0;
     border-radius: 8px;
     overflow: hidden;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
   }
 
   .playerInfoText {
@@ -52,7 +52,7 @@ $NAV_MARGIN: 10px;
     h1 {
       font-size: 2.4em;
       margin: 0 0 16px 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .playerStats {
@@ -69,7 +69,7 @@ $NAV_MARGIN: 10px;
           display: flex;
           align-items: center;
           gap: 8px;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           font-size: 0.85em;
 
           i {
@@ -82,7 +82,7 @@ $NAV_MARGIN: 10px;
         .value {
           font-size: 1.2em;
           font-weight: 500;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
         }
       }
     }
@@ -94,7 +94,7 @@ $NAV_MARGIN: 10px;
   display: flex;
   align-items: center;
   height: $NAV_HEIGHT;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 0 0 8px 8px;
 
   .tabs {
@@ -109,7 +109,7 @@ $NAV_MARGIN: 10px;
     align-items: center;
     justify-content: center;
     gap: 12px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     text-decoration: none;
     font-size: 15px;
     transition: color 0.2s ease;
@@ -117,18 +117,18 @@ $NAV_MARGIN: 10px;
     z-index: 1;
 
     &:hover {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       .icon {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 
     &.active {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       .icon {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 
@@ -143,7 +143,7 @@ $NAV_MARGIN: 10px;
     bottom: 0;
     left: 0;
     height: 2px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     transition:
       transform 0.2s ease,
       width 0.2s ease,
@@ -255,7 +255,7 @@ $NAV_MARGIN: 10px;
 
   .filters {
     width: 260px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .pbTables {
@@ -274,7 +274,7 @@ $NAV_MARGIN: 10px;
         text-align: center;
         font-weight: 500;
         margin: 0 0 8px 0;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         font-size: 1.1em;
       }
 
@@ -287,10 +287,10 @@ $NAV_MARGIN: 10px;
         width: 100%;
 
         a.pb:hover {
-          color: var(--blert-button);
+          color: var(--blert-purple);
 
           .time {
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
 
@@ -305,14 +305,14 @@ $NAV_MARGIN: 10px;
           .time {
             font-size: 24px;
             font-weight: 700;
-            color: var(--blert-text-color);
+            color: var(--blert-font-color-primary);
             transition: color 0.2s ease-in-out;
           }
 
           .scale {
             font-size: 18px;
             font-weight: 500;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
           }
         }
       }
@@ -354,14 +354,14 @@ $NAV_MARGIN: 10px;
         h3 {
           font-size: 1.1em;
           margin: 0 0 12px;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           display: flex;
           align-items: center;
           font-weight: 500;
           gap: 8px;
 
           i {
-            color: var(--blert-button);
+            color: var(--blert-purple);
             font-size: 0.9em;
           }
         }
@@ -371,13 +371,13 @@ $NAV_MARGIN: 10px;
           flex-direction: column;
           align-items: center;
           justify-content: center;
-          background: var(--nav-bg);
+          background: var(--blert-surface-dark);
           border-radius: 6px;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           font-style: italic;
           font-size: 0.9em;
           padding: 16px;
-          border: 1px dashed var(--font-color-nav-divider);
+          border: 1px dashed var(--blert-divider-color);
           gap: 8px;
           text-align: center;
 
@@ -405,15 +405,15 @@ $NAV_MARGIN: 10px;
         align-items: center;
         justify-content: space-between;
         padding: 12px;
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
         border-radius: 6px;
         transition: all 0.2s ease;
         text-decoration: none;
         border: 1px solid transparent;
 
         &:hover {
-          background: var(--nav-bg-lightened);
-          border-color: rgba(var(--blert-button-base), 0.3);
+          background: var(--blert-surface-light);
+          border-color: rgba(var(--blert-purple-base), 0.3);
           transform: translateY(-1px);
         }
 
@@ -425,7 +425,7 @@ $NAV_MARGIN: 10px;
 
           .partnerName {
             font-weight: 500;
-            color: var(--blert-text-color);
+            color: var(--blert-font-color-primary);
             font-size: 1em;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -434,7 +434,7 @@ $NAV_MARGIN: 10px;
 
           .partnerMeta {
             font-size: 0.8em;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
             display: flex;
             align-items: center;
             gap: 8px;
@@ -445,7 +445,7 @@ $NAV_MARGIN: 10px;
               gap: 4px;
 
               i {
-                color: var(--blert-button);
+                color: var(--blert-purple);
                 font-size: 0.9em;
               }
             }
@@ -453,13 +453,13 @@ $NAV_MARGIN: 10px;
         }
 
         .arrow {
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           transition: all 0.2s ease;
           font-size: 0.8em;
         }
 
         &:hover .arrow {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           transform: translateX(2px);
         }
       }
@@ -471,12 +471,12 @@ $NAV_MARGIN: 10px;
       align-items: center;
       justify-content: center;
       padding: 24px 16px;
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
       border-radius: 6px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       text-align: center;
       gap: 8px;
-      border: 1px dashed var(--font-color-nav-divider);
+      border: 1px dashed var(--blert-divider-color);
 
       i {
         font-size: 1.4em;
@@ -642,7 +642,7 @@ $NAV_MARGIN: 10px;
 
   .calendarTooltip {
     position: fixed;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 6px;
     padding: 8px 12px;
@@ -665,7 +665,7 @@ $NAV_MARGIN: 10px;
       height: 0;
       border-left: 5px solid transparent;
       border-right: 5px solid transparent;
-      border-top: 5px solid var(--nav-bg);
+      border-top: 5px solid var(--blert-surface-dark);
     }
 
     .date {
@@ -690,7 +690,7 @@ $NAV_MARGIN: 10px;
   .date {
     font-size: 14px;
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .challengeCount {
@@ -698,10 +698,10 @@ $NAV_MARGIN: 10px;
     align-items: center;
     gap: 8px;
     font-size: 13px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
-      color: rgba(var(--blert-button-base), 0.8);
+      color: rgba(var(--blert-purple-base), 0.8);
       font-size: 14px;
       width: 16px;
       text-align: center;
@@ -738,7 +738,7 @@ $NAV_MARGIN: 10px;
 
     i {
       font-size: 0.9em;
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 
@@ -747,7 +747,7 @@ $NAV_MARGIN: 10px;
     flex-direction: column;
     padding: 0;
     gap: 0;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     margin-bottom: 16px;
 
@@ -756,7 +756,7 @@ $NAV_MARGIN: 10px;
       align-items: center;
       justify-content: space-between;
       padding: 16px;
-      border-bottom: 1px solid var(--nav-bg-lightened);
+      border-bottom: 1px solid var(--blert-surface-light);
 
       &:last-child {
         border-bottom: none;
@@ -771,7 +771,7 @@ $NAV_MARGIN: 10px;
 
         .oldName,
         .newName {
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           overflow: hidden;
           text-overflow: ellipsis;
           white-space: nowrap;
@@ -780,14 +780,14 @@ $NAV_MARGIN: 10px;
         i {
           position: relative;
           top: 1px;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           font-size: 0.9em;
         }
       }
 
       .date {
         font-size: 0.85em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         margin-left: 12px;
       }
     }
@@ -826,14 +826,14 @@ $NAV_MARGIN: 10px;
   .selectedStat {
     position: relative;
     align-items: center;
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
     border-radius: 4px;
     display: flex;
     font-size: 0.9rem;
     gap: 0.5rem;
     padding: 0.25rem 0.5rem;
     transition: all 0.2s ease-in-out;
-    border: 1px solid var(--font-color-nav-divider);
+    border: 1px solid var(--blert-divider-color);
 
     i {
       position: relative;
@@ -843,18 +843,18 @@ $NAV_MARGIN: 10px;
 
     &:hover {
       cursor: pointer;
-      background: var(--nav-bg-lightened);
-      border-color: var(--blert-button);
+      background: var(--blert-surface-light);
+      border-color: var(--blert-purple);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
 }
 
 .legendItem {
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.8rem;
 }
 
@@ -886,36 +886,36 @@ $NAV_MARGIN: 10px;
     justify-content: center;
     gap: 12px;
     padding-bottom: 16px;
-    border-bottom: 1px solid var(--nav-bg-lightened);
+    border-bottom: 1px solid var(--blert-surface-light);
     font-weight: 500;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1.1em;
     }
 
     .statCounter {
       font-size: 0.8em;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       margin-left: auto;
     }
 
     .addStatButton {
       background: none;
       border: none;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       cursor: pointer;
       padding: 4px;
       border-radius: 4px;
       transition: all 0.2s ease;
 
       &:hover:not(.disabled) {
-        background: var(--nav-bg-lightened);
+        background: var(--blert-surface-light);
       }
 
       &.disabled {
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         cursor: not-allowed;
         opacity: 0.7;
       }

--- a/web/app/search/style.module.scss
+++ b/web/app/search/style.module.scss
@@ -18,7 +18,7 @@
 
   p {
     margin-bottom: 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -40,13 +40,13 @@
 
       .totalCount {
         font-size: 0.9em;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-weight: 500;
       }
 
       i {
         font-size: 0.9em;
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -68,22 +68,22 @@
     gap: 10px;
     padding: 32px 16px;
     margin-top: 8px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 8px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     text-align: center;
-    border: 1px solid rgba(var(--blert-button-base), 0.12);
+    border: 1px solid rgba(var(--blert-purple-base), 0.12);
 
     i {
       font-size: 20px;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       opacity: 0.9;
     }
 
     .title {
       margin: 0;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .hint {
@@ -99,9 +99,9 @@
       button {
         padding: 8px 12px;
         border-radius: 6px;
-        background: rgba(var(--blert-button-base), 0.1);
-        border: 1px solid rgba(var(--blert-button-base), 0.2);
-        color: var(--blert-button);
+        background: rgba(var(--blert-purple-base), 0.1);
+        border: 1px solid rgba(var(--blert-purple-base), 0.2);
+        color: var(--blert-purple);
         transition: all 0.2s ease;
         display: flex;
         align-items: center;
@@ -110,7 +110,7 @@
 
         &:hover {
           cursor: pointer;
-          background: rgba(var(--blert-button-base), 0.2);
+          background: rgba(var(--blert-purple-base), 0.2);
           transform: translateY(-1px);
         }
 
@@ -126,7 +126,7 @@
 
   table.table {
     border-collapse: collapse;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       font-size: 14px;
@@ -139,7 +139,7 @@
       overflow-x: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+      border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
 
       i {
         margin-left: 8px;
@@ -150,16 +150,16 @@
       tr {
         background: linear-gradient(
           135deg,
-          rgba(var(--blert-button-base), 0.15) 0%,
-          rgba(var(--blert-button-base), 0.08) 100%
+          rgba(var(--blert-purple-base), 0.15) 0%,
+          rgba(var(--blert-purple-base), 0.08) 100%
         );
-        border-bottom: 2px solid rgba(var(--blert-button-base), 0.2);
+        border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
 
         th > span,
         th > button {
           font-size: inherit;
           font-weight: 600;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           transition: color 0.2s ease;
         }
 
@@ -174,7 +174,7 @@
           position: relative;
 
           &:hover {
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
 
           i {
@@ -182,7 +182,7 @@
             top: 1px;
             font-size: 0.9em;
             margin-left: 0;
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
       }
@@ -196,13 +196,13 @@
         button {
           padding: 8px;
           border-radius: 4px;
-          background: rgba(var(--blert-button-base), 0.1);
-          border: 1px solid rgba(var(--blert-button-base), 0.2);
-          color: var(--blert-button);
+          background: rgba(var(--blert-purple-base), 0.1);
+          border: 1px solid rgba(var(--blert-purple-base), 0.2);
+          color: var(--blert-purple);
           transition: all 0.2s ease;
 
           &:hover {
-            background: rgba(var(--blert-button-base), 0.2);
+            background: rgba(var(--blert-purple-base), 0.2);
             transform: translateY(-1px);
           }
         }
@@ -214,20 +214,20 @@
         transition: all 0.2s ease;
 
         &:not(.selectedChallenge):hover {
-          background: rgba(var(--blert-button-base), 0.08);
-          color: var(--blert-text-color);
+          background: rgba(var(--blert-purple-base), 0.08);
+          color: var(--blert-font-color-primary);
           transform: translateY(-1px);
         }
 
         &:nth-child(even) {
-          background-color: rgba(var(--nav-bg-base), 0.4);
+          background-color: rgba(var(--blert-surface-dark-base), 0.4);
         }
 
         &.selectedChallenge {
           background: linear-gradient(
             135deg,
-            rgba(var(--blert-button-base), 0.2) 0%,
-            rgba(var(--blert-button-base), 0.1) 100%
+            rgba(var(--blert-purple-base), 0.2) 0%,
+            rgba(var(--blert-purple-base), 0.1) 100%
           );
         }
       }
@@ -237,8 +237,8 @@
   .contextMenu {
     position: fixed;
     z-index: 1000;
-    background-color: var(--panel-bg);
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    background-color: var(--blert-panel-background-color);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 8px;
     display: flex;
     flex-direction: column;
@@ -262,13 +262,13 @@
       &.info {
         height: auto;
         pointer-events: none;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       &:not(.inactive):hover {
-        background: rgba(var(--blert-button-base), 0.1);
+        background: rgba(var(--blert-purple-base), 0.1);
         cursor: pointer;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
 
@@ -276,22 +276,22 @@
       width: calc(100% - 16px);
       height: 1px;
       margin: 0 auto;
-      background-color: rgba(var(--blert-button-base), 0.1);
+      background-color: rgba(var(--blert-purple-base), 0.1);
     }
   }
 
   .id {
     font-family: var(--font-roboto-mono), monospace;
     font-size: 14px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-weight: 500;
     padding: 4px 8px;
     border-radius: 4px;
-    background: rgba(var(--blert-button-base), 0.1);
+    background: rgba(var(--blert-purple-base), 0.1);
     transition: all 0.2s ease;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.2);
+      background: rgba(var(--blert-purple-base), 0.2);
       transform: translateY(-1px);
     }
   }
@@ -313,9 +313,9 @@
         width: 36px;
         height: 36px;
         border-radius: 6px;
-        background: rgba(var(--blert-button-base), 0.1);
-        border: 1px solid rgba(var(--blert-button-base), 0.2);
-        color: var(--blert-button);
+        background: rgba(var(--blert-purple-base), 0.1);
+        border: 1px solid rgba(var(--blert-purple-base), 0.2);
+        color: var(--blert-purple);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -328,7 +328,7 @@
         }
 
         &:not(:disabled):hover {
-          background: rgba(var(--blert-button-base), 0.2);
+          background: rgba(var(--blert-purple-base), 0.2);
           transform: translateY(-1px);
         }
       }
@@ -337,7 +337,7 @@
         margin: 0 16px;
         width: 150px;
         text-align: center;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         font-weight: 500;
       }
     }
@@ -361,7 +361,7 @@
     .action {
       margin-left: auto;
       font-size: 0.8em;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       transition: opacity 0.2s ease;
 
       &:hover {
@@ -410,9 +410,9 @@
       padding: 8px 12px;
       border-radius: 6px;
       cursor: pointer;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 16px;
-      border: 1px solid rgba(var(--blert-button-base), 0.1);
+      border: 1px solid rgba(var(--blert-purple-base), 0.1);
       transition: all 0.2s ease;
 
       &:disabled {
@@ -421,8 +421,8 @@
       }
 
       &:not(:disabled):hover {
-        background: rgba(var(--blert-button-base), 0.1);
-        border-color: rgba(var(--blert-button-base), 0.2);
+        background: rgba(var(--blert-purple-base), 0.1);
+        border-color: rgba(var(--blert-purple-base), 0.2);
       }
     }
   }
@@ -451,7 +451,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.2),
+      rgba(var(--blert-purple-base), 0.2),
       transparent
     );
   }
@@ -477,9 +477,9 @@
         .action {
           padding: 8px 16px;
           border-radius: 6px;
-          background: rgba(var(--blert-button-base), 0.1);
-          border: 1px solid rgba(var(--blert-button-base), 0.2);
-          color: var(--blert-button);
+          background: rgba(var(--blert-purple-base), 0.1);
+          border: 1px solid rgba(var(--blert-purple-base), 0.2);
+          color: var(--blert-purple);
           font-weight: 500;
           transition: all 0.2s ease;
 
@@ -488,7 +488,7 @@
           }
 
           &:not(:disabled):hover {
-            background: rgba(var(--blert-button-base), 0.2);
+            background: rgba(var(--blert-purple-base), 0.2);
           }
         }
       }
@@ -508,12 +508,12 @@
         button.remove {
           margin-left: 12px;
           font-size: 18px;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           transition: color 0.2s ease;
 
           &:hover {
             cursor: pointer;
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
       }
@@ -536,16 +536,16 @@
     align-items: center;
     justify-content: space-between;
     padding: 20px 24px;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.08) 0%,
-      rgba(var(--blert-button-base), 0.03) 100%
+      rgba(var(--blert-purple-base), 0.08) 0%,
+      rgba(var(--blert-purple-base), 0.03) 100%
     );
 
     h2 {
       margin: 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 600;
       font-size: 1.3em;
     }
@@ -554,17 +554,17 @@
       width: 32px;
       height: 32px;
       border-radius: 6px;
-      background: rgba(var(--blert-button-base), 0.1);
-      border: 1px solid rgba(var(--blert-button-base), 0.2);
-      color: var(--font-color-nav);
+      background: rgba(var(--blert-purple-base), 0.1);
+      border: 1px solid rgba(var(--blert-purple-base), 0.2);
+      color: var(--blert-font-color-secondary);
       display: flex;
       align-items: center;
       justify-content: center;
       transition: all 0.2s ease;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.2);
-        color: var(--blert-text-color);
+        background: rgba(var(--blert-purple-base), 0.2);
+        color: var(--blert-font-color-primary);
         transform: scale(1.05);
       }
     }
@@ -572,7 +572,7 @@
 
   .searchWrapper {
     padding: 16px 24px;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
 
     .searchInput {
       position: relative;
@@ -582,7 +582,7 @@
       & > i:first-child {
         position: absolute;
         left: 12px;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-size: 0.9em;
         z-index: 1;
       }
@@ -590,22 +590,22 @@
       input {
         width: 100%;
         padding: 12px 16px 12px 40px;
-        border: 1px solid rgba(var(--blert-button-base), 0.2);
+        border: 1px solid rgba(var(--blert-purple-base), 0.2);
         border-radius: 8px;
-        background: rgba(var(--nav-bg-base), 0.3);
-        color: var(--blert-text-color);
+        background: rgba(var(--blert-surface-dark-base), 0.3);
+        color: var(--blert-font-color-primary);
         font-size: 1rem;
         transition: all 0.2s ease;
 
         &:focus {
           outline: none;
-          border-color: var(--blert-button);
-          background: rgba(var(--nav-bg-base), 0.5);
-          box-shadow: 0 0 0 3px rgba(var(--blert-button-base), 0.1);
+          border-color: var(--blert-purple);
+          background: rgba(var(--blert-surface-dark-base), 0.5);
+          box-shadow: 0 0 0 3px rgba(var(--blert-purple-base), 0.1);
         }
 
         &::placeholder {
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
         }
       }
 
@@ -615,17 +615,17 @@
         width: 24px;
         height: 24px;
         border-radius: 4px;
-        background: rgba(var(--blert-button-base), 0.1);
+        background: rgba(var(--blert-purple-base), 0.1);
         border: none;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         display: flex;
         align-items: center;
         justify-content: center;
         transition: all 0.2s ease;
 
         &:hover {
-          background: rgba(var(--blert-button-base), 0.2);
-          color: var(--blert-text-color);
+          background: rgba(var(--blert-purple-base), 0.2);
+          color: var(--blert-font-color-primary);
         }
       }
     }
@@ -634,9 +634,9 @@
   .searchInfo {
     padding: 12px 24px;
     font-size: 0.9em;
-    color: var(--font-color-nav);
-    background: rgba(var(--blert-button-base), 0.05);
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+    color: var(--blert-font-color-secondary);
+    background: rgba(var(--blert-purple-base), 0.05);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
   }
 
   .customFiltersContent {
@@ -664,7 +664,7 @@
 
     // Second level (ToB, Colosseum)
     &.level1 {
-      background: rgba(var(--nav-bg-base), 0.1);
+      background: rgba(var(--blert-surface-dark-base), 0.1);
 
       li {
         .collapsible {
@@ -682,7 +682,7 @@
 
     // Third level (Maiden, Nylocas, Challenge time, Overall time, etc.)
     &.level2 {
-      background: rgba(var(--nav-bg-base), 0.2);
+      background: rgba(var(--blert-surface-dark-base), 0.2);
 
       li {
         .collapsible {
@@ -700,7 +700,7 @@
 
     // Fourth level (Room time, 70s spawn, etc.)
     &.level3 {
-      background: rgba(var(--nav-bg-base), 0.3);
+      background: rgba(var(--blert-surface-dark-base), 0.3);
 
       li {
         .filterItem {
@@ -719,7 +719,7 @@
         padding: 12px 24px;
         font-size: 1rem;
         font-weight: 500;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         background: none;
         border: none;
         text-align: left;
@@ -727,12 +727,12 @@
         position: relative;
 
         &:hover {
-          background: rgba(var(--blert-button-base), 0.08);
-          color: var(--blert-button);
+          background: rgba(var(--blert-purple-base), 0.08);
+          color: var(--blert-purple);
         }
 
         i:first-child {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 0.9em;
           width: 16px;
           flex-shrink: 0;
@@ -741,7 +741,7 @@
         i:last-child {
           margin-left: auto;
           font-size: 0.8em;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           flex-shrink: 0;
         }
       }
@@ -753,7 +753,7 @@
         gap: 12px;
         padding: 10px 24px 10px 52px;
         font-size: 0.95rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         background: none;
         border: none;
         text-align: left;
@@ -761,14 +761,14 @@
         border-left: 3px solid transparent;
 
         &:hover {
-          background: rgba(var(--blert-button-base), 0.1);
-          color: var(--blert-text-color);
-          border-left-color: var(--blert-button);
+          background: rgba(var(--blert-purple-base), 0.1);
+          color: var(--blert-font-color-primary);
+          border-left-color: var(--blert-purple);
           transform: translateX(2px);
         }
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 0.8em;
           width: 12px;
           flex-shrink: 0;
@@ -779,8 +779,8 @@
 
   .modalFooter {
     padding: 16px 24px;
-    border-top: 1px solid rgba(var(--blert-button-base), 0.1);
-    background: rgba(var(--nav-bg-base), 0.2);
+    border-top: 1px solid rgba(var(--blert-purple-base), 0.1);
+    background: rgba(var(--blert-surface-dark-base), 0.2);
     display: flex;
     justify-content: flex-end;
 
@@ -809,16 +809,16 @@
     align-items: center;
     justify-content: space-between;
     padding: 20px 24px;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.08) 0%,
-      rgba(var(--blert-button-base), 0.03) 100%
+      rgba(var(--blert-purple-base), 0.08) 0%,
+      rgba(var(--blert-purple-base), 0.03) 100%
     );
 
     h2 {
       margin: 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 600;
       font-size: 1.3em;
     }
@@ -827,17 +827,17 @@
       width: 32px;
       height: 32px;
       border-radius: 6px;
-      background: rgba(var(--blert-button-base), 0.1);
-      border: 1px solid rgba(var(--blert-button-base), 0.2);
-      color: var(--font-color-nav);
+      background: rgba(var(--blert-purple-base), 0.1);
+      border: 1px solid rgba(var(--blert-purple-base), 0.2);
+      color: var(--blert-font-color-secondary);
       display: flex;
       align-items: center;
       justify-content: center;
       transition: all 0.2s ease;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.2);
-        color: var(--blert-text-color);
+        background: rgba(var(--blert-purple-base), 0.2);
+        color: var(--blert-font-color-primary);
         transform: scale(1.05);
       }
     }
@@ -868,9 +868,9 @@
     margin-bottom: 24px;
     width: 240px;
     padding: 20px 16px;
-    border: 2px solid rgba(var(--blert-button-base), 0.2);
+    border: 2px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 8px;
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
     transition: all 0.2s ease;
 
     @include styledScrollbar;
@@ -894,25 +894,25 @@
     }
 
     &.hint {
-      border-color: rgba(var(--blert-button-base), 0.4);
-      background: rgba(var(--blert-button-base), 0.08);
+      border-color: rgba(var(--blert-purple-base), 0.4);
+      background: rgba(var(--blert-purple-base), 0.08);
       transform: translateY(-2px);
-      box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.2);
+      box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.2);
     }
 
     &.active {
       .label {
-        color: var(--blert-button);
+        color: var(--blert-purple);
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
 
-      border-color: var(--blert-button);
-      background: rgba(var(--blert-button-base), 0.1);
+      border-color: var(--blert-purple);
+      background: rgba(var(--blert-purple-base), 0.1);
       transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(var(--blert-button-base), 0.3);
+      box-shadow: 0 6px 20px rgba(var(--blert-purple-base), 0.3);
     }
 
     .listWrapper {
@@ -927,8 +927,8 @@
     &:not(.dragging) {
       .column:hover {
         cursor: pointer;
-        background: rgba(var(--blert-button-base), 0.15);
-        color: var(--blert-text-color);
+        background: rgba(var(--blert-purple-base), 0.15);
+        color: var(--blert-font-color-primary);
         transform: translateX(2px);
       }
     }
@@ -940,20 +940,20 @@
       padding: 0 2px;
       background: linear-gradient(
         to bottom,
-        var(--nav-bg) calc(50% + 2px),
+        var(--blert-surface-dark) calc(50% + 2px),
         transparent calc(50% - 2px)
       );
       z-index: 10;
       font-size: 1em;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       display: flex;
       align-items: center;
       gap: 8px;
 
       i {
         font-size: 0.9em;
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 
@@ -967,10 +967,10 @@
       position: relative;
 
       &.selected {
-        background: rgba(var(--blert-button-base), 0.2);
-        color: var(--blert-text-color);
-        border-left: 3px solid var(--blert-button);
-        box-shadow: 0 2px 8px rgba(var(--blert-button-base), 0.2);
+        background: rgba(var(--blert-purple-base), 0.2);
+        color: var(--blert-font-color-primary);
+        border-left: 3px solid var(--blert-purple);
+        box-shadow: 0 2px 8px rgba(var(--blert-purple-base), 0.2);
       }
 
       &:has(span) {
@@ -985,15 +985,15 @@
       }
 
       &:has(i:global(.fa-plus)) {
-        background: rgba(var(--blert-button-base), 0.1);
-        border: 1px dashed rgba(var(--blert-button-base), 0.3);
-        color: var(--blert-button);
+        background: rgba(var(--blert-purple-base), 0.1);
+        border: 1px dashed rgba(var(--blert-purple-base), 0.3);
+        color: var(--blert-purple);
 
         &:hover {
-          background: rgba(var(--blert-button-base), 0.15);
+          background: rgba(var(--blert-purple-base), 0.15);
           border-style: solid;
           transform: translateY(-1px);
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
 
         &:before {
@@ -1008,29 +1008,29 @@
 
       i:not(:global(.fa-plus)) {
         margin-left: auto;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         transition: color 0.2s ease;
 
         &:hover {
           cursor: pointer;
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
     }
 
     .insertion {
       height: 3px;
-      background: var(--blert-button);
+      background: var(--blert-purple);
       z-index: 10;
       border-radius: 2px;
-      box-shadow: 0 0 8px rgba(var(--blert-button-base), 0.5);
+      box-shadow: 0 0 8px rgba(var(--blert-purple-base), 0.5);
 
       i {
         position: absolute;
-        color: var(--blert-button);
+        color: var(--blert-purple);
         top: -8px;
         font-size: 1.1em;
-        text-shadow: 0 0 4px rgba(var(--blert-button-base), 0.5);
+        text-shadow: 0 0 4px rgba(var(--blert-purple-base), 0.5);
 
         &:first-child {
           left: -8px;
@@ -1049,8 +1049,8 @@
     align-items: center;
     gap: 12px;
     padding: 16px 24px;
-    border-top: 1px solid rgba(var(--blert-button-base), 0.1);
-    background: rgba(var(--nav-bg-base), 0.2);
+    border-top: 1px solid rgba(var(--blert-purple-base), 0.1);
+    background: rgba(var(--blert-surface-dark-base), 0.2);
 
     button {
       padding: 10px 20px;
@@ -1059,22 +1059,22 @@
       transition: all 0.2s ease;
 
       &:not(.simple) {
-        background: var(--blert-button);
-        color: var(--panel-bg);
+        background: var(--blert-purple);
+        color: var(--blert-panel-background-color);
 
         &:hover {
           transform: translateY(-1px);
-          box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.3);
+          box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.3);
         }
       }
 
       &.simple {
-        background: rgba(var(--blert-button-base), 0.1);
-        color: var(--blert-button);
-        border: 1px solid rgba(var(--blert-button-base), 0.2);
+        background: rgba(var(--blert-purple-base), 0.1);
+        color: var(--blert-purple);
+        border: 1px solid rgba(var(--blert-purple-base), 0.2);
 
         &:hover {
-          background: rgba(var(--blert-button-base), 0.2);
+          background: rgba(var(--blert-purple-base), 0.2);
         }
       }
 
@@ -1104,7 +1104,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 101;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     padding: 24px;
     display: flex;
     flex-direction: column;
@@ -1115,7 +1115,7 @@
     .message {
       width: 100%;
       margin: 0 0 16px 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 500;
     }
 
@@ -1123,15 +1123,15 @@
       margin: 16px 0;
 
       input {
-        background: rgba(var(--nav-bg-base), 0.3);
-        border: 1px solid rgba(var(--blert-button-base), 0.2);
+        background: rgba(var(--blert-surface-dark-base), 0.3);
+        border: 1px solid rgba(var(--blert-purple-base), 0.2);
         border-radius: 6px;
         padding: 10px 12px;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         transition: border-color 0.2s ease;
 
         &:focus {
-          border-color: var(--blert-button);
+          border-color: var(--blert-purple);
           outline: none;
         }
       }
@@ -1151,22 +1151,22 @@
         transition: all 0.2s ease;
 
         &[type='submit'] {
-          background: var(--blert-button);
-          color: var(--panel-bg);
+          background: var(--blert-purple);
+          color: var(--blert-panel-background-color);
 
           &:hover {
             transform: translateY(-1px);
-            box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.3);
+            box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.3);
           }
         }
 
         &.simple {
-          background: rgba(var(--blert-button-base), 0.1);
-          color: var(--blert-button);
-          border: 1px solid rgba(var(--blert-button-base), 0.2);
+          background: rgba(var(--blert-purple-base), 0.1);
+          color: var(--blert-purple);
+          border: 1px solid rgba(var(--blert-purple-base), 0.2);
 
           &:hover {
-            background: rgba(var(--blert-button-base), 0.2);
+            background: rgba(var(--blert-purple-base), 0.2);
           }
         }
       }

--- a/web/app/sessions/[uuid]/style.module.scss
+++ b/web/app/sessions/[uuid]/style.module.scss
@@ -6,7 +6,7 @@ $LARGE_SCREEN_WIDTH: 2000px;
   width: 100%;
   padding: 2rem 1rem;
   margin: 0 auto;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     padding: 1rem 0;
@@ -127,7 +127,7 @@ $LARGE_SCREEN_WIDTH: 2000px;
 
 .skeletonMetric {
   height: 100px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: calc(var(--index) * 100ms);
@@ -168,7 +168,7 @@ $LARGE_SCREEN_WIDTH: 2000px;
 
 .skeletonTable {
   height: 400px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 12px;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: 300ms;
@@ -176,7 +176,7 @@ $LARGE_SCREEN_WIDTH: 2000px;
 
 .skeletonSidebar {
   height: 300px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 12px;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: 400ms;

--- a/web/app/sessions/components/actions-bar.module.scss
+++ b/web/app/sessions/components/actions-bar.module.scss
@@ -12,14 +12,14 @@
 }
 
 .actionGroup {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   padding: 1.25rem;
   border: 1px solid transparent;
   transition: all 0.2s ease;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.2);
     transform: translateY(-1px);
   }
 }
@@ -30,16 +30,16 @@
   gap: 0.5rem;
   margin-bottom: 1rem;
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid rgba(var(--blert-button-base), 0.1);
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.9rem;
   }
 
   span {
     font-weight: 600;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.95rem;
   }
 }
@@ -71,27 +71,27 @@
   }
 
   &.default {
-    color: var(--blert-text-color);
-    background: rgba(var(--blert-button-base), 0.1);
-    border-color: rgba(var(--blert-button-base), 0.2);
+    color: var(--blert-font-color-primary);
+    background: rgba(var(--blert-purple-base), 0.1);
+    border-color: rgba(var(--blert-purple-base), 0.2);
 
     &:hover:not(:disabled) {
-      background: rgba(var(--blert-button-base), 0.2);
-      border-color: rgba(var(--blert-button-base), 0.4);
+      background: rgba(var(--blert-purple-base), 0.2);
+      border-color: rgba(var(--blert-purple-base), 0.4);
       transform: translateY(-1px);
     }
   }
 
   &.primary {
     color: white;
-    background: var(--blert-button);
-    border-color: var(--blert-button);
+    background: var(--blert-purple);
+    border-color: var(--blert-purple);
 
     &:hover:not(:disabled) {
-      background: var(--blert-button-hover);
-      border-color: var(--blert-button-hover);
+      background: var(--blert-purple-hover);
+      border-color: var(--blert-purple-hover);
       transform: translateY(-1px);
-      box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.3);
+      box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.3);
     }
   }
 
@@ -126,7 +126,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 0;
-  border-bottom: 1px solid rgba(var(--blert-button-base), 0.05);
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.05);
 
   &:last-child {
     border-bottom: none;
@@ -135,13 +135,13 @@
 
 .statLabel {
   font-size: 0.85rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-weight: 500;
 }
 
 .statValue {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.9rem;
 }

--- a/web/app/sessions/components/challenge-analysis.module.scss
+++ b/web/app/sessions/components/challenge-analysis.module.scss
@@ -3,7 +3,7 @@
 .skeleton {
   @include panel;
   height: 200px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   animation: pulse 1.5s ease-in-out infinite;
 }
@@ -25,7 +25,7 @@
 
   span {
     font-size: 1.1rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -36,7 +36,7 @@
   justify-content: center;
   gap: 1rem;
   padding: 3rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: center;
 
   i {
@@ -46,13 +46,13 @@
 
   span {
     font-size: 1.1rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
 .emptyHint {
   font-size: 0.9rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   margin: 0;
   opacity: 0.8;
 }
@@ -64,11 +64,11 @@
   justify-content: center;
   gap: 1rem;
   padding: 2rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: center;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
 
   i {
     font-size: 2rem;
@@ -77,13 +77,13 @@
 
   span {
     font-size: 1rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
 .noDataHint {
   font-size: 0.85rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   margin: 0;
   opacity: 0.8;
 }
@@ -94,7 +94,7 @@
   gap: 1.5rem;
   margin-bottom: 2rem;
   padding: 1.5rem;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
 
   @media (min-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -134,7 +134,7 @@
 
 .accuracyDescription {
   font-size: 0.75rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   margin: 0;
   opacity: 0.8;
   line-height: 1.3;
@@ -147,17 +147,17 @@
   gap: 0.5rem;
   font-size: 0.9rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.8rem;
   }
 }
 
 .selectorDescription {
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   margin: 0.25rem 0 0.75rem 0;
   opacity: 0.9;
   line-height: 1.4;
@@ -170,23 +170,23 @@
   justify-content: space-between;
   align-items: center;
   padding: 10px 12px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 5px;
-  background: var(--panel-bg);
-  color: var(--blert-text-color);
+  background: var(--blert-panel-background-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.9rem;
   transition: all 0.2s ease;
   cursor: pointer;
 
   &:focus {
     outline: none;
-    border-color: var(--blert-button);
-    box-shadow: 0 0 0 2px rgba(var(--blert-button-base), 0.2);
+    border-color: var(--blert-purple);
+    box-shadow: 0 0 0 2px rgba(var(--blert-purple-base), 0.2);
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.7);
-    background: rgba(var(--blert-button-base), 0.05);
+    border-color: rgba(var(--blert-purple-base), 0.7);
+    background: rgba(var(--blert-purple-base), 0.05);
   }
 
   &:disabled {
@@ -195,13 +195,13 @@
   }
 
   i {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.8rem;
     transition: transform 0.2s ease;
   }
 
   &:hover i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -239,23 +239,23 @@
   gap: 0.75rem;
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin: 0;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1rem;
   }
 }
 
 .infoIcon {
   margin-left: auto;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   cursor: help;
   transition: color 0.2s ease;
 
   &:hover {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   i {
@@ -279,15 +279,15 @@
 }
 
 .chartContainer {
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 8px;
   padding: 1rem;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
 }
 
 .tooltipContent {
-  background: var(--panel-bg);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: var(--blert-panel-background-color);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 6px;
   padding: 8px 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -295,7 +295,7 @@
 
 .tooltipLabel {
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   margin: 0 0 4px 0;
 }
 
@@ -303,23 +303,23 @@
   font-family: var(--font-roboto-mono), monospace;
   font-size: 0.9rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin: 0;
 }
 
 // Distribution table styles
 .distributionTable {
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 8px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   overflow: hidden;
 }
 
 .tableHeader {
   display: grid;
   grid-template-columns: 1fr 80px 100px 1fr;
-  background: var(--nav-bg);
-  border-bottom: 1px solid var(--font-color-nav-divider);
+  background: var(--blert-surface-dark);
+  border-bottom: 1px solid var(--blert-divider-color);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     grid-template-columns: 1fr 60px 80px 100px;
@@ -330,7 +330,7 @@
   padding: 12px 16px;
   font-weight: 600;
   font-size: 0.85rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   text-align: left;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -356,11 +356,11 @@
   transition: background-color 0.2s ease;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.05);
+    background: rgba(var(--blert-purple-base), 0.05);
   }
 
   &:nth-child(even) {
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -372,7 +372,7 @@
   padding: 10px 16px;
   display: flex;
   align-items: center;
-  border-bottom: 1px solid rgba(var(--font-color-nav-divider), 0.3);
+  border-bottom: 1px solid rgba(var(--blert-divider-color), 0.3);
 
   &:last-child {
     justify-content: center;
@@ -391,7 +391,7 @@
 .valueText {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.9rem;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -402,7 +402,7 @@
 .countText {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 500;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   text-align: center;
   width: 100%;
 
@@ -414,7 +414,7 @@
 .percentageText {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 500;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: right;
   width: 100%;
 
@@ -426,7 +426,7 @@
 .distributionBar {
   width: 100%;
   height: 16px;
-  background: rgba(var(--nav-bg-base), 0.5);
+  background: rgba(var(--blert-surface-dark-base), 0.5);
   border-radius: 8px;
   overflow: hidden;
   position: relative;
@@ -441,8 +441,8 @@
   height: 100%;
   background: linear-gradient(
     90deg,
-    var(--blert-button),
-    rgba(var(--blert-button-base), 0.7)
+    var(--blert-purple),
+    rgba(var(--blert-purple-base), 0.7)
   );
   border-radius: inherit;
   transition: width 0.3s ease;

--- a/web/app/sessions/components/challenge-analysis.tsx
+++ b/web/app/sessions/components/challenge-analysis.tsx
@@ -522,7 +522,7 @@ function DistributionChart({
           />
           <XAxis
             dataKey="value"
-            tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+            tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
             axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             angle={selectedStat.type === StatType.SPLIT ? -45 : undefined}
@@ -531,22 +531,25 @@ function DistributionChart({
             interval={0}
           />
           <YAxis
-            tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+            tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
             axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             label={{
               value: 'Frequency',
               angle: -90,
               position: 'insideLeft',
-              style: { textAnchor: 'middle', fill: 'var(--blert-text-color)' },
+              style: {
+                textAnchor: 'middle',
+                fill: 'var(--blert-font-color-primary)',
+              },
             }}
           />
           <Tooltip
             contentStyle={{
-              backgroundColor: 'var(--panel-bg)',
-              border: '1px solid var(--nav-bg-lightened)',
+              backgroundColor: 'var(--blert-panel-background-color)',
+              border: '1px solid var(--blert-surface-light)',
               borderRadius: '6px',
-              color: 'var(--blert-text-color)',
+              color: 'var(--blert-font-color-primary)',
               boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
             }}
             cursor={{ fill: 'rgba(139, 92, 246, 0.1)' }}
@@ -555,14 +558,22 @@ function DistributionChart({
               _name: string,
               props: { payload?: { percentage: number } },
             ) => [
-              <span key={value} style={{ color: 'var(--blert-text-color)' }}>
+              <span
+                key={value}
+                style={{ color: 'var(--blert-font-color-primary)' }}
+              >
                 {value} occurrence{value === 1 ? '' : 's'}
                 {/* eslint-disable-next-line react/prop-types */}
                 {props.payload && ` (${props.payload.percentage.toFixed(1)}%)`}
               </span>,
             ]}
             labelFormatter={(label: string) => (
-              <span style={{ fontWeight: 600, color: 'var(--font-color-nav)' }}>
+              <span
+                style={{
+                  fontWeight: 600,
+                  color: 'var(--blert-font-color-secondary)',
+                }}
+              >
                 Value: {label}
               </span>
             )}
@@ -603,20 +614,25 @@ function ChartDisplay({
   const tooltip = (
     <Tooltip
       contentStyle={{
-        backgroundColor: 'var(--panel-bg)',
-        border: '1px solid var(--nav-bg-lightened)',
+        backgroundColor: 'var(--blert-panel-background-color)',
+        border: '1px solid var(--blert-surface-light)',
         borderRadius: '6px',
-        color: 'var(--blert-text-color)',
+        color: 'var(--blert-font-color-primary)',
         boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
       }}
       cursor={{ fill: 'rgba(139, 92, 246, 0.1)' }}
       formatter={(value: number, _name: string, _props: any) => [
-        <span key={value} style={{ color: 'var(--blert-text-color)' }}>
+        <span key={value} style={{ color: 'var(--blert-font-color-primary)' }}>
           {selectedStat.formatter ? selectedStat.formatter(value) : value}
         </span>,
       ]}
       labelFormatter={(label: string) => (
-        <span style={{ fontWeight: 600, color: 'var(--font-color-nav)' }}>
+        <span
+          style={{
+            fontWeight: 600,
+            color: 'var(--blert-font-color-secondary)',
+          }}
+        >
           {challengeTerm(challengeType)} #{label}
         </span>
       )}
@@ -649,13 +665,13 @@ function ChartDisplay({
             />
             <XAxis
               dataKey="challengeIndex"
-              tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+              tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
               axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickFormatter={(value: number) => `#${value}`}
             />
             <YAxis
-              tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+              tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
               axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickFormatter={selectedStat.formatter}
@@ -678,13 +694,13 @@ function ChartDisplay({
             />
             <XAxis
               dataKey="challengeIndex"
-              tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+              tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
               axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickFormatter={(value: number) => `#${value}`}
             />
             <YAxis
-              tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+              tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
               axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
               tickFormatter={selectedStat.formatter}
@@ -869,7 +885,7 @@ export default function ChallengeAnalysis() {
             across all challenges in the session.
           </p>
           {menuItems.length > 1 ? (
-            <div className={styles.statGroupSelector}>
+            <div>
               <RadioInput.Group
                 name="stat-group"
                 compact

--- a/web/app/sessions/components/challenges-table.module.scss
+++ b/web/app/sessions/components/challenges-table.module.scss
@@ -3,9 +3,9 @@
 .filtersContainer {
   margin-bottom: 1.5rem;
   padding: 1rem;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
-  border: 1px solid var(--nav-bg-lightened);
+  border: 1px solid var(--blert-surface-light);
 }
 
 .filterGroup {
@@ -22,14 +22,14 @@
 
 .filterLabel {
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.9rem;
   white-space: nowrap;
 }
 
 .skeletonFilter {
   height: 40px;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 6px;
   animation: pulse 2s ease-in-out infinite;
 }
@@ -37,7 +37,7 @@
 .tableContainer {
   overflow-x: auto;
   border-radius: 8px;
-  border: 1px solid var(--nav-bg-lightened);
+  border: 1px solid var(--blert-surface-light);
 
   @include styledScrollbar;
 }
@@ -46,7 +46,7 @@
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   display: flex;
   flex-direction: column;
   max-height: 1000px;
@@ -63,7 +63,7 @@
     display: table;
     width: 100%;
     table-layout: fixed;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     position: sticky;
     top: 0;
     z-index: 10;
@@ -88,12 +88,12 @@
   th {
     text-align: left;
     padding: 1rem;
-    border-bottom: 1px solid var(--nav-bg-lightened);
-    color: var(--blert-text-color);
+    border-bottom: 1px solid var(--blert-surface-light);
+    color: var(--blert-font-color-primary);
     font-weight: 600;
     font-size: 0.9rem;
     white-space: nowrap;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
 
     &:first-child {
       border-top-left-radius: 8px;
@@ -116,8 +116,8 @@
     transition: all 0.2s ease;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.1);
-      color: var(--blert-text-color);
+      background: rgba(var(--blert-purple-base), 0.1);
+      color: var(--blert-font-color-primary);
     }
 
     i {
@@ -137,11 +137,11 @@
     border-left: 4px solid transparent;
 
     &:hover {
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
     }
 
     &.expandedRow {
-      background: rgba(var(--blert-button-base), 0.05);
+      background: rgba(var(--blert-purple-base), 0.05);
     }
 
     &:last-child td {
@@ -151,7 +151,7 @@
 
   td {
     padding: 0.75rem 1rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.9rem;
     vertical-align: middle;
 
@@ -207,7 +207,7 @@
 .durationCell {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 500;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .deathsCell {
@@ -229,17 +229,17 @@
     justify-content: center;
     width: 28px;
     height: 28px;
-    background: rgba(var(--blert-button-base), 0.1);
-    border: 1px solid rgba(var(--blert-button-base), 0.3);
+    background: rgba(var(--blert-purple-base), 0.1);
+    border: 1px solid rgba(var(--blert-purple-base), 0.3);
     border-radius: 4px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     text-decoration: none;
     cursor: pointer;
     transition: all 0.2s ease;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.2);
-      border-color: rgba(var(--blert-button-base), 0.5);
+      background: rgba(var(--blert-purple-base), 0.2);
+      border-color: rgba(var(--blert-purple-base), 0.5);
       transform: translateY(-1px);
     }
 
@@ -265,15 +265,15 @@
   width: 20px;
   height: 20px;
   background: transparent;
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 3px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.1);
-    border-color: rgba(var(--blert-button-base), 0.5);
+    background: rgba(var(--blert-purple-base), 0.1);
+    border-color: rgba(var(--blert-purple-base), 0.5);
   }
 
   i {
@@ -293,17 +293,17 @@
 .expandedDetailsRow {
   td {
     padding: 0;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
   }
 }
 
 .expandedDetails {
   padding: 1.5rem;
-  border-top: 1px solid var(--nav-bg-lightened);
+  border-top: 1px solid var(--blert-surface-light);
   background: linear-gradient(
     135deg,
-    var(--panel-bg) 0%,
-    rgba(var(--nav-bg-base), 0.3) 100%
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.3) 100%
   );
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -332,7 +332,7 @@
 .detailLabel {
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   opacity: 0.8;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -340,7 +340,7 @@
 
 .detailValue {
   font-weight: 500;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-family: var(--font-roboto-mono), monospace;
 }
 
@@ -351,7 +351,7 @@
 .detailsTitle {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin-bottom: 0.75rem;
   display: flex;
   align-items: center;
@@ -361,7 +361,7 @@
     content: '';
     width: 3px;
     height: 1rem;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     border-radius: 2px;
   }
 
@@ -393,14 +393,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 0.7rem;
-  background: rgba(var(--nav-bg-base), 0.4);
+  background: rgba(var(--blert-surface-dark-base), 0.4);
   border-radius: 6px;
-  border: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
+  border: 1px solid rgba(var(--blert-surface-light-base), 0.6);
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-base), 0.6);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.6);
+    border-color: rgba(var(--blert-purple-base), 0.3);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -411,7 +411,7 @@
 .splitType {
   font-size: 0.8rem;
   font-weight: 500;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -420,7 +420,7 @@
 .splitTime {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.85rem;
 }
 
@@ -438,7 +438,7 @@
 
 .pbSection {
   padding-top: 1rem;
-  border-top: 1px solid var(--nav-bg-lightened);
+  border-top: 1px solid var(--blert-surface-light);
 }
 
 .pbList {
@@ -456,14 +456,14 @@
   flex-direction: column;
   gap: 0.5rem;
   padding: 0.75rem;
-  background: rgba(var(--nav-bg-base), 0.4);
-  border: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
+  background: rgba(var(--blert-surface-dark-base), 0.4);
+  border: 1px solid rgba(var(--blert-surface-light-base), 0.6);
   border-radius: 8px;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-base), 0.6);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.6);
+    border-color: rgba(var(--blert-purple-base), 0.3);
   }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -478,11 +478,11 @@
   gap: 0.5rem;
   font-size: 0.9rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   i {
     font-size: 0.8rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     opacity: 0.8;
   }
 
@@ -512,7 +512,7 @@
   gap: 0.3rem;
   background: rgba(255, 215, 0, 0.08);
   border: 1px solid rgba(255, 215, 0, 0.2);
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   padding: 0.2rem 0.5rem;
   border-radius: 12px;
   font-size: 0.75rem;
@@ -545,9 +545,9 @@
   height: 1.2rem;
   background: linear-gradient(
     90deg,
-    var(--nav-bg) 25%,
-    rgba(var(--nav-bg-lightened-base), 0.5) 50%,
-    var(--nav-bg) 75%
+    var(--blert-surface-dark) 25%,
+    rgba(var(--blert-surface-light-base), 0.5) 50%,
+    var(--blert-surface-dark) 75%
   );
   background-size: 200% 100%;
   animation: shimmer 2s infinite linear;
@@ -581,7 +581,7 @@
   justify-content: center;
   gap: 1rem;
   padding: 3rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: center;
 
   i {
@@ -622,13 +622,13 @@
   justify-content: center;
   gap: 1rem;
   padding: 2rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: center;
 
   i {
     font-size: 2rem;
     opacity: 0.5;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   span {
@@ -638,8 +638,8 @@
 }
 
 .clearFilterButton {
-  background: var(--blert-button);
-  color: var(--blert-text-color);
+  background: var(--blert-purple);
+  color: var(--blert-font-color-primary);
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 6px;
@@ -648,7 +648,7 @@
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.8);
+    background: rgba(var(--blert-purple-base), 0.8);
     transform: translateY(-1px);
   }
 }
@@ -669,9 +669,9 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  background: rgba(var(--nav-bg-base), 0.4);
-  border: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
-  color: var(--blert-text-color);
+  background: rgba(var(--blert-surface-dark-base), 0.4);
+  border: 1px solid rgba(var(--blert-surface-light-base), 0.6);
+  color: var(--blert-font-color-primary);
   padding: 0.25rem 0.5rem 0.4rem 0.5rem;
   border-radius: 6px;
   font-size: 0.8rem;
@@ -680,8 +680,8 @@
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-base), 0.6);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.6);
+    border-color: rgba(var(--blert-purple-base), 0.3);
   }
 
   i {
@@ -704,14 +704,14 @@
 }
 
 .moreTag {
-  background: rgba(var(--nav-bg-base), 0.2);
+  background: rgba(var(--blert-surface-dark-base), 0.2);
   border-style: dashed;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   opacity: 0.9;
   cursor: help;
 
   &:hover {
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
     opacity: 1;
   }
 
@@ -721,7 +721,7 @@
 }
 
 .playerDeath {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .detailLabel {

--- a/web/app/sessions/components/metrics-grid.module.scss
+++ b/web/app/sessions/components/metrics-grid.module.scss
@@ -4,7 +4,7 @@
   overflow: hidden;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
   }
@@ -40,13 +40,13 @@
 .skeletonHeader {
   margin-bottom: 1.5rem;
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid rgba(var(--blert-button-base), 0.1);
+  border-bottom: 2px solid rgba(var(--blert-purple-base), 0.1);
 }
 
 .skeletonTitle {
   width: 180px;
   height: 20px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
 }
@@ -54,7 +54,7 @@
 .skeletonStatistic {
   width: 100%;
   height: 116px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   animation: pulse 1.5s ease-in-out infinite;
   margin: 0 auto;
@@ -69,13 +69,13 @@
   gap: 1rem;
   padding: 3rem;
   text-align: center;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
 }
 
@@ -105,8 +105,8 @@
 }
 
 .successRateModerate {
-  color: var(--blert-button) !important;
-  text-shadow: 0 0 3px rgba(var(--blert-button-base), 0.4);
+  color: var(--blert-purple) !important;
+  text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.4);
 }
 
 .successRateLow {

--- a/web/app/sessions/components/player-breakdown.module.scss
+++ b/web/app/sessions/components/player-breakdown.module.scss
@@ -12,7 +12,7 @@
 }
 
 .playerCard {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 12px;
   padding: 1rem;
   border: 1px solid transparent;
@@ -27,12 +27,12 @@
     left: 0;
     right: 0;
     height: 3px;
-    background: linear-gradient(90deg, var(--blert-green), var(--blert-button));
+    background: linear-gradient(90deg, var(--blert-green), var(--blert-purple));
     opacity: 0.6;
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   }
@@ -44,7 +44,7 @@
   justify-content: space-between;
   margin-bottom: 1rem;
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid rgba(var(--font-color-nav-base), 0.1);
+  border-bottom: 1px solid rgba(var(--blert-font-color-secondary-base), 0.1);
 }
 
 .playerTitle {
@@ -53,7 +53,7 @@
   gap: 0.75rem;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1rem;
     width: 16px;
     text-align: center;
@@ -62,7 +62,7 @@
   span {
     font-weight: 600;
     font-size: 0.95rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -75,7 +75,7 @@
 
 .challenges {
   font-size: 0.7rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   opacity: 0.8;
   font-weight: 500;
 }
@@ -102,14 +102,14 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 0.5rem;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 8px;
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   transition: all 0.2s ease;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.2);
-    background: rgba(var(--panel-bg-base), 1.05);
+    border-color: rgba(var(--blert-purple-base), 0.2);
+    background: rgba(var(--blert-panel-background-color-base), 1.05);
   }
 
   i {
@@ -126,7 +126,7 @@
 
   .statLabel {
     font-size: 0.6rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.8;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -147,11 +147,11 @@
 
 .lowDeaths {
   .statValue {
-    color: var(--blert-button);
-    text-shadow: 0 0 3px rgba(var(--blert-button-base), 0.3);
+    color: var(--blert-purple);
+    text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.3);
   }
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -200,7 +200,7 @@
 }
 
 .skeleton {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
 }
@@ -240,13 +240,13 @@
   gap: 1rem;
   padding: 3rem 2rem;
   text-align: center;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
 }
 
@@ -256,8 +256,8 @@
   border-radius: 50%;
   background: linear-gradient(
     135deg,
-    rgba(var(--blert-button-base), 0.1) 0%,
-    rgba(var(--blert-button-base), 0.05) 100%
+    rgba(var(--blert-purple-base), 0.1) 0%,
+    rgba(var(--blert-purple-base), 0.05) 100%
   );
   display: flex;
   align-items: center;
@@ -265,7 +265,7 @@
 
   i {
     font-size: 1.5rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     opacity: 0.7;
   }
 }
@@ -286,13 +286,13 @@
   gap: 1rem;
   padding: 3rem;
   text-align: center;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
 }
 
@@ -323,10 +323,10 @@
     gap: 0.5rem;
     font-weight: 600;
     font-size: 0.9rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     margin-bottom: 0.5rem;
     padding-bottom: 0.25rem;
-    border-bottom: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
+    border-bottom: 1px solid rgba(var(--blert-surface-light-base), 0.6);
 
     i {
       color: #ffd700;
@@ -349,7 +349,7 @@
 
   .pbTooltipSplit {
     font-size: 0.8rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-weight: 500;
     flex: 1;
   }

--- a/web/app/sessions/components/session-header.module.scss
+++ b/web/app/sessions/components/session-header.module.scss
@@ -4,7 +4,7 @@
   position: relative;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
   }
@@ -144,14 +144,14 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  background: rgba(var(--nav-bg-base), 0.6);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  background: rgba(var(--blert-surface-dark-base), 0.6);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 8px;
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--nav-bg-lightened-base), 0.7);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    background: rgba(var(--blert-surface-light-base), 0.7);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-1px);
   }
 
@@ -166,7 +166,7 @@
   margin: 0;
   font-size: 1.75rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   line-height: 1.2;
   word-break: break-word;
   hyphens: auto;
@@ -197,13 +197,13 @@
     left: 50%;
     width: 0;
     height: 1px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     transition: all 0.2s ease;
     transform: translateX(-50%);
   }
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.08);
+    background: rgba(var(--blert-purple-base), 0.08);
 
     &::after {
       width: 100%;
@@ -212,7 +212,7 @@
 }
 
 .dotSeparator {
-  color: var(--font-color-nav-divider);
+  color: var(--blert-divider-color);
   font-weight: 300;
   user-select: none;
 
@@ -226,14 +226,14 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-weight: 500;
   position: relative;
 
   i {
     position: relative;
     top: 1px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     width: 14px;
     text-align: center;
     flex-shrink: 0;
@@ -282,16 +282,16 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background: rgba(var(--nav-bg-base), 0.6);
-  border: 1px solid rgba(var(--font-color-nav-divider), 0.3);
+  background: rgba(var(--blert-surface-dark-base), 0.6);
+  border: 1px solid rgba(var(--blert-divider-color), 0.3);
   border-radius: 8px;
   font-size: 0.85rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   transition: all 0.2s ease;
   white-space: nowrap;
 
   &:hover {
-    background: rgba(var(--nav-bg-lightened-base), 0.7);
+    background: rgba(var(--blert-surface-light-base), 0.7);
     transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   }
@@ -300,7 +300,7 @@
     width: 14px;
     text-align: center;
     font-size: 0.8rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   span {
@@ -348,10 +348,10 @@
   gap: 0.5rem;
   position: relative;
   padding: 0.75rem 1rem;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 8px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   font-size: 0.9rem;
   font-weight: 500;
   cursor: pointer;
@@ -360,8 +360,8 @@
   justify-content: center;
 
   &:hover:not(:disabled) {
-    background: rgba(var(--blert-button-base), 0.2);
-    border-color: rgba(var(--blert-button-base), 0.5);
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.5);
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   }
@@ -376,8 +376,8 @@
   }
 
   &.loading {
-    background: rgba(var(--blert-button-base), 0.15);
-    border-color: rgba(var(--blert-button-base), 0.4);
+    background: rgba(var(--blert-purple-base), 0.15);
+    border-color: rgba(var(--blert-purple-base), 0.4);
   }
 
   i {
@@ -389,7 +389,7 @@
 
 .skeletonHeader {
   height: 100px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   animation: pulse 1.5s ease-in-out infinite;
   animation-delay: calc(var(--index) * 100ms);

--- a/web/app/sessions/components/session-header.tsx
+++ b/web/app/sessions/components/session-header.tsx
@@ -148,7 +148,7 @@ export default function SessionHeader() {
                     stats.completionRate >= 80
                       ? 'var(--blert-green)'
                       : stats.completionRate >= 50
-                        ? 'var(--blert-button)'
+                        ? 'var(--blert-purple)'
                         : 'var(--blert-red)',
                 }}
               />

--- a/web/app/sessions/components/session-timeline.module.scss
+++ b/web/app/sessions/components/session-timeline.module.scss
@@ -21,13 +21,13 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.9rem;
   font-weight: 500;
 
   i {
     position: relative;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     width: 14px;
     top: 1px;
     text-align: center;
@@ -74,11 +74,11 @@
   min-height: 200px;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
   border-radius: 8px;
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   padding: 1rem;
   position: relative;
   overflow: auto;
@@ -115,21 +115,21 @@
   }
 
   &::-webkit-scrollbar-track {
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
     border-radius: 4px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: rgba(var(--blert-button-base), 0.4);
+    background: rgba(var(--blert-purple-base), 0.4);
     border-radius: 4px;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.6);
+      background: rgba(var(--blert-purple-base), 0.6);
     }
   }
 
   &::-webkit-scrollbar-corner {
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
   }
 }
 
@@ -162,12 +162,12 @@
 }
 
 .tooltip {
-  background: var(--panel-bg);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: var(--blert-panel-background-color);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 8px;
   padding: 0.75rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   font-size: 0.85rem;
   max-width: 320px;
   z-index: 1000;
@@ -183,14 +183,14 @@
   align-items: center;
   margin-bottom: 0.5rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid rgba(var(--blert-button-base), 0.2);
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.2);
   gap: 0.5rem;
 }
 
 .challengeNumber {
   font-family: var(--font-roboto-mono), monospace;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .challengeStatus {
@@ -221,11 +221,11 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.8rem;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     width: 12px;
     text-align: center;
     font-size: 0.75rem;
@@ -236,7 +236,7 @@
   }
 
   span:last-of-type {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-variant-numeric: tabular-nums;
   }
 }
@@ -244,10 +244,10 @@
 .tooltipFooter {
   margin-top: 0.5rem;
   padding-top: 0.5rem;
-  border-top: 1px solid rgba(var(--blert-button-base), 0.2);
+  border-top: 1px solid rgba(var(--blert-purple-base), 0.2);
   text-align: center;
   font-size: 0.75rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-style: italic;
 }
 
@@ -256,7 +256,7 @@
   flex-direction: column;
   gap: 1rem;
   padding-top: 1rem;
-  border-top: 1px solid rgba(var(--blert-button-base), 0.1);
+  border-top: 1px solid rgba(var(--blert-purple-base), 0.1);
 
   @media (min-width: $COMPACT_WIDTH_THRESHOLD) {
     flex-direction: row;
@@ -280,7 +280,7 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.85rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 }
 
 .legendColor {
@@ -296,13 +296,13 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.8rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   opacity: 0.8;
 
   i {
     position: relative;
     top: 1px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     opacity: 0.7;
   }
 
@@ -332,11 +332,11 @@
   justify-content: center;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
   border-radius: 8px;
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
 }
 
 .skeletonBars {
@@ -349,7 +349,7 @@
 
 .skeletonBar {
   height: 16px;
-  background: var(--font-color-nav-divider);
+  background: var(--blert-divider-color);
   border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
 
@@ -378,14 +378,14 @@
   justify-content: center;
   gap: 1rem;
   padding: 3rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-align: center;
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
 
   i {
@@ -409,12 +409,12 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   font-size: 0.8rem;
   font-weight: 600;
   padding: 0.25rem 0.5rem;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 1px solid rgba(var(--blert-button-base), 0.2);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
   border-radius: 4px;
   font-family: var(--font-roboto-mono), monospace;
 

--- a/web/app/sessions/components/session-timeline.tsx
+++ b/web/app/sessions/components/session-timeline.tsx
@@ -442,7 +442,7 @@ export default function SessionTimeline() {
           durationMinutes: breakDurationMinutes,
           endMinutes: breakStartMinutes + breakDurationMinutes,
           challenge: null,
-          color: 'rgba(var(--blert-text-color-base), 0.1)',
+          color: 'rgba(var(--blert-font-color-primary-base), 0.1)',
           baseWidth: breakStartMinutes,
         });
       }
@@ -559,7 +559,7 @@ export default function SessionTimeline() {
             type="number"
             domain={[0, maxMinutes]}
             tickFormatter={formatTimeAxis}
-            tick={{ fill: 'var(--blert-text-color)', fontSize: 12 }}
+            tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
             tickCount={8}
             axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
@@ -569,7 +569,7 @@ export default function SessionTimeline() {
             type="category"
             dataKey="index"
             width={50}
-            tick={{ fill: 'var(--blert-text-color)', fontSize: 11 }}
+            tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 11 }}
             axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
             tickFormatter={(value: number) => {
@@ -673,7 +673,7 @@ export default function SessionTimeline() {
               <div
                 className={styles.legendColor}
                 style={{
-                  background: 'rgba(var(--blert-text-color-base), 0.1)',
+                  background: 'rgba(var(--blert-font-color-primary-base), 0.1)',
                 }}
               ></div>
               <span>Break</span>

--- a/web/app/sessions/components/stage-stats.module.scss
+++ b/web/app/sessions/components/stage-stats.module.scss
@@ -12,7 +12,7 @@
 }
 
 .stageCard {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 12px;
   padding: 1rem;
   border: 1px solid transparent;
@@ -27,12 +27,12 @@
     left: 0;
     right: 0;
     height: 3px;
-    background: linear-gradient(90deg, var(--blert-button), var(--blert-green));
+    background: linear-gradient(90deg, var(--blert-purple), var(--blert-green));
     opacity: 0.6;
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     transform: translateY(-2px);
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
   }
@@ -43,7 +43,7 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1rem;
-  border-bottom: 1px solid rgba(var(--font-color-nav-base), 0.1);
+  border-bottom: 1px solid rgba(var(--blert-font-color-secondary-base), 0.1);
 }
 
 .stageTitle {
@@ -52,26 +52,26 @@
   gap: 0.75rem;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1.1rem;
     width: 20px;
     text-align: center;
   }
 
   svg {
-    fill: var(--blert-button);
-    stroke: var(--blert-button);
+    fill: var(--blert-purple);
+    stroke: var(--blert-purple);
   }
 
   path {
-    fill: var(--blert-button);
-    stroke: var(--blert-button);
+    fill: var(--blert-purple);
+    stroke: var(--blert-purple);
   }
 
   span {
     font-weight: 600;
     font-size: 1rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 }
 
@@ -83,7 +83,7 @@
 
   .attempts {
     font-size: 0.7rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.8;
     font-weight: 500;
   }
@@ -112,14 +112,14 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 8px;
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   transition: all 0.2s ease;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.2);
-    background: rgba(var(--panel-bg-base), 1.05);
+    border-color: rgba(var(--blert-purple-base), 0.2);
+    background: rgba(var(--blert-panel-background-color-base), 1.05);
   }
 
   i {
@@ -136,7 +136,7 @@
 
   .statLabel {
     font-size: 0.6rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.8;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -158,14 +158,14 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.5rem;
-  background: rgba(var(--nav-bg-base), 0.5);
+  background: rgba(var(--blert-surface-dark-base), 0.5);
   border-radius: 6px;
-  border: 1px solid rgba(var(--blert-button-base), 0.08);
+  border: 1px solid rgba(var(--blert-purple-base), 0.08);
 }
 
 .timeLabel {
   font-size: 0.7rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   opacity: 0.7;
   text-transform: uppercase;
   letter-spacing: 0.3px;
@@ -176,7 +176,7 @@
   font-family: var(--font-roboto-mono), monospace;
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 }
 
 .noCompletions {
@@ -185,7 +185,7 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 1rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   opacity: 0.6;
   font-size: 0.9rem;
   font-style: italic;
@@ -197,14 +197,14 @@
 }
 
 .splitsStats {
-  border-top: 1px solid rgba(var(--font-color-nav-base), 0.1);
+  border-top: 1px solid rgba(var(--blert-font-color-secondary-base), 0.1);
 
   .splitsHeader {
     margin-bottom: 0.25rem;
 
     .splitsTitle {
       font-size: 0.75rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       opacity: 0.8;
       text-transform: uppercase;
       letter-spacing: 0.5px;
@@ -223,13 +223,13 @@
     justify-content: space-between;
     align-items: center;
     padding: 0 0.5rem;
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
     border-radius: 4px;
     font-size: 0.8rem;
   }
 
   .splitName {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.9;
     font-weight: 500;
     flex: 1;
@@ -240,7 +240,7 @@
 
   .splitTime {
     font-family: var(--font-roboto-mono), monospace;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.75rem;
     margin-left: 0.5rem;
   }
@@ -258,11 +258,11 @@
 
 .moderateCompletion {
   .statValue {
-    color: var(--blert-button);
-    text-shadow: 0 0 3px rgba(var(--blert-button-base), 0.3);
+    color: var(--blert-purple);
+    text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.3);
   }
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -288,11 +288,11 @@
 
 .lowDeaths {
   .statValue {
-    color: var(--blert-button);
-    text-shadow: 0 0 3px rgba(var(--blert-button-base), 0.3);
+    color: var(--blert-purple);
+    text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.3);
   }
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -339,7 +339,7 @@
 }
 
 .skeleton {
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
 }
@@ -389,13 +389,13 @@
   gap: 1rem;
   padding: 3rem 2rem;
   text-align: center;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
 }
 
@@ -405,8 +405,8 @@
   border-radius: 50%;
   background: linear-gradient(
     135deg,
-    rgba(var(--blert-button-base), 0.1) 0%,
-    rgba(var(--blert-button-base), 0.05) 100%
+    rgba(var(--blert-purple-base), 0.1) 0%,
+    rgba(var(--blert-purple-base), 0.05) 100%
   );
   display: flex;
   align-items: center;
@@ -414,7 +414,7 @@
 
   i {
     font-size: 1.5rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     opacity: 0.7;
   }
 }
@@ -434,13 +434,13 @@
   gap: 1rem;
   padding: 3rem;
   text-align: center;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   background: linear-gradient(
     135deg,
-    rgba(var(--panel-bg-base), 0.3) 0%,
-    rgba(var(--nav-bg-base), 0.1) 100%
+    rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+    rgba(var(--blert-surface-dark-base), 0.1) 100%
   );
-  border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+  border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
   border-radius: 12px;
 }
 

--- a/web/app/setups/[id]/edit/debug-overlay.module.scss
+++ b/web/app/setups/[id]/edit/debug-overlay.module.scss
@@ -2,13 +2,13 @@
   position: fixed;
   top: 80px;
   right: 20px;
-  background: rgba(var(--nav-bg-base), 0.95);
-  border: 1px solid rgba(var(--blert-button-base), 0.3);
+  background: rgba(var(--blert-surface-dark-base), 0.95);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
   border-radius: 8px;
   padding: 12px;
   font-size: 12px;
   font-family: var(--font-roboto-mono), monospace;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   min-width: 200px;
   z-index: 9999;
   backdrop-filter: blur(8px);
@@ -22,8 +22,8 @@
   font-size: 13px;
   margin-bottom: 10px;
   padding-bottom: 8px;
-  border-bottom: 1px solid rgba(var(--blert-button-base), 0.2);
-  color: var(--blert-button);
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.2);
+  color: var(--blert-purple);
 }
 
 .section {
@@ -36,7 +36,7 @@
 
 .label {
   font-size: 10px;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 2px;
@@ -44,12 +44,12 @@
 
 .value {
   font-weight: 500;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin-bottom: 2px;
 }
 
 .subValue {
   font-size: 10px;
-  color: var(--font-color-nav-active);
+  color: var(--blert-font-color-secondary-active);
   margin-left: 8px;
 }

--- a/web/app/setups/[id]/edit/style.module.scss
+++ b/web/app/setups/[id]/edit/style.module.scss
@@ -29,7 +29,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     z-index: 100;
 
@@ -43,9 +43,9 @@
       background: linear-gradient(
         90deg,
         transparent 0%,
-        rgba(var(--blert-button-base), 0.2) 25%,
-        rgba(var(--blert-button-base), 0.3) 50%,
-        rgba(var(--blert-button-base), 0.2) 75%,
+        rgba(var(--blert-purple-base), 0.2) 25%,
+        rgba(var(--blert-purple-base), 0.3) 50%,
+        rgba(var(--blert-purple-base), 0.2) 75%,
         transparent 100%
       );
     }
@@ -74,7 +74,7 @@
         background-color: transparent;
         border: 1px solid transparent;
         border-radius: 4px;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         transition: all 0.2s ease;
         cursor: pointer;
 
@@ -85,7 +85,7 @@
           &:hover {
             background-color: transparent;
             border-color: transparent;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
           }
 
           &:active {
@@ -94,12 +94,12 @@
         }
 
         &:not(:disabled):hover {
-          background-color: var(--nav-bg-lightened);
-          border-color: rgba(var(--blert-button-base), 0.3);
-          color: var(--blert-text-color);
+          background-color: var(--blert-surface-light);
+          border-color: rgba(var(--blert-purple-base), 0.3);
+          color: var(--blert-font-color-primary);
 
           i {
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
 
@@ -119,14 +119,14 @@
 
       .saveTime {
         font-size: 11px;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-weight: 500;
         white-space: nowrap;
         transition: color 0.2s ease;
         width: 24px;
 
         button:hover & {
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
         }
       }
 
@@ -137,8 +137,8 @@
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        background: var(--blert-button);
-        box-shadow: 0 0 6px rgba(var(--blert-button-base), 0.6);
+        background: var(--blert-purple);
+        box-shadow: 0 0 6px rgba(var(--blert-purple-base), 0.6);
         animation: pulse 2s ease-in-out infinite;
       }
 
@@ -198,7 +198,7 @@
     height: var(--anonymous-banner-height);
     left: $LEFT_NAV_WIDTH;
     width: calc(100% - $LEFT_NAV_WIDTH);
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     z-index: 100;
 
     .anonymousBannerContent {
@@ -222,7 +222,7 @@
       }
 
       a {
-        color: var(--blert-button);
+        color: var(--blert-purple);
 
         &:hover {
           text-decoration: underline;
@@ -338,7 +338,7 @@
       justify-content: center;
       height: $TOGGLE_BUTTON_HEIGHT;
       width: 100%;
-      background: var(--nav-bg);
+      background: var(--blert-surface-dark);
       border: none;
       color: #fff;
       font-size: 16px;
@@ -359,9 +359,9 @@
     left: 0;
     z-index: 98;
     padding: 10px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 0 5px 5px 0;
-    border: 1px solid var(--blert-button);
+    border: 1px solid var(--blert-purple);
     display: flex;
     align-items: center;
     gap: 8px;
@@ -383,10 +383,10 @@
     padding: 12px;
     background: linear-gradient(
       145deg,
-      rgba(var(--nav-bg-base), 0.6),
-      rgba(var(--nav-bg-darkened-base), 0.4)
+      rgba(var(--blert-surface-dark-base), 0.6),
+      rgba(var(--blert-surface-darker-base), 0.4)
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.1);
+    border: 1px solid rgba(var(--blert-purple-base), 0.1);
     border-radius: 6px;
   }
 
@@ -398,10 +398,10 @@
     padding: 8px 14px;
     background: linear-gradient(
       145deg,
-      rgba(var(--nav-bg-base), 0.6),
-      rgba(var(--nav-bg-darkened-base), 0.4)
+      rgba(var(--blert-surface-dark-base), 0.6),
+      rgba(var(--blert-surface-darker-base), 0.4)
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.15);
+    border: 1px solid rgba(var(--blert-purple-base), 0.15);
     border-radius: 6px;
     min-height: 48px;
     transition: all 0.2s ease;
@@ -414,12 +414,12 @@
       .name {
         font-size: 14px;
         font-weight: 500;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
 
     .clear {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       padding: 6px;
       font-size: 14px;
       transition: all 0.2s ease;
@@ -438,7 +438,7 @@
       gap: 8px;
       font-size: 14px;
       font-style: italic;
-      color: rgba(var(--blert-text-color-base), 0.6);
+      color: rgba(var(--blert-font-color-primary-base), 0.6);
 
       .placeholderIcon {
         width: 24px;
@@ -458,11 +458,11 @@
     &:has(.item) {
       background: linear-gradient(
         145deg,
-        rgba(var(--blert-button-base), 0.12),
-        rgba(var(--blert-button-base), 0.08)
+        rgba(var(--blert-purple-base), 0.12),
+        rgba(var(--blert-purple-base), 0.08)
       );
-      border-color: rgba(var(--blert-button-base), 0.3);
-      box-shadow: 0 0 0 1px rgba(var(--blert-button-base), 0.05);
+      border-color: rgba(var(--blert-purple-base), 0.3);
+      box-shadow: 0 0 0 1px rgba(var(--blert-purple-base), 0.05);
     }
   }
 
@@ -489,14 +489,14 @@
     align-items: center;
     margin-bottom: 12px;
     padding: 0 4px 8px 4px;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.15);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
   }
 
   .sectionHeading {
     font-size: 1rem;
     font-weight: 600;
     margin: 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .categoryActions {
@@ -512,16 +512,16 @@
     margin-bottom: 8px;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.08),
-      rgba(var(--blert-button-base), 0.04)
+      rgba(var(--blert-purple-base), 0.08),
+      rgba(var(--blert-purple-base), 0.04)
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 5px;
     font-size: 0.85rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.9rem;
     }
 
@@ -538,12 +538,12 @@
     padding: 6px 12px;
     background: linear-gradient(
       145deg,
-      rgba(var(--nav-bg-base), 0.6),
-      rgba(var(--nav-bg-darkened-base), 0.4)
+      rgba(var(--blert-surface-dark-base), 0.6),
+      rgba(var(--blert-surface-darker-base), 0.4)
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 5px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.85rem;
     font-weight: 500;
     width: 80px;
@@ -567,14 +567,14 @@
     &:hover:not(:disabled) {
       background: linear-gradient(
         145deg,
-        rgba(var(--blert-button-base), 0.15),
-        rgba(var(--blert-button-base), 0.1)
+        rgba(var(--blert-purple-base), 0.15),
+        rgba(var(--blert-purple-base), 0.1)
       );
-      border-color: rgba(var(--blert-button-base), 0.4);
-      color: var(--blert-text-color);
+      border-color: rgba(var(--blert-purple-base), 0.4);
+      color: var(--blert-font-color-primary);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 
@@ -586,10 +586,10 @@
   .section {
     background: linear-gradient(
       145deg,
-      rgba(var(--nav-bg-base), 0.6),
-      rgba(var(--nav-bg-darkened-base), 0.4)
+      rgba(var(--blert-surface-dark-base), 0.6),
+      rgba(var(--blert-surface-darker-base), 0.4)
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.1);
+    border: 1px solid rgba(var(--blert-purple-base), 0.1);
     width: 100%;
     display: flex;
     flex-flow: row wrap;
@@ -599,7 +599,7 @@
     transition: all 0.2s ease;
 
     &.editMode {
-      background: rgba(var(--blert-button-base), 0.03);
+      background: rgba(var(--blert-purple-base), 0.03);
       border-color: rgba(var(--blert-yellow-base), 0.25);
       box-shadow: inset 0 0 0 1px rgba(var(--blert-yellow-base), 0.1);
     }
@@ -615,7 +615,7 @@
         transform: translate(-50%, -50%);
         width: 30px;
         height: 30px;
-        border: 2px solid var(--panel-bg);
+        border: 2px solid var(--blert-panel-background-color);
         border-radius: 50%;
         color: white;
         font-size: 12px;
@@ -677,9 +677,9 @@
       transition: all 0.2s ease;
 
       &.selected {
-        border-color: var(--blert-button);
-        background: rgba(var(--blert-button-base), 0.15);
-        box-shadow: 0 0 8px rgba(var(--blert-button-base), 0.3);
+        border-color: var(--blert-purple);
+        background: rgba(var(--blert-purple-base), 0.15);
+        box-shadow: 0 0 8px rgba(var(--blert-purple-base), 0.3);
       }
 
       &.hidden {
@@ -705,8 +705,8 @@
           transform: scale(1.08);
 
           &:not(.selected) {
-            background: rgba(var(--nav-bg-lightened-base), 0.6);
-            border-color: rgba(var(--blert-button-base), 0.2);
+            background: rgba(var(--blert-surface-light-base), 0.6);
+            border-color: rgba(var(--blert-purple-base), 0.2);
           }
         }
 
@@ -720,22 +720,22 @@
       }
 
       &:has(.add) {
-        border-color: rgba(var(--blert-button-base), 0.15);
+        border-color: rgba(var(--blert-purple-base), 0.15);
 
         &:hover {
           transform: none;
 
           i {
-            color: var(--blert-button);
+            color: var(--blert-purple);
           }
         }
       }
 
       &.hasSearch {
-        border-color: rgba(var(--blert-button-base), 0.8) !important;
+        border-color: rgba(var(--blert-purple-base), 0.8) !important;
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
         }
       }
     }
@@ -749,7 +749,7 @@
 
     i {
       font-size: 1.1rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       transition: color 0.2s ease;
     }
   }
@@ -777,11 +777,11 @@
     justify-content: space-between;
     align-items: center;
     padding: 1.5rem;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.15);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
     background: linear-gradient(
       135deg,
-      var(--panel-bg) 0%,
-      rgba(var(--nav-bg-base), 0.8) 100%
+      var(--blert-panel-background-color) 0%,
+      rgba(var(--blert-surface-dark-base), 0.8) 100%
     );
 
     h2 {
@@ -791,10 +791,10 @@
       margin: 0;
       font-size: 1.5rem;
       font-weight: 700;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1.25rem;
       }
 
@@ -816,13 +816,13 @@
       background: none;
       border: none;
       border-radius: 6px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 1.25rem;
       cursor: pointer;
       transition: all 0.2s ease;
 
       &:hover {
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
         color: var(--blert-red);
       }
     }
@@ -850,10 +850,10 @@
     padding: 1.25rem;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.1) 0%,
-      rgba(var(--blert-button-base), 0.05) 100%
+      rgba(var(--blert-purple-base), 0.1) 0%,
+      rgba(var(--blert-purple-base), 0.05) 100%
     );
-    border: 2px solid rgba(var(--blert-button-base), 0.3);
+    border: 2px solid rgba(var(--blert-purple-base), 0.3);
     border-radius: 12px;
 
     .noticeIcon {
@@ -862,12 +862,12 @@
       justify-content: center;
       width: 48px;
       height: 48px;
-      background: rgba(var(--blert-button-base), 0.2);
+      background: rgba(var(--blert-purple-base), 0.2);
       border-radius: 10px;
       flex-shrink: 0;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1.5rem;
       }
     }
@@ -879,12 +879,12 @@
         margin: 0 0 0.5rem 0;
         font-size: 1.1rem;
         font-weight: 600;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
 
       p {
         margin: 0;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-size: 0.9rem;
         line-height: 1.5;
       }
@@ -893,15 +893,15 @@
 
   .benefits {
     padding: 1.25rem;
-    background: var(--nav-bg);
-    border: 1px solid var(--font-color-nav-divider);
+    background: var(--blert-surface-dark);
+    border: 1px solid var(--blert-divider-color);
     border-radius: 10px;
 
     h4 {
       margin: 0 0 1rem 0;
       font-size: 1rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     ul {
@@ -931,13 +931,13 @@
           gap: 0.125rem;
 
           strong {
-            color: var(--blert-text-color);
+            color: var(--blert-font-color-primary);
             font-size: 0.95rem;
             font-weight: 600;
           }
 
           span {
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
             font-size: 0.85rem;
             line-height: 1.4;
           }
@@ -952,7 +952,7 @@
     gap: 0.75rem;
 
     .previewLabel {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.85rem;
       font-weight: 500;
       text-transform: uppercase;
@@ -964,8 +964,8 @@
       align-items: center;
       gap: 1rem;
       padding: 1rem;
-      background: var(--panel-bg);
-      border: 1px solid var(--font-color-nav-divider);
+      background: var(--blert-panel-background-color);
+      border: 1px solid var(--blert-divider-color);
       border-radius: 8px;
 
       .previewIcon {
@@ -974,13 +974,13 @@
         justify-content: center;
         width: 48px;
         height: 48px;
-        background: rgba(var(--blert-button-base), 0.1);
-        border: 1px solid rgba(var(--blert-button-base), 0.3);
+        background: rgba(var(--blert-purple-base), 0.1);
+        border: 1px solid rgba(var(--blert-purple-base), 0.3);
         border-radius: 8px;
         flex-shrink: 0;
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 1.5rem;
         }
       }
@@ -991,7 +991,7 @@
 
         .previewName {
           display: block;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           font-size: 1rem;
           font-weight: 600;
           margin-bottom: 0.25rem;
@@ -1010,7 +1010,7 @@
             display: flex;
             align-items: center;
             gap: 0.4rem;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
             font-size: 0.85rem;
 
             i {
@@ -1028,10 +1028,10 @@
     padding: 1.25rem;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.08) 0%,
-      rgba(var(--blert-button-base), 0.02) 100%
+      rgba(var(--blert-purple-base), 0.08) 0%,
+      rgba(var(--blert-purple-base), 0.02) 100%
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.3);
+    border: 1px solid rgba(var(--blert-purple-base), 0.3);
     border-radius: 12px;
 
     .infoIcon {
@@ -1057,12 +1057,12 @@
         margin: 0 0 0.5rem 0;
         font-size: 1.1rem;
         font-weight: 600;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
 
       p {
         margin: 0;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-size: 0.9rem;
         line-height: 1.5;
 
@@ -1144,25 +1144,25 @@
       gap: 0.5rem;
       font-size: 0.95rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 0.9rem;
       }
 
       .optional {
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-weight: 400;
         font-size: 0.85rem;
       }
     }
 
     textarea {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       padding: 0.75rem;
-      background: var(--panel-bg);
-      border: 1px solid var(--font-color-nav-divider);
+      background: var(--blert-panel-background-color);
+      border: 1px solid var(--blert-divider-color);
       border-radius: 6px;
       font-size: 0.9rem;
       font-family: inherit;
@@ -1172,18 +1172,18 @@
 
       &:focus {
         outline: none;
-        border-color: var(--blert-button);
-        background: var(--nav-bg);
+        border-color: var(--blert-purple);
+        background: var(--blert-surface-dark);
       }
 
       &::placeholder {
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
     }
 
     .characterCount {
       text-align: right;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.8rem;
     }
   }
@@ -1193,7 +1193,7 @@
     justify-content: flex-end;
     gap: 0.75rem;
     padding-top: 1rem;
-    border-top: 1px solid var(--font-color-nav-divider);
+    border-top: 1px solid var(--blert-divider-color);
 
     button {
       display: flex;
@@ -1220,7 +1220,7 @@
   }
 
   .signupButton {
-    background: var(--blert-button);
+    background: var(--blert-purple);
     color: #fff;
     position: relative;
     overflow: hidden;
@@ -1246,8 +1246,8 @@
     }
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.9);
-      box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.4);
+      background: rgba(var(--blert-purple-base), 0.9);
+      box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.4);
     }
 
     &:active {
@@ -1267,11 +1267,11 @@
   .signInPrompt {
     text-align: center;
     padding-top: 0.5rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.9rem;
 
     a {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       text-decoration: none;
       font-weight: 500;
 
@@ -1290,18 +1290,18 @@
     justify-content: space-between;
     align-items: center;
     padding: 20px 24px;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.15);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
     background: linear-gradient(
       135deg,
-      var(--panel-bg) 0%,
-      rgba(var(--nav-bg-base), 0.8) 100%
+      var(--blert-panel-background-color) 0%,
+      rgba(var(--blert-surface-dark-base), 0.8) 100%
     );
 
     h2 {
       margin: 0;
       font-size: 1.25rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     button {
@@ -1311,10 +1311,10 @@
       cursor: pointer;
       transition: all 0.2s ease;
       font-size: 16px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       &:hover {
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
   }
@@ -1326,8 +1326,8 @@
     gap: 24px;
     background: linear-gradient(
       135deg,
-      rgba(var(--nav-bg-base), 0.3) 0%,
-      rgba(var(--panel-bg-base), 0.2) 100%
+      rgba(var(--blert-surface-dark-base), 0.3) 0%,
+      rgba(var(--blert-panel-background-color-base), 0.2) 100%
     );
 
     @media (max-width: 768px) {
@@ -1347,8 +1347,8 @@
       display: flex;
       align-items: center;
       padding-bottom: 8px;
-      border-bottom: 1px solid rgba(var(--blert-button-base), 0.2);
-      color: var(--blert-text-color);
+      border-bottom: 1px solid rgba(var(--blert-purple-base), 0.2);
+      color: var(--blert-font-color-primary);
     }
   }
 
@@ -1366,20 +1366,20 @@
     padding: 10px 14px;
     background: linear-gradient(
       135deg,
-      rgba(var(--nav-bg-base), 0.6) 0%,
-      rgba(var(--nav-bg-darkened-base), 0.4) 100%
+      rgba(var(--blert-surface-dark-base), 0.6) 0%,
+      rgba(var(--blert-surface-darker-base), 0.4) 100%
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.1);
+    border: 1px solid rgba(var(--blert-purple-base), 0.1);
     border-radius: 6px;
     transition: all 0.2s ease;
 
     &:hover {
       background: linear-gradient(
         135deg,
-        rgba(var(--nav-bg-base), 0.8) 0%,
-        rgba(var(--nav-bg-darkened-base), 0.6) 100%
+        rgba(var(--blert-surface-dark-base), 0.8) 0%,
+        rgba(var(--blert-surface-darker-base), 0.6) 100%
       );
-      border-color: rgba(var(--blert-button-base), 0.25);
+      border-color: rgba(var(--blert-purple-base), 0.25);
       transform: translateX(2px);
     }
 
@@ -1393,16 +1393,16 @@
     .key {
       background: linear-gradient(
         145deg,
-        var(--panel-bg),
-        var(--nav-bg-darkened)
+        var(--blert-panel-background-color),
+        var(--blert-surface-darker)
       );
-      border: 1px solid rgba(var(--blert-text-color-base), 0.3);
+      border: 1px solid rgba(var(--blert-font-color-primary-base), 0.3);
       border-radius: 4px;
       padding: 4px 10px;
       font-family: var(--font-roboto-mono), monospace;
       font-size: 13px;
       font-weight: 500;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       box-shadow:
         0 2px 0 rgba(0, 0, 0, 0.3),
         inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -1412,7 +1412,7 @@
 
     .description {
       font-size: 14px;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       text-align: right;
       flex: 1;
       line-height: 1.4;
@@ -1434,13 +1434,13 @@
       margin: 0;
       font-size: 18px;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       display: flex;
       align-items: center;
       gap: 8px;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
 
@@ -1451,10 +1451,10 @@
       cursor: pointer;
       transition: color 0.2s;
       font-size: 16px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
 
       &:hover {
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
   }
@@ -1467,10 +1467,10 @@
 
     textarea {
       min-width: 300px;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       padding: 12px;
-      background: var(--nav-bg);
-      border: 1px solid rgba(var(--blert-button-base), 0.3);
+      background: var(--blert-surface-dark);
+      border: 1px solid rgba(var(--blert-purple-base), 0.3);
       border-radius: 5px;
       font-size: 14px;
       font-family: inherit;
@@ -1480,17 +1480,17 @@
 
       &:focus {
         outline: none;
-        border-color: var(--blert-button);
+        border-color: var(--blert-purple);
       }
 
       &::placeholder {
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
     }
 
     .characterCount {
       font-size: 12px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       text-align: right;
       margin-top: -4px;
     }

--- a/web/app/setups/[id]/style.module.scss
+++ b/web/app/setups/[id]/style.module.scss
@@ -42,7 +42,7 @@
     margin: 0 0 1rem 0;
     font-size: 2.25rem;
     font-weight: 700;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     line-height: 1.2;
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -59,21 +59,21 @@
     padding: 12px 16px;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.1) 0%,
-      rgba(var(--blert-button-base), 0.05) 100%
+      rgba(var(--blert-purple-base), 0.1) 0%,
+      rgba(var(--blert-purple-base), 0.05) 100%
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 8px;
     font-size: 0.9rem;
     line-height: 1.4;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1em;
     }
 
     a {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       text-decoration: none;
       font-weight: 500;
 
@@ -119,40 +119,40 @@
     gap: 6px;
     font-size: 0.9rem;
     font-weight: 500;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 0.9em;
     }
   }
 
   .author {
     .username {
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 600;
     }
   }
 
   .challenge {
-    background: var(--nav-bg-darkened);
+    background: var(--blert-surface-darker);
     padding: 6px 10px;
     border-radius: 12px;
     font-size: 0.85rem;
-    border: 1px solid rgba(var(--blert-button-base), 0.1);
-    color: var(--font-color-nav);
+    border: 1px solid rgba(var(--blert-purple-base), 0.1);
+    color: var(--blert-font-color-secondary);
   }
 
   .version {
-    background: var(--nav-bg-darkened);
+    background: var(--blert-surface-darker);
     padding: 6px 10px;
     border-radius: 12px;
     font-size: 0.85rem;
-    border: 1px solid rgba(var(--blert-button-base), 0.1);
+    border: 1px solid rgba(var(--blert-purple-base), 0.1);
   }
 
   .views {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -229,10 +229,10 @@
   gap: 8px;
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 }
 
@@ -240,9 +240,9 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  background: var(--nav-bg);
-  border: 1px solid var(--font-color-nav-divider);
-  color: var(--font-color-nav);
+  background: var(--blert-surface-dark);
+  border: 1px solid var(--blert-divider-color);
+  color: var(--blert-font-color-secondary);
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 0.85rem;
@@ -250,9 +250,9 @@
   transition: all 0.2s ease;
 
   &:hover {
-    background: var(--nav-bg-lightened);
-    border-color: var(--blert-button);
-    color: var(--blert-text-color);
+    background: var(--blert-surface-light);
+    border-color: var(--blert-purple);
+    color: var(--blert-font-color-primary);
   }
 
   i {
@@ -264,7 +264,7 @@
 .currentRevision {
   margin-bottom: 1rem;
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid var(--font-color-nav-divider);
+  border-bottom: 1px solid var(--blert-divider-color);
 }
 
 .revisions {
@@ -285,10 +285,10 @@
       gap: 8px;
       font-size: 1.2em;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1.1em;
       }
     }
@@ -296,10 +296,10 @@
     .current {
       font-size: 0.85rem;
       font-weight: 500;
-      background: var(--nav-bg-darkened);
+      background: var(--blert-surface-darker);
       padding: 4px 8px;
       border-radius: 10px;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
   }
 
@@ -309,7 +309,7 @@
     justify-content: center;
     gap: 12px;
     padding: 2rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-style: italic;
 
     i {
@@ -328,14 +328,14 @@
     flex-direction: column;
     gap: 8px;
     padding: 12px 16px;
-    background: var(--nav-bg);
-    border: 1px solid rgba(var(--blert-button-base), 0.05);
+    background: var(--blert-surface-dark);
+    border: 1px solid rgba(var(--blert-purple-base), 0.05);
     border-radius: 8px;
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
-      border-color: rgba(var(--blert-button-base), 0.15);
+      background: var(--blert-surface-light);
+      border-color: rgba(var(--blert-purple-base), 0.15);
     }
   }
 
@@ -348,10 +348,10 @@
   .revisionVersion {
     font-size: 0.85rem;
     font-weight: 500;
-    background: var(--nav-bg-darkened);
+    background: var(--blert-surface-darker);
     padding: 4px 8px;
     border-radius: 10px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     a {
       color: inherit;
@@ -359,7 +359,7 @@
       transition: color 0.2s ease;
 
       &:hover {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -374,18 +374,18 @@
 
   .revisionAuthor {
     font-weight: 500;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   .revisionDate {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .revisionMessage {
     font-size: 0.9rem;
     line-height: 1.5;
     white-space: pre-wrap;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 }
 
@@ -415,10 +415,10 @@
     left: 50%;
     bottom: -8px;
     transform: translateX(-50%);
-    background: var(--nav-bg);
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    background: var(--blert-surface-dark);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 20px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 0.85rem;
     font-weight: 500;
     cursor: pointer;
@@ -427,8 +427,8 @@
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 
     &:hover {
-      background: var(--nav-bg-lightened);
-      border-color: rgba(var(--blert-button-base), 0.3);
+      background: var(--blert-surface-light);
+      border-color: rgba(var(--blert-purple-base), 0.3);
       transform: translateX(-50%) translateY(-2px);
     }
 
@@ -467,16 +467,16 @@
   font-weight: 500;
   text-decoration: none;
   transition: all 0.2s ease;
-  background: var(--blert-button);
+  background: var(--blert-purple);
   color: #fff;
-  border: 1px solid var(--blert-button);
+  border: 1px solid var(--blert-purple);
 
   i {
     font-size: 0.9em;
   }
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.8);
+    background: rgba(var(--blert-purple-base), 0.8);
     transform: translateY(-1px);
   }
 }
@@ -490,18 +490,18 @@
   font-size: 0.9rem;
   font-weight: 500;
   transition: all 0.2s ease;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
   cursor: pointer;
-  background: var(--nav-bg);
-  color: var(--blert-text-color);
+  background: var(--blert-surface-dark);
+  color: var(--blert-font-color-primary);
 
   i {
     font-size: 0.9em;
   }
 
   &:hover {
-    background: var(--nav-bg-lightened);
-    border-color: var(--blert-button);
+    background: var(--blert-surface-light);
+    border-color: var(--blert-purple);
     transform: translateY(-1px);
   }
 

--- a/web/app/setups/delete-modal.module.scss
+++ b/web/app/setups/delete-modal.module.scss
@@ -10,7 +10,7 @@
 
   p {
     margin: 0 0 24px 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
   }
 
   .actions {
@@ -59,7 +59,7 @@
     .current {
       font-size: 14px;
       font-weight: 500;
-      background: var(--nav-bg-darkened);
+      background: var(--blert-surface-darker);
       padding: 4px 6px;
       border-radius: 10px;
     }
@@ -81,12 +81,12 @@
     flex-direction: column;
     gap: 4px;
     padding: 8px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 4px;
     transition: background-color 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
     }
   }
 
@@ -99,7 +99,7 @@
   .revisionVersion {
     font-size: 14px;
     font-weight: 500;
-    background: var(--nav-bg-darkened);
+    background: var(--blert-surface-darker);
     padding: 4px 6px;
     border-radius: 10px;
 
@@ -108,7 +108,7 @@
       text-decoration: none;
 
       &:hover {
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
     }
   }
@@ -125,7 +125,7 @@
   }
 
   .revisionDate {
-    color: rgba(var(--blert-text-color-base), 0.8);
+    color: rgba(var(--blert-font-color-primary-base), 0.8);
   }
 
   .revisionMessage {

--- a/web/app/setups/local-setups-list.module.scss
+++ b/web/app/setups/local-setups-list.module.scss
@@ -13,7 +13,7 @@
   gap: 0.75rem;
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   .badge {
@@ -51,7 +51,7 @@
 
     p {
       margin: 0 0 0.5rem 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 0.9rem;
       line-height: 1.5;
 
@@ -65,7 +65,7 @@
     }
 
     a {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       text-decoration: none;
       font-weight: 500;
 
@@ -88,14 +88,14 @@
   justify-content: space-between;
   gap: 1rem;
   padding: 1rem;
-  background: var(--nav-bg);
-  border: 1px solid var(--font-color-nav-divider);
+  background: var(--blert-surface-dark);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 8px;
   transition: all 0.2s ease;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
-    background: var(--nav-bg-lightened);
+    border-color: rgba(var(--blert-purple-base), 0.3);
+    background: var(--blert-surface-light);
   }
 
   @media (max-width: 940px) {
@@ -141,7 +141,7 @@
   h3 {
     margin: 0 0 0.5rem 0;
     font-size: 1rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 600;
     white-space: nowrap;
     overflow: hidden;
@@ -157,17 +157,17 @@
     span {
       display: flex;
       align-items: center;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.85rem;
       white-space: nowrap;
-      background: var(--nav-bg-darkened);
+      background: var(--blert-surface-darker);
       padding: 4px 8px;
       border-radius: 12px;
 
       i {
         font-size: 0.8rem;
         margin-right: 4px;
-        color: var(--blert-button);
+        color: var(--blert-purple);
       }
 
       time {
@@ -218,19 +218,19 @@
 }
 
 .editButton {
-  background: var(--blert-button);
+  background: var(--blert-purple);
   color: #fff;
   border: none;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.9);
+    background: rgba(var(--blert-purple-base), 0.9);
   }
 }
 
 .deleteButton {
   background: none;
-  border: 1px solid var(--font-color-nav-divider);
-  color: var(--font-color-nav);
+  border: 1px solid var(--blert-divider-color);
+  color: var(--blert-font-color-secondary);
 
   &:hover {
     border-color: var(--blert-red);
@@ -250,7 +250,7 @@
   justify-content: center;
   gap: 1rem;
   padding: 2rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   i {
     font-size: 1.5rem;
@@ -268,19 +268,19 @@
 
   i {
     font-size: 3rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     opacity: 0.5;
   }
 
   h3 {
     margin: 0;
     font-size: 1.25rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   p {
     margin: 0;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.95rem;
   }
 }
@@ -290,7 +290,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: var(--blert-button);
+  background: var(--blert-purple);
   color: #fff;
   text-decoration: none;
   border-radius: 6px;
@@ -299,7 +299,7 @@
   transition: all 0.2s ease;
 
   &:hover {
-    background: rgba(var(--blert-button-base), 0.9);
+    background: rgba(var(--blert-purple-base), 0.9);
   }
 
   i {

--- a/web/app/setups/my/style.module.scss
+++ b/web/app/setups/my/style.module.scss
@@ -3,11 +3,11 @@
 .migrationBanner {
   padding: 1.5rem;
   margin-bottom: 2rem;
-  border: 2px solid rgba(var(--blert-button-base), 0.3);
+  border: 2px solid rgba(var(--blert-purple-base), 0.3);
   background: linear-gradient(
     135deg,
-    rgba(var(--blert-button-base), 0.08) 0%,
-    rgba(var(--blert-button-base), 0.02) 50%,
+    rgba(var(--blert-purple-base), 0.08) 0%,
+    rgba(var(--blert-purple-base), 0.02) 50%,
     transparent 100%
   );
   box-shadow:
@@ -26,7 +26,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      var(--blert-button),
+      var(--blert-purple),
       transparent
     );
     animation: borderSlide 3s ease-in-out infinite;
@@ -69,15 +69,15 @@
     height: 64px;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.2) 0%,
-      rgba(var(--blert-button-base), 0.05) 100%
+      rgba(var(--blert-purple-base), 0.2) 0%,
+      rgba(var(--blert-purple-base), 0.05) 100%
     );
-    border: 2px solid rgba(var(--blert-button-base), 0.4);
+    border: 2px solid rgba(var(--blert-purple-base), 0.4);
     border-radius: 12px;
     flex-shrink: 0;
 
     > i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 2rem;
       z-index: 1;
     }
@@ -101,7 +101,7 @@
     height: 100%;
     background: radial-gradient(
       circle,
-      rgba(var(--blert-button-base), 0.4) 0%,
+      rgba(var(--blert-purple-base), 0.4) 0%,
       transparent 70%
     );
     border-radius: 12px;
@@ -130,11 +130,11 @@
       gap: 0.5rem;
       margin: 0 0 0.5rem 0;
       font-size: 1.5rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 700;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1.25rem;
       }
 
@@ -149,12 +149,12 @@
 
     p {
       margin: 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 1rem;
       line-height: 1.6;
 
       strong {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-weight: 600;
       }
 
@@ -182,22 +182,22 @@
     justify-content: space-between;
     width: 100%;
     padding: 0.75rem 1rem;
-    background: var(--nav-bg);
-    border: 1px solid var(--font-color-nav-divider);
+    background: var(--blert-surface-dark);
+    border: 1px solid var(--blert-divider-color);
     border-radius: 6px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
-      border-color: rgba(var(--blert-button-base), 0.3);
+      background: var(--blert-surface-light);
+      border-color: rgba(var(--blert-purple-base), 0.3);
     }
 
     i {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.85rem;
       transition: transform 0.2s ease;
     }
@@ -207,7 +207,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    background: rgba(var(--panel-bg), 0.5);
+    background: rgba(var(--blert-panel-background-color), 0.5);
     max-height: 300px;
     overflow-y: auto;
     animation: slideDown 0.3s ease-out;
@@ -240,8 +240,8 @@
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem;
-    background: var(--nav-bg);
-    border: 1px solid var(--font-color-nav-divider);
+    background: var(--blert-surface-dark);
+    border: 1px solid var(--blert-divider-color);
     border-radius: 6px;
     transition: all 0.2s ease;
     animation: fadeIn 0.2s ease-out;
@@ -274,13 +274,13 @@
       justify-content: center;
       width: 40px;
       height: 40px;
-      background: rgba(var(--blert-button-base), 0.1);
-      border: 1px solid rgba(var(--blert-button-base), 0.3);
+      background: rgba(var(--blert-purple-base), 0.1);
+      border: 1px solid rgba(var(--blert-purple-base), 0.3);
       border-radius: 6px;
       flex-shrink: 0;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1.1rem;
       }
 
@@ -302,7 +302,7 @@
       min-width: 0;
 
       .setupName {
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         font-size: 0.95rem;
         font-weight: 600;
         white-space: nowrap;
@@ -324,7 +324,7 @@
           display: flex;
           align-items: center;
           gap: 0.35rem;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           font-size: 0.8rem;
           white-space: nowrap;
 
@@ -377,7 +377,7 @@
     gap: 0.75rem;
     align-items: center;
     padding-top: 1rem;
-    border-top: 1px solid var(--font-color-nav-divider);
+    border-top: 1px solid var(--blert-divider-color);
     justify-content: flex-end;
 
     @media (max-width: 940px) {
@@ -404,8 +404,8 @@
       overflow: hidden;
 
       &:hover {
-        background: rgba(var(--blert-button-base), 0.9);
-        box-shadow: 0 4px 12px rgba(var(--blert-button-base), 0.3);
+        background: rgba(var(--blert-purple-base), 0.9);
+        box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.3);
       }
 
       &:active {
@@ -444,8 +444,8 @@
     }
 
     .dismissButton {
-      border: 1px solid var(--font-color-nav-divider);
-      color: var(--font-color-nav);
+      border: 1px solid var(--blert-divider-color);
+      color: var(--blert-font-color-secondary);
       font-size: 0.95rem;
       font-weight: 500;
       white-space: nowrap;
@@ -461,8 +461,8 @@
         cursor: not-allowed;
 
         &:hover {
-          border-color: var(--font-color-nav-divider);
-          color: var(--font-color-nav);
+          border-color: var(--blert-divider-color);
+          color: var(--blert-font-color-secondary);
           background: none;
         }
       }

--- a/web/app/setups/new/style.module.scss
+++ b/web/app/setups/new/style.module.scss
@@ -18,17 +18,17 @@
     margin-bottom: 1.5rem;
     position: relative;
     padding: 1.2em 1.8em;
-    border-bottom: 1px solid rgba(var(--blert-button-base), 0.15);
+    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
     background: linear-gradient(
       135deg,
-      var(--panel-bg) 0%,
-      rgba(var(--nav-bg-base), 0.8) 100%
+      var(--blert-panel-background-color) 0%,
+      rgba(var(--blert-surface-dark-base), 0.8) 100%
     );
 
     h2 {
       margin: 0;
       font-size: 1.7rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       flex: 1;
       font-weight: 500;
 
@@ -40,7 +40,7 @@
     > button {
       background: none;
       border: none;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 1.25rem;
       cursor: pointer;
       padding: 0.5rem;
@@ -53,8 +53,8 @@
       height: 36px;
 
       &:hover {
-        background: var(--nav-bg);
-        color: var(--blert-text-color);
+        background: var(--blert-surface-dark);
+        color: var(--blert-font-color-primary);
       }
 
       &:active {
@@ -64,7 +64,7 @@
   }
 
   .description {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 1rem;
     line-height: 1.5;
     margin: 0 0 2rem 0;
@@ -112,14 +112,14 @@
   flex-direction: column;
   gap: 1rem;
   padding: 1.5rem;
-  background: var(--nav-bg);
-  border: 1px solid var(--font-color-nav-divider);
+  background: var(--blert-surface-dark);
+  border: 1px solid var(--blert-divider-color);
   border-radius: 8px;
   transition: all 0.2s ease;
 
   &:hover {
     transform: translateY(-2px);
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   }
 
@@ -145,26 +145,26 @@
 .signupOption {
   background: linear-gradient(
     135deg,
-    rgba(var(--blert-button-base), 0.1) 0%,
-    rgba(var(--blert-button-base), 0.05) 100%
+    rgba(var(--blert-purple-base), 0.1) 0%,
+    rgba(var(--blert-purple-base), 0.05) 100%
   );
-  border-color: rgba(var(--blert-button-base), 0.3);
+  border-color: rgba(var(--blert-purple-base), 0.3);
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.5);
+    border-color: rgba(var(--blert-purple-base), 0.5);
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.15) 0%,
-      rgba(var(--blert-button-base), 0.08) 100%
+      rgba(var(--blert-purple-base), 0.15) 0%,
+      rgba(var(--blert-purple-base), 0.08) 100%
     );
   }
 
   button {
-    background: var(--blert-button);
+    background: var(--blert-purple);
     color: #fff;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.9);
+      background: rgba(var(--blert-purple-base), 0.9);
     }
   }
 }
@@ -177,19 +177,19 @@
 
   i {
     font-size: 1.5rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
   }
 
   h3 {
     margin: 0;
     font-size: 1.05rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 600;
   }
 }
 
 .optionDescription {
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.9rem;
   margin: 0;
   line-height: 1.4;
@@ -200,18 +200,18 @@
   flex-direction: column;
   gap: 0.25rem;
   padding: 0.75rem;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 6px;
-  border: 1px solid var(--font-color-nav-divider);
+  border: 1px solid var(--blert-divider-color);
 
   .title {
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 500;
     font-size: 0.95rem;
   }
 
   .meta {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 0.85rem;
   }
 }
@@ -228,7 +228,7 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.9rem;
     line-height: 1.4;
 
@@ -244,14 +244,14 @@
   display: flex;
   justify-content: center;
   padding-top: 1rem;
-  border-top: 1px solid var(--font-color-nav-divider);
+  border-top: 1px solid var(--blert-divider-color);
   padding-bottom: 1em;
 }
 
 .cancelLink {
   background: none;
   border: none;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
   font-size: 0.9rem;
   cursor: pointer;
   padding: 0.5rem 1rem;
@@ -259,8 +259,8 @@
   transition: all 0.2s ease;
 
   &:hover {
-    color: var(--blert-text-color);
-    background: var(--nav-bg);
+    color: var(--blert-font-color-primary);
+    background: var(--blert-surface-dark);
   }
 }
 
@@ -285,33 +285,33 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem;
-  background: var(--nav-bg);
-  border: 2px solid var(--font-color-nav-divider);
+  background: var(--blert-surface-dark);
+  border: 2px solid var(--blert-divider-color);
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.5);
-    background: var(--nav-bg-lightened);
+    border-color: rgba(var(--blert-purple-base), 0.5);
+    background: var(--blert-surface-light);
   }
 
   &.selected {
-    border-color: var(--blert-button);
-    background: rgba(var(--blert-button-base), 0.1);
+    border-color: var(--blert-purple);
+    background: rgba(var(--blert-purple-base), 0.1);
 
     .setupInfo h3 {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     > i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1.5rem;
     }
   }
 
   > i {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 1.25rem;
     transition: all 0.2s ease;
   }
@@ -326,7 +326,7 @@
   h3 {
     margin: 0;
     font-size: 1rem;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 600;
     transition: color 0.2s ease;
   }
@@ -341,7 +341,7 @@
       display: flex;
       align-items: center;
       gap: 0.4rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.85rem;
 
       i {
@@ -356,7 +356,7 @@
   gap: 0.75rem;
   justify-content: flex-end;
   padding: 1em 1.8em;
-  border-top: 1px solid var(--font-color-nav-divider);
+  border-top: 1px solid var(--blert-divider-color);
 
   button {
     padding: 0.75rem 1.5rem;

--- a/web/app/setups/page.module.scss
+++ b/web/app/setups/page.module.scss
@@ -43,8 +43,8 @@
       margin: 0 0 0.5rem 0;
       background: linear-gradient(
         135deg,
-        var(--blert-text-color),
-        rgba(var(--blert-text-color-base), 0.8)
+        var(--blert-font-color-primary),
+        rgba(var(--blert-font-color-primary-base), 0.8)
       );
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
@@ -57,7 +57,7 @@
     }
 
     .subtitle {
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 1.1rem;
       margin: 0;
       line-height: 1.5;
@@ -78,7 +78,7 @@
     padding: 12px 24px;
     border-radius: 6px;
     font-weight: 500;
-    background: var(--blert-button);
+    background: var(--blert-purple);
     color: #fff;
     transition: all 0.2s ease;
     text-decoration: none;
@@ -86,7 +86,7 @@
     white-space: nowrap;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.8);
+      background: rgba(var(--blert-purple-base), 0.8);
       transform: translateY(-1px);
 
       i {
@@ -142,10 +142,10 @@
   gap: 8px;
   font-size: 1.2em;
   font-weight: 600;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1.1em;
   }
 }
@@ -154,14 +154,14 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  color: var(--blert-button);
+  color: var(--blert-purple);
   text-decoration: none;
   font-size: 0.9rem;
   font-weight: 500;
   transition: all 0.2s ease;
 
   &:hover {
-    color: rgba(var(--blert-button-base), 0.8);
+    color: rgba(var(--blert-purple-base), 0.8);
 
     i {
       transform: translateX(2px);
@@ -192,15 +192,15 @@
   padding: 3rem 2rem;
   background: linear-gradient(
     135deg,
-    rgba(var(--blert-button-base), 0.05) 0%,
-    rgba(var(--nav-bg-base), 0.3) 100%
+    rgba(var(--blert-purple-base), 0.05) 0%,
+    rgba(var(--blert-surface-dark-base), 0.3) 100%
   );
   border-radius: 12px;
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
 
   i {
     font-size: 3rem;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     margin-bottom: 1rem;
     opacity: 0.8;
   }
@@ -209,11 +209,11 @@
     font-size: 1.5rem;
     font-weight: 600;
     margin: 0 0 0.5rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   p {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin: 0 0 1.5rem 0;
     font-size: 1rem;
     line-height: 1.5;
@@ -225,18 +225,18 @@
     align-items: center;
     gap: 8px;
     padding: 10px 20px;
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
-    border: 1px solid var(--font-color-nav-divider);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
+    border: 1px solid var(--blert-divider-color);
     border-radius: 6px;
     text-decoration: none;
     font-weight: 500;
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
-      border-color: var(--blert-button);
-      color: var(--blert-button);
+      background: var(--blert-surface-light);
+      border-color: var(--blert-purple);
+      color: var(--blert-purple);
 
       i {
         transform: scale(1.1);

--- a/web/app/setups/placement-preview.module.scss
+++ b/web/app/setups/placement-preview.module.scss
@@ -25,9 +25,9 @@
   white-space: nowrap;
 
   &.swap {
-    background: rgba(var(--nav-bg-base), 0.95);
-    border-color: rgba(var(--blert-text-color-base), 0.3);
-    color: var(--blert-text-color);
+    background: rgba(var(--blert-surface-dark-base), 0.95);
+    border-color: rgba(var(--blert-font-color-primary-base), 0.3);
+    color: var(--blert-font-color-primary);
   }
 
   &.merge {
@@ -45,15 +45,15 @@
   .key {
     background: linear-gradient(
       145deg,
-      var(--panel-bg),
-      var(--nav-bg-darkened)
+      var(--blert-panel-background-color),
+      var(--blert-surface-darker)
     );
-    border: 1px solid rgba(var(--blert-text-color-base), 0.3);
+    border: 1px solid rgba(var(--blert-font-color-primary-base), 0.3);
     border-radius: 3px;
     padding: 1px 3px 1px 4px;
     font-family: var(--font-roboto-mono), monospace;
     font-size: 9px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     box-shadow:
       0 2px 0 rgba(0, 0, 0, 0.3),
       inset 0 1px 0 rgba(255, 255, 255, 0.05);

--- a/web/app/setups/selectable-container.module.scss
+++ b/web/app/setups/selectable-container.module.scss
@@ -5,8 +5,8 @@
 
 .marquee {
   position: absolute;
-  background: rgba(var(--blert-button-base), 0.1);
-  border: 2px dashed var(--blert-button);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 2px dashed var(--blert-purple);
   pointer-events: none;
   z-index: 15;
   box-sizing: border-box;

--- a/web/app/setups/selection-overlay.module.scss
+++ b/web/app/setups/selection-overlay.module.scss
@@ -10,7 +10,7 @@
 }
 
 .selectedSlot {
-  background: rgba(var(--blert-button-base), 0.08);
+  background: rgba(var(--blert-purple-base), 0.08);
   pointer-events: none;
 
   &.cut {

--- a/web/app/setups/setup-list.module.scss
+++ b/web/app/setups/setup-list.module.scss
@@ -22,7 +22,7 @@
     align-items: center;
     margin-bottom: 1rem;
     padding-bottom: 0.75rem;
-    border-bottom: 2px solid rgba(var(--blert-button-base), 0.2);
+    border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
     position: relative;
 
     &::after {
@@ -32,7 +32,7 @@
       left: 0;
       width: 60px;
       height: 2px;
-      background: var(--blert-button);
+      background: var(--blert-purple);
     }
 
     .filtersTitle {
@@ -42,17 +42,17 @@
       font-size: 1.1rem;
       font-weight: 600;
       margin: 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1em;
       }
     }
 
     .resultsCount {
       font-size: 0.9rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-weight: 500;
 
       @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
@@ -87,10 +87,10 @@
         gap: 6px;
         font-size: 0.9rem;
         font-weight: 500;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 0.9em;
           width: 14px;
           text-align: center;
@@ -114,9 +114,9 @@
         .searchInput {
           padding: 10px 16px;
           border-radius: 6px;
-          border: 1px solid var(--font-color-nav-divider);
-          background: var(--nav-bg);
-          color: var(--blert-text-color);
+          border: 1px solid var(--blert-divider-color);
+          background: var(--blert-surface-dark);
+          color: var(--blert-font-color-primary);
           font-size: 0.95rem;
           transition: all 0.2s ease;
           width: 100%;
@@ -127,12 +127,12 @@
 
           &:focus {
             outline: none;
-            border-color: var(--blert-button);
-            background: var(--nav-bg-lightened);
+            border-color: var(--blert-purple);
+            background: var(--blert-surface-light);
           }
 
           &::placeholder {
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
             font-style: italic;
           }
         }
@@ -142,7 +142,7 @@
           right: 8px;
           background: none;
           border: none;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           cursor: pointer;
           padding: 6px;
           border-radius: 4px;
@@ -152,8 +152,8 @@
           justify-content: center;
 
           &:hover {
-            color: var(--blert-text-color);
-            background: var(--nav-bg);
+            color: var(--blert-font-color-primary);
+            background: var(--blert-surface-dark);
           }
 
           i {
@@ -164,9 +164,9 @@
 
       .filterSelect {
         padding: 8px 12px;
-        border: 1px solid var(--font-color-nav-divider);
-        background: var(--nav-bg);
-        color: var(--blert-text-color);
+        border: 1px solid var(--blert-divider-color);
+        background: var(--blert-surface-dark);
+        color: var(--blert-font-color-primary);
         border-radius: 6px;
         font-size: 0.9rem;
         transition: all 0.2s ease;
@@ -178,17 +178,17 @@
 
         &:focus {
           outline: none;
-          border-color: var(--blert-button);
-          background: var(--nav-bg-lightened);
+          border-color: var(--blert-purple);
+          background: var(--blert-surface-light);
         }
 
         &:hover {
-          border-color: var(--blert-button);
+          border-color: var(--blert-purple);
         }
 
         option {
-          background: var(--nav-bg);
-          color: var(--blert-text-color);
+          background: var(--blert-surface-dark);
+          color: var(--blert-font-color-primary);
           padding: 4px 8px;
         }
       }
@@ -202,7 +202,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(var(--nav-bg-base), 0.7);
+  background: rgba(var(--blert-surface-dark-base), 0.7);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
@@ -216,15 +216,15 @@
     align-items: center;
     gap: 12px;
     padding: 16px 24px;
-    background: var(--panel-bg);
-    border: 1px solid rgba(var(--blert-button-base), 0.2);
+    background: var(--blert-panel-background-color);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
     border-radius: 8px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     font-weight: 500;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       font-size: 1.2em;
     }
   }
@@ -262,10 +262,10 @@
   padding: 1.5rem;
   background: linear-gradient(
     135deg,
-    var(--nav-bg) 0%,
-    rgba(var(--nav-bg-base), 0.8) 100%
+    var(--blert-surface-dark) 0%,
+    rgba(var(--blert-surface-dark-base), 0.8) 100%
   );
-  border: 1px solid rgba(var(--blert-button-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.1);
   border-radius: 8px;
   text-decoration: none;
   transition: all 0.2s ease;
@@ -287,18 +287,18 @@
     background: linear-gradient(
       90deg,
       transparent,
-      rgba(var(--blert-button-base), 0.05),
+      rgba(var(--blert-purple-base), 0.05),
       transparent
     );
     transition: left 0.4s ease;
   }
 
   &:hover {
-    border-color: rgba(var(--blert-button-base), 0.3);
+    border-color: rgba(var(--blert-purple-base), 0.3);
     background: linear-gradient(
       135deg,
-      var(--nav-bg-lightened) 0%,
-      rgba(var(--nav-bg-lightened-base), 0.9) 100%
+      var(--blert-surface-light) 0%,
+      rgba(var(--blert-surface-light-base), 0.9) 100%
     );
     transform: translateY(-2px);
     box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
@@ -308,7 +308,7 @@
     }
 
     .setupTitle h3 {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
   }
 
@@ -336,7 +336,7 @@
         margin: 0 0 8px 0;
         font-size: 1.25rem;
         font-weight: 600;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
         transition: color 0.2s ease;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -360,12 +360,12 @@
           align-items: center;
           gap: 4px;
           font-weight: 500;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
 
           i {
             position: relative;
             top: 1px;
-            color: var(--blert-button);
+            color: var(--blert-purple);
             font-size: 0.8em;
           }
         }
@@ -374,15 +374,15 @@
           display: flex;
           align-items: center;
           gap: 4px;
-          background: var(--nav-bg-darkened);
+          background: var(--blert-surface-darker);
           padding: 4px 8px;
           border-radius: 12px;
           font-size: 0.8rem;
           font-weight: 500;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
 
           i {
-            color: var(--blert-button);
+            color: var(--blert-purple);
             font-size: 0.8em;
           }
         }
@@ -399,7 +399,7 @@
           }
 
           &.draft {
-            background: var(--font-color-nav);
+            background: var(--blert-font-color-secondary);
           }
 
           &.published {
@@ -429,11 +429,11 @@
         align-items: center;
         gap: 6px;
         font-size: 0.9rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-weight: 500;
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 0.9em;
         }
       }
@@ -454,10 +454,10 @@
         align-items: center;
         gap: 4px;
         font-size: 0.85rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
 
         i {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           font-size: 0.8em;
           opacity: 0.8;
         }
@@ -475,15 +475,15 @@
   padding: 3rem 2rem;
   background: linear-gradient(
     135deg,
-    rgba(var(--font-color-nav-base), 0.1) 0%,
-    rgba(var(--nav-bg-base), 0.3) 100%
+    rgba(var(--blert-font-color-secondary-base), 0.1) 0%,
+    rgba(var(--blert-surface-dark-base), 0.3) 100%
   );
   border-radius: 12px;
-  border: 1px solid rgba(var(--font-color-nav-divider-base), 0.5);
+  border: 1px solid rgba(var(--blert-divider-color-base), 0.5);
 
   i {
     font-size: 2.5rem;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin-bottom: 1rem;
     opacity: 0.6;
   }
@@ -492,11 +492,11 @@
     font-size: 1.25rem;
     font-weight: 600;
     margin: 0 0 0.5rem 0;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
   }
 
   p {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     margin: 0;
     font-size: 0.95rem;
     line-height: 1.5;
@@ -511,7 +511,7 @@
   gap: 1rem;
   padding: 1.5rem 0;
   margin-top: 1rem;
-  border-top: 1px solid var(--font-color-nav-divider);
+  border-top: 1px solid var(--blert-divider-color);
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     gap: 1rem;
@@ -522,18 +522,18 @@
     align-items: center;
     gap: 8px;
     padding: 10px 16px;
-    background: var(--nav-bg);
-    color: var(--blert-text-color);
-    border: 1px solid var(--font-color-nav-divider);
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
+    border: 1px solid var(--blert-divider-color);
     border-radius: 6px;
     font-weight: 500;
     transition: all 0.2s ease;
     font-size: 0.9rem;
 
     &:hover:not(:disabled) {
-      background: var(--nav-bg-lightened);
-      border-color: var(--blert-button);
-      color: var(--blert-button);
+      background: var(--blert-surface-light);
+      border-color: var(--blert-purple);
+      color: var(--blert-purple);
       cursor: pointer;
 
       i {
@@ -546,7 +546,7 @@
       cursor: not-allowed;
 
       &:hover {
-        background: var(--nav-bg);
+        background: var(--blert-surface-dark);
         transform: none;
       }
     }
@@ -571,13 +571,13 @@
 
     .pageIndicator {
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 0.95rem;
     }
 
     .resultsInfo {
       font-size: 0.85rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
   }
 }
@@ -591,7 +591,6 @@
     position: sticky;
     top: 60px;
     z-index: 5;
-    background: var(--page-bg);
     padding: 12px;
     margin: -12px -12px 12px;
     border-radius: 0;

--- a/web/app/setups/style.module.scss
+++ b/web/app/setups/style.module.scss
@@ -15,13 +15,13 @@
   .arrow {
     width: 40px;
     font-size: 28px;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     cursor: pointer;
     transition: all 0.2s ease;
     z-index: 1;
 
     &:not(:disabled):hover {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     &:disabled {
@@ -52,7 +52,7 @@
     width: 60px;
     display: inline-flex;
     justify-content: center;
-    border: 1px dashed var(--font-color-nav);
+    border: 1px dashed var(--blert-font-color-secondary);
     border-radius: 5px;
     min-height: 300px;
 
@@ -75,7 +75,7 @@
       }
 
       &:not(:disabled):hover {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         cursor: pointer;
       }
     }
@@ -95,13 +95,13 @@
         width: 10px;
         height: 10px;
         border-radius: 50%;
-        background: var(--blert-text-color);
+        background: var(--blert-font-color-primary);
         opacity: 0.5;
         transition: all 0.2s ease;
 
         &.active {
           opacity: 1;
-          background: var(--blert-button);
+          background: var(--blert-purple);
         }
       }
     }
@@ -149,10 +149,10 @@
       button {
         font-size: 14px;
         padding: 4px;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
 
         &:hover {
-          color: var(--blert-button);
+          color: var(--blert-purple);
           cursor: pointer;
         }
       }
@@ -220,7 +220,7 @@
     }
 
     .import {
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     .remove {
@@ -229,7 +229,7 @@
   }
 
   &.highlighted {
-    outline: 2px solid var(--blert-button);
+    outline: 2px solid var(--blert-purple);
     outline-offset: 2px;
     border-radius: 5px;
     transition: outline-color 0.2s ease;
@@ -240,19 +240,19 @@
   width: calc(var(--slot-size) - 2px);
   height: calc(var(--slot-size) - 2px);
   margin: 1px;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
 
   &:hover {
-    background: var(--nav-bg-lightened);
+    background: var(--blert-surface-light);
   }
 
   &.highlighted {
-    background: var(--nav-bg-lightened);
-    outline: 1px solid var(--blert-text-color);
+    background: var(--blert-surface-light);
+    outline: 1px solid var(--blert-font-color-primary);
   }
 
   &:not(.empty).invalid:hover {
@@ -275,7 +275,7 @@
   }
 
   &.search {
-    border: 1px solid var(--blert-button);
+    border: 1px solid var(--blert-purple);
   }
 
   &.deletable {
@@ -289,17 +289,17 @@
   }
 
   &.eyedropperHint {
-    outline: 1px solid rgba(var(--blert-button-base), 0.3);
+    outline: 1px solid rgba(var(--blert-purple-base), 0.3);
     outline-offset: -1px;
   }
 
   &.eyedropperHover {
-    border: 1px solid var(--blert-button);
-    background: rgba(var(--blert-button-base), 0.2);
+    border: 1px solid var(--blert-purple);
+    background: rgba(var(--blert-purple-base), 0.2);
     cursor: copy;
 
     &:hover {
-      background: rgba(var(--blert-button-base), 0.25);
+      background: rgba(var(--blert-purple-base), 0.25);
     }
   }
 
@@ -316,7 +316,7 @@
     bottom: 2px;
     right: 2px;
     font-size: 10px;
-    color: var(--blert-button);
+    color: var(--blert-purple);
     pointer-events: none;
     transition: transform 0.2s ease;
     filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
@@ -338,17 +338,17 @@
   gap: 0.5rem;
   font-weight: 600;
   font-size: 0.9rem;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   margin-bottom: 0.5rem;
   padding-bottom: 0.25rem;
-  border-bottom: 1px solid rgba(var(--nav-bg-lightened-base), 0.6);
+  border-bottom: 1px solid rgba(var(--blert-surface-light-base), 0.6);
 }
 
 .commentSection {
   display: flex;
   gap: 0.5rem;
   font-size: 0.85rem;
-  color: var(--font-color-nav);
+  color: var(--blert-font-color-secondary);
 
   i {
     margin-top: 2px;
@@ -368,7 +368,7 @@
   left: 0;
   z-index: 100;
   width: 200px;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border: 1px solid var(--border-color);
   border-radius: 4px;
   padding: 4px;
@@ -391,7 +391,7 @@
     font-weight: 500;
 
     i {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       margin-right: 4px;
     }
   }
@@ -409,7 +409,7 @@
     gap: 6px;
     padding: 4px 8px;
     width: 75px;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 4px;
     transition: all 0.2s ease;
 
@@ -419,8 +419,8 @@
     }
 
     &.highlighted {
-      background: var(--nav-bg-lightened);
-      outline: 1px solid var(--blert-text-color);
+      background: var(--blert-surface-light);
+      outline: 1px solid var(--blert-font-color-primary);
     }
 
     .quantity {

--- a/web/app/styles.module.scss
+++ b/web/app/styles.module.scss
@@ -16,7 +16,7 @@
 
 .pageParentContent {
   min-height: 100%;
-  background-color: var(--content-area-bg);
+  background-color: var(--blert-page-background-color);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/web/app/trends/bloat-hands/controls.module.scss
+++ b/web/app/trends/bloat-hands/controls.module.scss
@@ -17,7 +17,7 @@
       margin: 0 0 0.75rem 0;
       font-size: 0.9rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
   }
 
@@ -44,15 +44,15 @@
 
     label {
       font-size: 0.8rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-weight: 500;
     }
 
     .filterSelect {
       padding: 0.4rem 0.6rem;
-      border: 1px solid var(--font-color-nav);
-      background: var(--nav-bg);
-      color: var(--blert-text-color);
+      border: 1px solid var(--blert-font-color-secondary);
+      background: var(--blert-surface-dark);
+      color: var(--blert-font-color-primary);
       border-radius: 5px;
       font-size: 0.85rem;
       transition: border-color 0.2s ease;
@@ -61,16 +61,16 @@
 
       &:focus {
         outline: none;
-        border-color: var(--blert-button);
+        border-color: var(--blert-purple);
       }
 
       &:hover {
-        border-color: var(--blert-button);
+        border-color: var(--blert-purple);
       }
 
       option {
-        background: var(--nav-bg);
-        color: var(--blert-text-color);
+        background: var(--blert-surface-dark);
+        color: var(--blert-font-color-primary);
       }
     }
   }

--- a/web/app/trends/bloat-hands/stats.module.scss
+++ b/web/app/trends/bloat-hands/stats.module.scss
@@ -6,7 +6,7 @@
   gap: 1.5rem;
 
   .section {
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     padding: 1rem;
 
@@ -14,8 +14,8 @@
       margin: 0 0 1rem 0;
       font-size: 0.9rem;
       font-weight: 600;
-      color: var(--blert-text-color);
-      border-bottom: 1px solid rgba(var(--blert-text-color-base), 0.2);
+      color: var(--blert-font-color-primary);
+      border-bottom: 1px solid rgba(var(--blert-font-color-primary-base), 0.2);
       padding-bottom: 0.5rem;
     }
 
@@ -30,13 +30,13 @@
         .statValue {
           font-size: 1.5rem;
           font-weight: 600;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           margin-bottom: 0.25rem;
         }
 
         .statLabel {
           font-size: 0.75rem;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
         }
       }
     }
@@ -58,7 +58,7 @@
 
         .statLabel {
           font-size: 0.75rem;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           text-transform: uppercase;
           letter-spacing: 0.5px;
         }
@@ -74,7 +74,7 @@
           margin: 0;
           font-size: 0.85rem;
           line-height: 1.4;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
         }
       }
     }
@@ -87,13 +87,13 @@
         gap: 0.5rem;
         margin-bottom: 1rem;
         padding: 0.5rem;
-        background: rgba(var(--blert-button-base), 0.1);
+        background: rgba(var(--blert-purple-base), 0.1);
         border-radius: 4px;
 
         .modeLabel {
           font-size: 0.9rem;
           font-weight: 600;
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
         }
 
         .modeIcon {
@@ -105,7 +105,7 @@
         margin: 0;
         font-size: 0.9rem;
         line-height: 1.5;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         text-align: center;
       }
     }

--- a/web/app/trends/bloat-hands/style.module.scss
+++ b/web/app/trends/bloat-hands/style.module.scss
@@ -8,19 +8,19 @@
     h1 {
       margin: 0 0 0.5rem 0;
       font-size: 1.6rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .subtitle {
       margin: 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
     }
   }
 
   .mainPanel {
     .controlsSection {
       padding: 0 1rem 1rem 1rem;
-      border-bottom: 1px solid rgba(var(--blert-text-color-base), 0.2);
+      border-bottom: 1px solid rgba(var(--blert-font-color-primary-base), 0.2);
     }
 
     .contentGrid {
@@ -67,7 +67,7 @@
   align-items: center;
   text-align: center;
   padding: 4rem 2rem;
-  background: var(--nav-bg);
+  background: var(--blert-surface-dark);
   border-radius: 6px;
   gap: 1rem;
   width: 100%;
@@ -81,13 +81,13 @@
   .errorContent {
     h3 {
       margin: 0 0 8px 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 1.1em;
     }
 
     p {
       margin: 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
     }
   }
@@ -98,15 +98,15 @@
     gap: 8px;
     padding: 12px 24px;
     border-radius: 4px;
-    background: var(--panel-bg);
-    color: var(--blert-text-color);
+    background: var(--blert-panel-background-color);
+    color: var(--blert-font-color-primary);
     font-size: 0.9em;
     border: none;
     cursor: pointer;
     transition: all 0.2s ease;
 
     &:hover {
-      background: var(--nav-bg-lightened);
+      background: var(--blert-surface-light);
 
       i {
         transform: rotate(180deg);
@@ -146,7 +146,7 @@
     gap: 1px;
     width: 480px;
     height: 480px;
-    background: var(--panel-bg);
+    background: var(--blert-panel-background-color);
     border-radius: 4px;
     padding: 2px;
 
@@ -157,7 +157,7 @@
   }
 
   .skeletonTile {
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 1px;
     animation: pulse 2s ease-in-out infinite;
     animation-delay: calc(var(--i, 0) * 0.01s);
@@ -192,7 +192,7 @@
 
   .skeletonStatCard {
     padding: 1rem;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     min-height: 120px;
 
@@ -211,20 +211,20 @@
 
   .placeholderCard {
     padding: 1.5rem;
-    background: var(--nav-bg);
+    background: var(--blert-surface-dark);
     border-radius: 6px;
     border-left: 3px solid var(--blert-purple);
 
     h3 {
       margin: 0 0 1rem 0;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-size: 1.1em;
       font-weight: 500;
     }
 
     p {
       margin: 0;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
       line-height: 1.5;
     }
@@ -232,7 +232,7 @@
     ul {
       margin: 0;
       padding-left: 1.2rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 0.9em;
       line-height: 1.6;
 
@@ -244,7 +244,7 @@
         }
 
         strong {
-          color: var(--blert-text-color);
+          color: var(--blert-font-color-primary);
           font-weight: 500;
         }
       }
@@ -260,7 +260,7 @@
 
 .skeletonLine {
   height: 16px;
-  background: var(--panel-bg);
+  background: var(--blert-panel-background-color);
   border-radius: 3px;
   animation: pulse 1.5s ease-in-out infinite;
 }

--- a/web/app/trends/bloat-hands/visualizer.module.scss
+++ b/web/app/trends/bloat-hands/visualizer.module.scss
@@ -32,9 +32,9 @@ $RELATIVE_POS_B: 255;
   .gridContainer {
     position: relative;
     display: inline-block;
-    border: 2px solid rgba(var(--blert-text-color-base), 0.3);
+    border: 2px solid rgba(var(--blert-font-color-primary-base), 0.3);
     border-radius: 4px;
-    background: rgba(var(--nav-bg-base), 0.3);
+    background: rgba(var(--blert-surface-dark-base), 0.3);
   }
 
   .coordinateLabels {
@@ -56,7 +56,7 @@ $RELATIVE_POS_B: 255;
         align-items: center;
         justify-content: center;
         font-size: 0.75rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-family: monospace;
       }
     }
@@ -73,7 +73,7 @@ $RELATIVE_POS_B: 255;
           align-items: center;
           justify-content: center;
           font-size: 0.75rem;
-          color: var(--font-color-nav);
+          color: var(--blert-font-color-secondary);
           font-family: monospace;
           flex-shrink: 0;
         }
@@ -88,7 +88,7 @@ $RELATIVE_POS_B: 255;
   .tile {
     width: $TILE_SIZE;
     height: $TILE_SIZE;
-    border: 1px solid rgba(var(--blert-text-color-base), 0.1);
+    border: 1px solid rgba(var(--blert-font-color-primary-base), 0.1);
     cursor: pointer;
     position: relative;
     transition: all 0.15s ease;
@@ -150,8 +150,8 @@ $RELATIVE_POS_B: 255;
     &.impassable {
       background: repeating-linear-gradient(
         45deg,
-        rgba(var(--blert-text-color-base), 0.2),
-        rgba(var(--blert-text-color-base), 0.2) 2px,
+        rgba(var(--blert-font-color-primary-base), 0.2),
+        rgba(var(--blert-font-color-primary-base), 0.2) 2px,
         transparent 2px,
         transparent 4px
       );
@@ -159,15 +159,15 @@ $RELATIVE_POS_B: 255;
     }
 
     &.hovered:not(.impassable) {
-      border-color: rgba(var(--blert-text-color-base), 0.6);
+      border-color: rgba(var(--blert-font-color-primary-base), 0.6);
       transform: scale(1.1);
       z-index: 10;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     }
 
     &.selected:not(.impassable) {
-      border: 2px solid var(--blert-button);
-      box-shadow: 0 0 0 1px var(--blert-button);
+      border: 2px solid var(--blert-purple);
+      box-shadow: 0 0 0 1px var(--blert-purple);
       z-index: 5;
     }
 
@@ -193,7 +193,7 @@ $RELATIVE_POS_B: 255;
 
     .chunkBoundary {
       position: absolute;
-      background: rgba(var(--blert-text-color-base), 0.8);
+      background: rgba(var(--blert-font-color-primary-base), 0.8);
       pointer-events: none;
 
       &:first-child {
@@ -223,7 +223,7 @@ $RELATIVE_POS_B: 255;
 
     .legendTitle {
       font-size: 0.9rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       font-weight: 500;
     }
 
@@ -240,7 +240,7 @@ $RELATIVE_POS_B: 255;
           rgb($GRADIENT_START_R, $GRADIENT_START_G, $GRADIENT_START_B),
           rgb($GRADIENT_END_R, $GRADIENT_END_G, $GRADIENT_END_B)
         );
-        border: 1px solid rgba(var(--blert-text-color-base), 0.3);
+        border: 1px solid rgba(var(--blert-font-color-primary-base), 0.3);
         border-radius: 2px;
 
         &.relativeGradient {
@@ -257,7 +257,7 @@ $RELATIVE_POS_B: 255;
         display: flex;
         justify-content: space-between;
         font-size: 0.75rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
         font-family: monospace;
         position: relative;
 
@@ -286,7 +286,7 @@ $RELATIVE_POS_B: 255;
     .topSpawnTitle {
       font-size: 0.9rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       margin-bottom: 0.75rem;
       text-align: center;
     }
@@ -329,7 +329,7 @@ $RELATIVE_POS_B: 255;
             display: flex;
             align-items: center;
             font-size: 0.85rem;
-            color: var(--blert-text-color);
+            color: var(--blert-font-color-primary);
             font-weight: 500;
             margin-bottom: 0.2rem;
 
@@ -342,7 +342,7 @@ $RELATIVE_POS_B: 255;
 
           .tileCount {
             font-size: 0.75rem;
-            color: var(--font-color-nav);
+            color: var(--blert-font-color-secondary);
           }
         }
       }
@@ -407,7 +407,7 @@ $RELATIVE_POS_B: 255;
 }
 
 .tileTooltip {
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
 
   .tileHeader {
     display: flex;
@@ -416,18 +416,18 @@ $RELATIVE_POS_B: 255;
     gap: 1rem;
     margin: 0.5rem 0 0.75rem 0;
     padding: 0.5rem;
-    background: rgba(var(--blert-button-base), 0.1);
+    background: rgba(var(--blert-purple-base), 0.1);
     border-radius: 4px;
 
     .tileId {
       font-size: 1rem;
       font-weight: 600;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .tileCoords {
       font-size: 0.85rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-family: monospace;
     }
   }
@@ -442,19 +442,19 @@ $RELATIVE_POS_B: 255;
       justify-content: space-between;
       align-items: center;
       padding: 0.4rem 0.6rem;
-      background: rgba(var(--nav-bg-base), 0.4);
+      background: rgba(var(--blert-surface-dark-base), 0.4);
       border-radius: 3px;
 
       span:first-child {
         font-size: 0.8rem;
-        color: var(--font-color-nav);
+        color: var(--blert-font-color-secondary);
       }
 
       span:last-child {
         margin-left: 0.5rem;
         font-size: 0.85rem;
         font-weight: 500;
-        color: var(--blert-text-color);
+        color: var(--blert-font-color-primary);
       }
     }
   }

--- a/web/app/trends/bloat-hands/visualizer.tsx
+++ b/web/app/trends/bloat-hands/visualizer.tsx
@@ -95,7 +95,7 @@ function TileTooltipRenderer({
                 style={{
                   color:
                     Math.abs(value) < RELATIVE_LABEL_THRESHOLD
-                      ? 'var(--blert-text-color)'
+                      ? 'var(--blert-font-color-primary)'
                       : value > 0
                         ? 'var(--blert-green)'
                         : 'var(--blert-red)',

--- a/web/app/trends/challenge-stats.tsx
+++ b/web/app/trends/challenge-stats.tsx
@@ -229,7 +229,7 @@ export default function ChallengeStats({
                   <XAxis
                     dataKey="name"
                     tick={{
-                      fill: 'var(--blert-text-color)',
+                      fill: 'var(--blert-font-color-primary)',
                       fontSize: display.isCompact() ? 12 : 14,
                     }}
                     axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
@@ -238,7 +238,7 @@ export default function ChallengeStats({
                   />
                   <YAxis
                     tick={{
-                      fill: 'var(--blert-text-color)',
+                      fill: 'var(--blert-font-color-primary)',
                       fontSize: 12,
                     }}
                     axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
@@ -246,10 +246,10 @@ export default function ChallengeStats({
                   />
                   <Tooltip
                     contentStyle={{
-                      backgroundColor: 'var(--panel-bg)',
-                      border: '1px solid var(--nav-bg-lightened)',
+                      backgroundColor: 'var(--blert-panel-background-color)',
+                      border: '1px solid var(--blert-surface-light)',
                       borderRadius: '6px',
-                      color: 'var(--blert-text-color)',
+                      color: 'var(--blert-font-color-primary)',
                       boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
                     }}
                     cursor={{ fill: 'rgba(139, 92, 246, 0.1)' }}
@@ -267,7 +267,7 @@ export default function ChallengeStats({
                         <span
                           style={{
                             fontWeight: 600,
-                            color: 'var(--font-color-nav)',
+                            color: 'var(--blert-font-color-secondary)',
                           }}
                         >
                           {label}
@@ -277,7 +277,7 @@ export default function ChallengeStats({
                     formatter={(value: number) => [
                       <span
                         key="deaths"
-                        style={{ color: 'var(--blert-text-color)' }}
+                        style={{ color: 'var(--blert-font-color-primary)' }}
                       >
                         {value.toLocaleString()} death{value === 1 ? '' : 's'}
                       </span>,

--- a/web/app/trends/style.module.scss
+++ b/web/app/trends/style.module.scss
@@ -29,7 +29,7 @@
     background: linear-gradient(
       90deg,
       transparent,
-      var(--blert-button),
+      var(--blert-purple),
       transparent
     );
   }
@@ -39,8 +39,8 @@
     margin: 0 0 0.5rem 0;
     background: linear-gradient(
       135deg,
-      var(--blert-text-color),
-      rgba(var(--blert-text-color-base), 0.8)
+      var(--blert-font-color-primary),
+      rgba(var(--blert-font-color-primary-base), 0.8)
     );
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
@@ -53,7 +53,7 @@
   }
 
   .subtitle {
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
     font-size: 1.1rem;
     margin: 0;
     line-height: 1.5;
@@ -96,9 +96,9 @@
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0 0 1.5rem 0;
-  color: var(--blert-text-color);
+  color: var(--blert-font-color-primary);
   padding-bottom: 0.75rem;
-  border-bottom: 2px solid rgba(var(--blert-button-base), 0.2);
+  border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
   position: relative;
 
   &::after {
@@ -108,11 +108,11 @@
     left: 0;
     width: 60px;
     height: 2px;
-    background: var(--blert-button);
+    background: var(--blert-purple);
   }
 
   i {
-    color: var(--blert-button);
+    color: var(--blert-purple);
     font-size: 1.2rem;
   }
 }
@@ -132,13 +132,13 @@
     padding: 1.5rem;
     background: linear-gradient(
       135deg,
-      rgba(var(--blert-button-base), 0.08) 0%,
-      rgba(var(--blert-button-base), 0.03) 100%
+      rgba(var(--blert-purple-base), 0.08) 0%,
+      rgba(var(--blert-purple-base), 0.03) 100%
     );
-    border: 1px solid rgba(var(--blert-button-base), 0.15);
+    border: 1px solid rgba(var(--blert-purple-base), 0.15);
     border-radius: 12px;
     text-decoration: none;
-    color: var(--blert-text-color);
+    color: var(--blert-font-color-primary);
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
@@ -153,18 +153,18 @@
       background: linear-gradient(
         90deg,
         transparent,
-        rgba(var(--blert-button-base), 0.1),
+        rgba(var(--blert-purple-base), 0.1),
         transparent
       );
       transition: left 0.5s ease;
     }
 
     &:hover {
-      border-color: rgba(var(--blert-button-base), 0.3);
+      border-color: rgba(var(--blert-purple-base), 0.3);
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.12) 0%,
-        rgba(var(--blert-button-base), 0.06) 100%
+        rgba(var(--blert-purple-base), 0.12) 0%,
+        rgba(var(--blert-purple-base), 0.06) 100%
       );
       transform: translateY(-2px);
       box-shadow: 0 8px 25px rgba(0, 0, 0, 0.3);
@@ -179,7 +179,7 @@
     }
 
     .linkIcon {
-      color: var(--blert-button);
+      color: var(--blert-purple);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -206,18 +206,18 @@
     .linkTitle {
       font-weight: 600;
       font-size: 1.15rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
     }
 
     .linkDescription {
       font-size: 0.95rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       line-height: 1.4;
     }
 
     .linkArrow {
       font-size: 1.25rem;
-      color: var(--blert-button);
+      color: var(--blert-purple);
       transition: transform 0.3s ease;
     }
   }
@@ -241,12 +241,12 @@
       align-items: center;
       justify-content: center;
       gap: 0.75rem;
-      color: var(--font-color-nav);
+      color: var(--blert-font-color-secondary);
       font-size: 1.1rem;
       padding: 2rem;
 
       i {
-        color: var(--blert-button);
+        color: var(--blert-purple);
         font-size: 1.2rem;
       }
     }
@@ -270,11 +270,11 @@
     justify-content: center;
     gap: 1rem;
     height: 400px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     i {
       font-size: 2rem;
-      color: var(--blert-button);
+      color: var(--blert-purple);
     }
 
     span {
@@ -292,12 +292,12 @@
     padding: 2rem;
     background: linear-gradient(
       135deg,
-      rgba(var(--panel-bg-base), 0.3) 0%,
-      rgba(var(--nav-bg-base), 0.1) 100%
+      rgba(var(--blert-panel-background-color-base), 0.3) 0%,
+      rgba(var(--blert-surface-dark-base), 0.1) 100%
     );
-    border: 2px dashed rgba(var(--font-color-nav-base), 0.3);
+    border: 2px dashed rgba(var(--blert-font-color-secondary-base), 0.3);
     border-radius: 12px;
-    color: var(--font-color-nav);
+    color: var(--blert-font-color-secondary);
 
     .placeholderIcon {
       width: 80px;
@@ -305,8 +305,8 @@
       border-radius: 50%;
       background: linear-gradient(
         135deg,
-        rgba(var(--blert-button-base), 0.1) 0%,
-        rgba(var(--blert-button-base), 0.05) 100%
+        rgba(var(--blert-purple-base), 0.1) 0%,
+        rgba(var(--blert-purple-base), 0.05) 100%
       );
       display: flex;
       align-items: center;
@@ -315,14 +315,14 @@
 
       i {
         font-size: 2rem;
-        color: var(--blert-button);
+        color: var(--blert-purple);
         opacity: 0.7;
       }
     }
 
     h4 {
       font-size: 1.3rem;
-      color: var(--blert-text-color);
+      color: var(--blert-font-color-primary);
       margin: 0 0 1rem 0;
       font-weight: 600;
     }

--- a/web/app/utils/challenge.ts
+++ b/web/app/utils/challenge.ts
@@ -22,7 +22,7 @@ export function statusNameAndColor(status: ChallengeStatus, stage?: Stage) {
   const prefix = stage ? `${stageName(stage)} ` : '';
 
   if (status === ChallengeStatus.RESET) {
-    return [`${prefix}Reset`, 'var(--blert-text-color)'];
+    return [`${prefix}Reset`, 'var(--blert-font-color-primary)'];
   }
   return [`${prefix}Wipe`, 'rgba(var(--blert-red-base), 0.9)'];
 }


### PR DESCRIPTION
Instead of using loose variable names like --nav-bg for global CSS colors, updates the names to be more semantic to reflect their purpose and usage. Ensures all variable names are prefixed with --blert.