### PR TITLE
Allow dimming Nylocas in replay

### DIFF
--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/__tests__/dim-settings.test.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/__tests__/dim-settings.test.tsx
@@ -1,0 +1,401 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import NyloDimSettings, { DimThreshold, NyloDimConfig } from '../dim-settings';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+describe('NyloDimSettings', () => {
+  let onChangeMock: jest.Mock<void, [DimThreshold[]]>;
+  let onShowLabelsChangeMock: jest.Mock<void, [boolean]>;
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    onChangeMock = jest.fn<void, [DimThreshold[]]>();
+    onShowLabelsChangeMock = jest.fn<void, [boolean]>();
+  });
+
+  const renderComponent = (
+    props: Partial<Parameters<typeof NyloDimSettings>[0]> = {},
+  ) => {
+    return render(
+      <NyloDimSettings
+        scale={5}
+        onDimThresholdsChange={onChangeMock}
+        onShowLabelsChange={onShowLabelsChangeMock}
+        {...props}
+      />,
+    );
+  };
+
+  describe('initial rendering', () => {
+    it('renders the Dim label', () => {
+      renderComponent();
+      expect(screen.getByText('Dim:')).toBeInTheDocument();
+    });
+
+    it('renders all preset options', () => {
+      renderComponent();
+
+      expect(screen.getByLabelText('None')).toBeInTheDocument();
+      expect(screen.getByLabelText('W26')).toBeInTheDocument();
+      expect(screen.getByLabelText('W27')).toBeInTheDocument();
+      expect(screen.getByLabelText('W27+4')).toBeInTheDocument();
+      expect(screen.getByLabelText('W28')).toBeInTheDocument();
+      expect(screen.getByLabelText('W29')).toBeInTheDocument();
+    });
+
+    it('renders the Custom button', () => {
+      renderComponent();
+      expect(screen.getByText('Custom')).toBeInTheDocument();
+    });
+
+    it('has None selected by default', () => {
+      renderComponent();
+      expect(screen.getByLabelText('None')).toBeChecked();
+    });
+
+    it('calls onChange with empty array on mount when no preset selected', () => {
+      renderComponent();
+      expect(onChangeMock).toHaveBeenCalledWith([]);
+    });
+
+    it('renders the Show wave numbers checkbox', () => {
+      renderComponent();
+      expect(screen.getByLabelText('Show wave numbers')).toBeInTheDocument();
+    });
+
+    it('has Show wave numbers checked by default', () => {
+      renderComponent();
+      expect(screen.getByLabelText('Show wave numbers')).toBeChecked();
+    });
+
+    it('calls onShowLabelsChange with true on mount', () => {
+      renderComponent();
+      expect(onShowLabelsChangeMock).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('preset selection', () => {
+    it('selects W27 preset when clicked', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('W27'));
+
+      expect(screen.getByLabelText('W27')).toBeChecked();
+      expect(screen.getByLabelText('None')).not.toBeChecked();
+    });
+
+    it('calls onChange with preset threshold when preset selected', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('W28'));
+
+      expect(onChangeMock).toHaveBeenLastCalledWith([{ wave: 28, offset: 0 }]);
+    });
+
+    it('calls onChange with W27+4 offset threshold', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('W27+4'));
+
+      expect(onChangeMock).toHaveBeenLastCalledWith([{ wave: 27, offset: 4 }]);
+    });
+
+    it('deselects preset when None is clicked', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('W26'));
+      fireEvent.click(screen.getByLabelText('None'));
+
+      expect(screen.getByLabelText('None')).toBeChecked();
+      expect(onChangeMock).toHaveBeenLastCalledWith([]);
+    });
+
+    it('only allows one preset to be selected at a time', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('W26'));
+      expect(screen.getByLabelText('W26')).toBeChecked();
+
+      fireEvent.click(screen.getByLabelText('W29'));
+      expect(screen.getByLabelText('W29')).toBeChecked();
+      expect(screen.getByLabelText('W26')).not.toBeChecked();
+    });
+  });
+
+  describe('custom dropdown', () => {
+    it('opens dropdown when Custom button is clicked', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+
+      expect(screen.getByText('Wave')).toBeInTheDocument();
+      expect(screen.getByText('Offset')).toBeInTheDocument();
+      expect(screen.getByText('Add')).toBeInTheDocument();
+      expect(screen.getByText('Cancel')).toBeInTheDocument();
+    });
+
+    it('closes dropdown when Cancel is clicked', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+      expect(screen.getByText('Wave')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Cancel'));
+      expect(screen.queryByText('Wave')).not.toBeInTheDocument();
+    });
+
+    it('adds custom threshold when Add is clicked', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      const offsetInput = screen.getByRole('spinbutton', { name: /offset/i });
+
+      fireEvent.change(waveInput, { target: { value: '21' } });
+      fireEvent.change(offsetInput, { target: { value: '3' } });
+      fireEvent.click(screen.getByText('Add'));
+
+      expect(onChangeMock).toHaveBeenLastCalledWith([{ wave: 21, offset: 3 }]);
+    });
+
+    it('displays custom threshold as chip after adding', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      fireEvent.change(waveInput, { target: { value: '25' } });
+      fireEvent.click(screen.getByText('Add'));
+
+      expect(screen.getByText('W25')).toBeInTheDocument();
+    });
+
+    it('displays custom threshold with offset in chip', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      const offsetInput = screen.getByRole('spinbutton', { name: /offset/i });
+      fireEvent.change(waveInput, { target: { value: '22' } });
+      fireEvent.change(offsetInput, { target: { value: '5' } });
+      fireEvent.click(screen.getByText('Add'));
+
+      expect(screen.getByText('W22+5')).toBeInTheDocument();
+    });
+
+    it('removes custom threshold when chip is clicked', () => {
+      renderComponent();
+
+      // Add custom threshold
+      fireEvent.click(screen.getByText('Custom'));
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      fireEvent.change(waveInput, { target: { value: '23' } });
+      fireEvent.click(screen.getByText('Add'));
+
+      expect(screen.getByText('W23')).toBeInTheDocument();
+
+      // Remove it
+      fireEvent.click(screen.getByText('W23'));
+
+      expect(screen.queryByText('W23')).not.toBeInTheDocument();
+      expect(onChangeMock).toHaveBeenLastCalledWith([]);
+    });
+
+    it('does not add duplicate custom thresholds', () => {
+      renderComponent();
+
+      // Add first threshold
+      fireEvent.click(screen.getByText('Custom'));
+      fireEvent.click(screen.getByText('Add'));
+
+      // Try to add same threshold again
+      fireEvent.click(screen.getByText('Custom'));
+      fireEvent.click(screen.getByText('Add'));
+
+      // Should only have one chip
+      const chips = screen.getAllByTitle('Click to remove');
+      expect(chips).toHaveLength(1);
+    });
+
+    it('closes dropdown after adding threshold', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+      expect(screen.getByText('Wave')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Add'));
+      expect(screen.queryByText('Wave')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('combined preset and custom', () => {
+    it('includes both preset and custom thresholds in onChange', () => {
+      renderComponent();
+
+      // Select preset
+      fireEvent.click(screen.getByLabelText('W28'));
+
+      // Add custom
+      fireEvent.click(screen.getByText('Custom'));
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      fireEvent.change(waveInput, { target: { value: '21' } });
+      fireEvent.click(screen.getByText('Add'));
+
+      expect(onChangeMock).toHaveBeenLastCalledWith([
+        { wave: 28, offset: 0 },
+        { wave: 21, offset: 0 },
+      ]);
+    });
+  });
+
+  describe('disabled state', () => {
+    it('disables all preset radio buttons when disabled', () => {
+      renderComponent({ disabled: true });
+
+      expect(screen.getByLabelText('None')).toBeDisabled();
+      expect(screen.getByLabelText('W26')).toBeDisabled();
+      expect(screen.getByLabelText('W27')).toBeDisabled();
+    });
+
+    it('disables Custom button when disabled', () => {
+      renderComponent({ disabled: true });
+
+      expect(screen.getByText('Custom')).toBeDisabled();
+    });
+
+    it('disables Show wave numbers checkbox when disabled', () => {
+      renderComponent({ disabled: true });
+
+      expect(screen.getByLabelText('Show wave numbers')).toBeDisabled();
+    });
+  });
+
+  describe('persistence', () => {
+    it('persists preset selection to localStorage', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('W27'));
+
+      const stored = JSON.parse(
+        localStorageMock.getItem('nylo-dims-5')!,
+      ) as NyloDimConfig;
+      expect(stored.preset).toEqual({ wave: 27, offset: 0 });
+    });
+
+    it('uses scale-specific localStorage key', () => {
+      renderComponent({ scale: 3 });
+
+      fireEvent.click(screen.getByLabelText('W26'));
+
+      expect(localStorageMock.getItem('nylo-dims-3')).toBeTruthy();
+      expect(localStorageMock.getItem('nylo-dims-5')).toBeNull();
+    });
+
+    it('restores preset from localStorage on mount', () => {
+      localStorageMock.setItem(
+        'nylo-dims-5',
+        JSON.stringify({ preset: { wave: 29, offset: 0 }, custom: [] }),
+      );
+
+      renderComponent();
+
+      expect(screen.getByLabelText('W29')).toBeChecked();
+      expect(onChangeMock).toHaveBeenCalledWith([{ wave: 29, offset: 0 }]);
+    });
+
+    it('restores custom thresholds from localStorage on mount', () => {
+      localStorageMock.setItem(
+        'nylo-dims-5',
+        JSON.stringify({
+          preset: null,
+          custom: [{ wave: 21, offset: 2 }],
+        }),
+      );
+
+      renderComponent();
+
+      expect(screen.getByText('W21+2')).toBeInTheDocument();
+      expect(onChangeMock).toHaveBeenCalledWith([{ wave: 21, offset: 2 }]);
+    });
+  });
+
+  describe('keyboard interactions', () => {
+    it('adds threshold on Enter key in dropdown', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      fireEvent.change(waveInput, { target: { value: '24' } });
+      fireEvent.keyDown(waveInput, { key: 'Enter' });
+
+      expect(screen.getByText('W24')).toBeInTheDocument();
+    });
+
+    it('closes dropdown on Escape key', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByText('Custom'));
+      expect(screen.getByText('Wave')).toBeInTheDocument();
+
+      const waveInput = screen.getByRole('spinbutton', { name: /wave/i });
+      fireEvent.keyDown(waveInput, { key: 'Escape' });
+
+      expect(screen.queryByText('Wave')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('show wave numbers checkbox', () => {
+    it('toggles show wave numbers when clicked', () => {
+      renderComponent();
+
+      const checkbox = screen.getByLabelText('Show wave numbers');
+      expect(checkbox).toBeChecked();
+
+      fireEvent.click(checkbox);
+      expect(checkbox).not.toBeChecked();
+      expect(onShowLabelsChangeMock).toHaveBeenLastCalledWith(false);
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
+      expect(onShowLabelsChangeMock).toHaveBeenLastCalledWith(true);
+    });
+
+    it('persists show wave numbers setting to localStorage', () => {
+      renderComponent();
+
+      fireEvent.click(screen.getByLabelText('Show wave numbers'));
+
+      expect(localStorageMock.getItem('nylo-show-labels')).toBe('false');
+    });
+
+    it('restores show wave numbers from localStorage on mount', () => {
+      localStorageMock.setItem('nylo-show-labels', 'false');
+
+      renderComponent();
+
+      expect(screen.getByLabelText('Show wave numbers')).not.toBeChecked();
+      expect(onShowLabelsChangeMock).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/dim-settings.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/dim-settings.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import Checkbox from '@/components/checkbox';
+import RadioInput from '@/components/radio-input';
+import { useSetting } from '@/utils/user-settings';
+
+import styles from './style.module.scss';
+
+export type DimThreshold = {
+  wave: number;
+  offset: number;
+};
+
+export type NyloDimConfig = {
+  preset: DimThreshold | null;
+  custom: DimThreshold[];
+};
+
+const PRESET_DIMS: { label: string; threshold: DimThreshold }[] = [
+  { label: 'W26', threshold: { wave: 26, offset: 0 } },
+  { label: 'W27', threshold: { wave: 27, offset: 0 } },
+  { label: 'W27+4', threshold: { wave: 27, offset: 4 } },
+  { label: 'W28', threshold: { wave: 28, offset: 0 } },
+  { label: 'W29', threshold: { wave: 29, offset: 0 } },
+];
+
+function thresholdEquals(a: DimThreshold, b: DimThreshold): boolean {
+  return a.wave === b.wave && a.offset === b.offset;
+}
+
+function thresholdKey(t: DimThreshold): string {
+  return t.offset === 0 ? `W${t.wave}` : `W${t.wave}+${t.offset}`;
+}
+
+type NyloDimSettingsProps = {
+  scale: number;
+  disabled?: boolean;
+  onDimThresholdsChange: (thresholds: DimThreshold[]) => void;
+  onShowLabelsChange: (showLabels: boolean) => void;
+};
+
+export default function NyloDimSettings({
+  scale,
+  disabled = false,
+  onDimThresholdsChange,
+  onShowLabelsChange,
+}: NyloDimSettingsProps) {
+  const [dimConfig, setDimConfig] = useSetting<NyloDimConfig>({
+    key: `nylo-dims-${scale}`,
+    defaultValue: { preset: null, custom: [] },
+  });
+
+  const [showLabels, setShowLabels] = useSetting<boolean>({
+    key: 'nylo-show-labels',
+    defaultValue: true,
+  });
+
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [customWave, setCustomWave] = useState(20);
+  const [customOffset, setCustomOffset] = useState(0);
+  const waveInputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const thresholds: DimThreshold[] = [];
+    if (dimConfig.preset !== null) {
+      thresholds.push(dimConfig.preset);
+    }
+    thresholds.push(...dimConfig.custom);
+    onDimThresholdsChange(thresholds);
+  }, [dimConfig, onDimThresholdsChange]);
+
+  useEffect(() => {
+    onShowLabelsChange(showLabels);
+  }, [showLabels, onShowLabelsChange]);
+
+  useEffect(() => {
+    // Focus wave input when dropdown opens.
+    if (dropdownOpen && waveInputRef.current) {
+      waveInputRef.current.focus();
+      waveInputRef.current.select();
+    }
+  }, [dropdownOpen]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setDropdownOpen(false);
+      }
+    };
+
+    if (dropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () =>
+        document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [dropdownOpen]);
+
+  const updateConfig = (newConfig: NyloDimConfig) => {
+    setDimConfig(newConfig);
+  };
+
+  const selectedPresetIndex = dimConfig.preset
+    ? PRESET_DIMS.findIndex((p) =>
+        thresholdEquals(p.threshold, dimConfig.preset!),
+      )
+    : -1;
+
+  const handlePresetChange = (value: number | string) => {
+    const index = Number(value);
+    if (index === -1) {
+      updateConfig({ ...dimConfig, preset: null });
+    } else {
+      updateConfig({ ...dimConfig, preset: PRESET_DIMS[index].threshold });
+    }
+  };
+
+  const handleAddCustom = () => {
+    const newThreshold = { wave: customWave, offset: customOffset };
+    const isDuplicate =
+      dimConfig.custom.some((t) => thresholdEquals(t, newThreshold)) ||
+      (dimConfig.preset && thresholdEquals(dimConfig.preset, newThreshold));
+    if (!isDuplicate) {
+      updateConfig({
+        ...dimConfig,
+        custom: [...dimConfig.custom, newThreshold],
+      });
+    }
+    setDropdownOpen(false);
+  };
+
+  const handleRemoveCustom = (threshold: DimThreshold) => {
+    updateConfig({
+      ...dimConfig,
+      custom: dimConfig.custom.filter((t) => !thresholdEquals(t, threshold)),
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleAddCustom();
+    } else if (e.key === 'Escape') {
+      setDropdownOpen(false);
+    }
+  };
+
+  return (
+    <div className={styles.dimSettings}>
+      <div className={styles.dimSection}>
+        <span className={styles.dimSettingsLabel}>Dim:</span>
+
+        <div className={styles.dimControls}>
+          <div className={styles.dimPresetRow}>
+            <RadioInput.Group
+              name="nylo-dim-preset"
+              joined
+              compact
+              onChange={handlePresetChange}
+              readOnly={disabled}
+            >
+              <RadioInput.Option
+                id="nylo-dim-none"
+                value={-1}
+                label="None"
+                checked={selectedPresetIndex === -1}
+                disabled={disabled}
+              />
+              {PRESET_DIMS.map((preset, index) => (
+                <RadioInput.Option
+                  key={preset.label}
+                  id={`nylo-dim-${preset.label}`}
+                  value={index}
+                  label={preset.label}
+                  checked={selectedPresetIndex === index}
+                  disabled={disabled}
+                />
+              ))}
+            </RadioInput.Group>
+          </div>
+
+          <div className={styles.dimCustomRow}>
+            {dimConfig.custom
+              .toSorted((a, b) => a.wave - b.wave || a.offset - b.offset)
+              .map((threshold) => (
+                <button
+                  key={thresholdKey(threshold)}
+                  className={styles.customDimChip}
+                  onClick={() => handleRemoveCustom(threshold)}
+                  disabled={disabled}
+                  title="Click to remove"
+                >
+                  {thresholdKey(threshold)}
+                  <span className={styles.removeIcon}>&times;</span>
+                </button>
+              ))}
+
+            <div className={styles.customDropdownContainer} ref={dropdownRef}>
+              <button
+                className={styles.addCustomButton}
+                onClick={() => setDropdownOpen(!dropdownOpen)}
+                disabled={disabled}
+              >
+                <i className="fas fa-plus" />
+                Custom
+              </button>
+
+              {dropdownOpen && (
+                <div className={styles.customDropdown}>
+                  <div className={styles.dropdownContent}>
+                    <label className={styles.dropdownInput}>
+                      <span>Wave</span>
+                      <input
+                        ref={waveInputRef}
+                        type="number"
+                        min={1}
+                        max={31}
+                        value={customWave}
+                        onChange={(e) => setCustomWave(Number(e.target.value))}
+                        onKeyDown={handleKeyDown}
+                        disabled={disabled}
+                      />
+                    </label>
+                    <label className={styles.dropdownInput}>
+                      <span>Offset</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={96}
+                        value={customOffset}
+                        onChange={(e) =>
+                          setCustomOffset(Number(e.target.value))
+                        }
+                        onKeyDown={handleKeyDown}
+                        disabled={disabled}
+                      />
+                    </label>
+                  </div>
+                  <div className={styles.dropdownActions}>
+                    <button
+                      className={styles.dropdownCancel}
+                      onClick={() => setDropdownOpen(false)}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className={styles.dropdownAdd}
+                      onClick={handleAddCustom}
+                      disabled={disabled}
+                    >
+                      Add
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.dimSeparator} />
+
+      <Checkbox
+        label="Show wave numbers"
+        checked={showLabels}
+        onChange={setShowLabels}
+        disabled={disabled}
+        simple
+      />
+    </div>
+  );
+}

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/style.module.scss
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/style.module.scss
@@ -8,10 +8,6 @@
   justify-content: space-between;
 }
 
-.statsHeading {
-  margin: 0;
-}
-
 .bossRotationContainer {
   display: flex;
   flex-direction: column;
@@ -276,5 +272,236 @@
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
       font-size: 0.8rem;
     }
+  }
+}
+
+.dimSettings {
+  display: flex;
+  gap: 12px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  flex-wrap: wrap;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    gap: 8px;
+    padding: 8px 10px;
+    margin-bottom: 10px;
+  }
+}
+
+.dimSection {
+  display: flex;
+  align-items: flex-start;
+  flex: 1;
+  gap: 12px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    gap: 8px;
+  }
+}
+
+.dimSettingsLabel {
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+  font-size: 0.9rem;
+  letter-spacing: 0.5px;
+  padding-top: 5px;
+}
+
+.dimControls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.dimPresetRow {
+  display: flex;
+  align-items: center;
+
+  // Override default RadioInput.Group margin
+  > div {
+    margin-bottom: 0 !important;
+  }
+}
+
+.dimCustomRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dimSeparator {
+  width: 1px;
+  height: 100%;
+  background: var(--blert-divider-color);
+  margin: 0 4px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    display: none;
+  }
+}
+
+.customDimChip {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: rgba(var(--blert-purple-base), 0.15);
+  border: 1px solid rgba(var(--blert-purple-base), 0.3);
+  border-radius: 4px;
+  color: var(--blert-font-color-primary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-red-base), 0.2);
+    border-color: rgba(var(--blert-red-base), 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .removeIcon {
+    font-size: 0.9rem;
+    line-height: 1;
+    opacity: 0.7;
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      position: relative;
+      top: -1px;
+    }
+  }
+}
+
+.customDropdownContainer {
+  position: relative;
+}
+
+.addCustomButton {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  background: transparent;
+  border: 1px solid var(--blert-divider-color);
+  border-radius: 4px;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  i {
+    font-size: 0.7rem;
+    position: relative;
+    top: 1px;
+  }
+
+  &:hover:not(:disabled) {
+    border-color: var(--blert-purple);
+    color: var(--blert-purple);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.customDropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 100;
+  min-width: 180px;
+  padding: 12px;
+  background: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-divider-color);
+  border-radius: 6px;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.3),
+    0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.dropdownContent {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.dropdownInput {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  span {
+    font-size: 0.75rem;
+    color: var(--blert-font-color-secondary);
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  input {
+    width: 100%;
+    padding: 6px 8px;
+    border: 1px solid var(--blert-divider-color);
+    border-radius: 4px;
+    background: var(--blert-surface-dark);
+    color: var(--blert-font-color-primary);
+    font-size: 0.9rem;
+
+    &:focus {
+      outline: none;
+      border-color: var(--blert-purple);
+    }
+  }
+}
+
+.dropdownActions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.dropdownCancel,
+.dropdownAdd {
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.dropdownCancel {
+  background: transparent;
+  border: 1px solid var(--blert-divider-color);
+  color: var(--blert-font-color-secondary);
+
+  &:hover {
+    border-color: var(--blert-font-color-secondary);
+    color: var(--blert-font-color-primary);
+  }
+}
+
+.dropdownAdd {
+  background: var(--blert-purple);
+  border: none;
+  color: #fff;
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-purple-base), 0.8);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 }

--- a/web/app/components/boss-page-replay/boss-page-replay.tsx
+++ b/web/app/components/boss-page-replay/boss-page-replay.tsx
@@ -73,6 +73,8 @@ type BossReplayProps = {
   currentTick: number;
   advanceTick: () => void;
   setUseLegacy?: () => void;
+  /** Custom controls to render above the map. */
+  customControls?: React.ReactNode;
 };
 
 export function BossPageReplay({
@@ -85,6 +87,7 @@ export function BossPageReplay({
   currentTick,
   advanceTick,
   setUseLegacy,
+  customControls,
 }: BossReplayProps) {
   const [config, setConfig] = useState({
     interpolationEnabled: true,
@@ -189,6 +192,7 @@ export function BossPageReplay({
         }}
         className={styles.replay}
       >
+        {customControls}
         {!isFullscreen && renderMap(false)}
       </Card>
 

--- a/web/app/components/map-renderer/map-canvas.tsx
+++ b/web/app/components/map-renderer/map-canvas.tsx
@@ -282,7 +282,7 @@ function MapScene({
               isHovered={
                 interactionState.hoveredActorId === entity.getUniqueId()
               }
-              isDimmed={hoveredStack !== null && !inStack}
+              isDimmed={hoveredStack !== null ? !inStack : entity.dimmed}
               fanOutIndex={stackEntity?.fanOutIndex}
               stackSize={hoveredStack?.size ?? 1}
             />

--- a/web/app/components/map-renderer/npc.tsx
+++ b/web/app/components/map-renderer/npc.tsx
@@ -482,6 +482,21 @@ export default function Npc({
               {entity.name}
             </Text>
 
+            {npcEntity.label && (
+              <Text
+                position={[0, 0, 0.01]}
+                fontSize={0.4}
+                color="#ffffff"
+                anchorX="center"
+                anchorY="middle"
+                font="/fonts/runescape.ttf"
+                outlineWidth={0.03}
+                outlineColor="#000000"
+              >
+                {npcEntity.label}
+              </Text>
+            )}
+
             {!npcEntity.prayers.isEmpty() && (
               <group position={[0, 2.0 + (entity.size - 1) * 0.5, 0]}>
                 <Suspense fallback={null}>

--- a/web/app/components/map-renderer/types.ts
+++ b/web/app/components/map-renderer/types.ts
@@ -160,6 +160,8 @@ export class NpcEntity implements Entity {
   imageUrl: string;
   readonly maxSpeed: number;
   hitpoints: HitpointsState | null;
+  dimmed: boolean = false;
+  label?: string;
 
   public constructor(
     public readonly position: Coords,

--- a/web/app/utils/user-settings.ts
+++ b/web/app/utils/user-settings.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type UseSettingOptions<T> = {
+  key: string;
+  defaultValue: T;
+};
+
+/**
+ * Hook for persisting user settings.
+ *
+ * @param key The settings key.
+ * @param defaultValue The default value.
+ * @returns A tuple of the current value and a `setState`-compatible function to
+ *   update the value.
+ */
+export function useSetting<T>({
+  key,
+  defaultValue,
+}: UseSettingOptions<T>): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return defaultValue;
+    }
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // Ignore localStorage errors (e.g., quota exceeded, private browsing).
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}


### PR DESCRIPTION
Allows wave and offset based dimming of Nylocas in the room replay. Users can configure dim settings by either selecting a preset common dim or manually entering a custom one. All Nylocas alive at each configured dim tick are then dimmed using the existing functionality in the entity renderer.

Dim settings are persisted to local storage across page loads.

Implements #60.