### PR TITLE
Persistent user settings

### DIFF
--- a/common/migrations/20251224232427-create-user-settings-table.ts
+++ b/common/migrations/20251224232427-create-user-settings-table.ts
@@ -1,0 +1,13 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE TABLE user_settings (
+      user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      key VARCHAR(64) NOT NULL,
+      value JSONB NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, key)
+    )
+  `;
+}

--- a/web/app/actions/settings.ts
+++ b/web/app/actions/settings.ts
@@ -1,0 +1,101 @@
+'use server';
+
+import { JSONValue } from 'postgres';
+
+import { auth } from '@/auth';
+
+import { sql } from './db';
+
+export type UserSettings = Record<string, unknown>;
+
+/**
+ * Get all settings for the currently authenticated user.
+ * @returns Record of setting keys to values, or null if not authenticated.
+ */
+export async function getUserSettings(): Promise<UserSettings | null> {
+  const session = await auth();
+  if (!session?.user.id) {
+    return null;
+  }
+
+  const userId = parseInt(session.user.id, 10);
+  const rows = await sql<{ key: string; value: unknown }[]>`
+    SELECT key, value FROM user_settings
+    WHERE user_id = ${userId}
+  `;
+
+  const settings: UserSettings = {};
+  for (const row of rows) {
+    settings[row.key] = row.value;
+  }
+  return settings;
+}
+
+/**
+ * Update a single setting for the currently authenticated user.
+ * @param key The setting key.
+ * @param value The setting value.
+ */
+export async function setUserSetting(
+  key: string,
+  value: unknown,
+): Promise<void> {
+  const session = await auth();
+  if (!session?.user.id) {
+    throw new Error('Not authenticated');
+  }
+
+  const userId = parseInt(session.user.id, 10);
+  const jsonValue = sql.json(value as JSONValue);
+  await sql`
+    INSERT INTO user_settings (user_id, key, value, updated_at)
+    VALUES (${userId}, ${key}, ${jsonValue}, NOW())
+    ON CONFLICT (user_id, key)
+    DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+  `;
+}
+
+/**
+ * Sync multiple settings from localStorage to the server.
+ * Only syncs settings that don't already exist on the server.
+ *
+ * @param settings The settings to sync.
+ * @returns The final merged settings from the server.
+ */
+export async function syncSettings(
+  settings: UserSettings,
+): Promise<UserSettings> {
+  const session = await auth();
+  if (!session?.user.id) {
+    throw new Error('Not authenticated');
+  }
+
+  const userId = parseInt(session.user.id, 10);
+  const entries = Object.entries(settings);
+
+  if (entries.length > 0) {
+    const insertRows = entries.map(([key, value]) => ({
+      user_id: userId,
+      key,
+      value: sql.json(value as JSONValue),
+    }));
+
+    // Batch insert all settings, skipping any that already exist.
+    await sql`
+      INSERT INTO user_settings ${sql(insertRows)}
+      ON CONFLICT (user_id, key) DO NOTHING
+    `;
+  }
+
+  // Re-fetch all settings to get the authoritative merged state.
+  const rows = await sql<{ key: string; value: unknown }[]>`
+    SELECT key, value FROM user_settings
+    WHERE user_id = ${userId}
+  `;
+
+  const merged: UserSettings = {};
+  for (const row of rows) {
+    merged[row.key] = row.value;
+  }
+  return merged;
+}

--- a/web/app/components/boss-page-attack-timeline/boss-page-attack-timeline.tsx
+++ b/web/app/components/boss-page-attack-timeline/boss-page-attack-timeline.tsx
@@ -10,6 +10,7 @@ import Checkbox from '@/components/checkbox';
 import Menu from '@/components/menu';
 import Modal from '@/components/modal';
 import { DisplayContext } from '@/display';
+import { useSetting } from '@/utils/user-settings';
 
 import styles from './styles.module.scss';
 
@@ -21,7 +22,10 @@ export function BossPageAttackTimeline(props: AttackTimelineProps) {
   const [showSettings, setShowSettings] = useState(false);
   const [width, setWidth] = useState(0);
 
-  const [showKits, setShowKits] = useState(true);
+  const [showKits, setShowKits] = useSetting<boolean>({
+    key: 'timeline-show-kits',
+    defaultValue: true,
+  });
 
   useEffect(() => {
     const handleResize = () => setWidth(window.innerWidth);
@@ -75,20 +79,17 @@ export function BossPageAttackTimeline(props: AttackTimelineProps) {
   return (
     <Card
       className={styles.attackTimelineCard}
+      fixed
       header={{
         title: 'Room Timeline',
         action: (
           <div className={styles.actionButtons}>
-            <button
-              className={styles.expandButton}
-              onClick={() => setShowFullTimeline(true)}
-            >
+            <button onClick={() => setShowFullTimeline(true)}>
               <i className="fas fa-expand" />
               Expand
             </button>
             <button
               ref={settingsButtonRef}
-              className={styles.settingsButton}
               id="timeline-settings-button"
               onClick={() => setShowSettings(true)}
             >

--- a/web/app/components/settings-provider.tsx
+++ b/web/app/components/settings-provider.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { setUserSetting, syncSettings, UserSettings } from '@/actions/settings';
+
+import { useToast } from './toast';
+
+const SETTINGS_KEY_PREFIX = 'blert-setting:';
+
+type SettingsContextValue = {
+  settings: UserSettings;
+  isLoading: boolean;
+  updateSetting: <T>(key: string, value: T) => void;
+};
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+/**
+ * Retrieves all settings from localStorage.
+ */
+function getLocalStorageSettings(): UserSettings {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+
+  const settings = Object.create(null) as UserSettings;
+  for (let i = 0; i < localStorage.length; i++) {
+    const fullKey = localStorage.key(i);
+    if (fullKey?.startsWith(SETTINGS_KEY_PREFIX)) {
+      const key = fullKey.slice(SETTINGS_KEY_PREFIX.length);
+      try {
+        const value = localStorage.getItem(fullKey);
+        if (value !== null) {
+          settings[key] = JSON.parse(value);
+        }
+      } catch {
+        // Ignore parse errors.
+      }
+    }
+  }
+  return settings;
+}
+
+/**
+ * Saves a setting to localStorage.
+ */
+function setLocalStorageSetting(key: string, value: unknown): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    localStorage.setItem(SETTINGS_KEY_PREFIX + key, JSON.stringify(value));
+  } catch {
+    // Ignore localStorage errors (e.g., quota exceeded, private browsing).
+  }
+}
+
+export default function SettingsProvider({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  const session = useSession();
+  const showToast = useToast();
+
+  const [settings, setSettings] = useState<UserSettings>({});
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Track if we've already synced for this session to avoid repeated syncs.
+  const hasSynced = useRef(false);
+
+  // Track updates made while sync is in progress to avoid race conditions.
+  const isSyncing = useRef(false);
+  const pendingUpdates = useRef(Object.create(null) as UserSettings);
+
+  // Fetch and sync settings when user authenticates.
+  useEffect(() => {
+    if (session.status === 'loading') {
+      return;
+    }
+
+    const localSettings = getLocalStorageSettings();
+
+    if (session.status === 'unauthenticated') {
+      setSettings(localSettings);
+      setIsLoading(false);
+      hasSynced.current = false;
+      return;
+    }
+
+    // User is authenticated: sync settings with server.
+    if (hasSynced.current) {
+      return;
+    }
+    hasSynced.current = true;
+    isSyncing.current = true;
+    pendingUpdates.current = Object.create(null) as UserSettings;
+
+    syncSettings(localSettings)
+      .then((merged) => {
+        // Apply any updates made while sync was in progress.
+        const pending = pendingUpdates.current;
+        const finalSettings = { ...merged, ...pending };
+
+        setSettings(finalSettings);
+
+        for (const [key, value] of Object.entries(finalSettings)) {
+          setLocalStorageSetting(key, value);
+        }
+
+        // Send pending updates to server.
+        for (const [key, value] of Object.entries(pending)) {
+          setUserSetting(key, value).catch((error) => {
+            console.error('Failed to save pending setting:', error);
+          });
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to sync settings:', error);
+        // Fall back to localStorage on error, including any pending updates.
+        const pending = pendingUpdates.current;
+        setSettings({ ...localSettings, ...pending });
+      })
+      .finally(() => {
+        isSyncing.current = false;
+        pendingUpdates.current = Object.create(null) as UserSettings;
+        setIsLoading(false);
+      });
+  }, [session.status]);
+
+  const updateSetting = useCallback(
+    <T,>(key: string, value: T) => {
+      // Optimistic update.
+      setSettings((prev) => ({ ...prev, [key]: value }));
+      setLocalStorageSetting(key, value);
+
+      if (session.status === 'authenticated') {
+        if (isSyncing.current) {
+          // Track update to apply after sync completes.
+          pendingUpdates.current[key] = value;
+        } else {
+          setUserSetting(key, value).catch((error) => {
+            console.error('Failed to save setting:', error);
+            showToast('Failed to save setting', 'error');
+            // Note: We don't revert the optimistic update since localStorage
+            // still has the value and it will be synced on next load.
+          });
+        }
+      }
+    },
+    [session.status, showToast],
+  );
+
+  const contextValue = useMemo(
+    () => ({ settings, isLoading, updateSetting }),
+    [settings, isLoading, updateSetting],
+  );
+
+  return (
+    <SettingsContext.Provider value={contextValue}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the settings context.
+ * @returns The settings context value.
+ */
+export function useSettingsContext(): SettingsContextValue {
+  const context = useContext(SettingsContext);
+  if (context === null) {
+    throw new Error(
+      'useSettingsContext must be used within a SettingsProvider',
+    );
+  }
+  return context;
+}

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -3,6 +3,7 @@
 import { SessionProvider } from 'next-auth/react';
 
 import ChallengeProvider from './challenge-context';
+import SettingsProvider from './components/settings-provider';
 import ToastProvider from './components/toast';
 import { DisplayWrapper } from './display';
 
@@ -15,7 +16,9 @@ export default function Providers({ children }: ProvidersProps) {
     <SessionProvider>
       <DisplayWrapper>
         <ChallengeProvider>
-          <ToastProvider>{children}</ToastProvider>
+          <ToastProvider>
+            <SettingsProvider>{children}</SettingsProvider>
+          </ToastProvider>
         </ChallengeProvider>
       </DisplayWrapper>
     </SessionProvider>

--- a/web/app/utils/user-settings.ts
+++ b/web/app/utils/user-settings.ts
@@ -1,6 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useRef } from 'react';
+
+import { useSettingsContext } from '@/components/settings-provider';
 
 type UseSettingOptions<T> = {
   key: string;
@@ -10,34 +12,30 @@ type UseSettingOptions<T> = {
 /**
  * Hook for persisting user settings.
  *
+ * For authenticated users, settings are synced to the server.
+ * For unauthenticated users, settings are stored in localStorage.
+ *
  * @param key The settings key.
- * @param defaultValue The default value.
- * @returns A tuple of the current value and a `setState`-compatible function to
- *   update the value.
+ * @param defaultValue The default value (captured on first render).
+ * @returns A tuple of the current value and a function to update the value.
  */
 export function useSetting<T>({
   key,
   defaultValue,
-}: UseSettingOptions<T>): [T, React.Dispatch<React.SetStateAction<T>>] {
-  const [value, setValue] = useState<T>(() => {
-    if (typeof window === 'undefined') {
-      return defaultValue;
-    }
-    try {
-      const stored = localStorage.getItem(key);
-      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
-    } catch {
-      return defaultValue;
-    }
-  });
+}: UseSettingOptions<T>): [T, (value: T) => void] {
+  const { settings, updateSetting } = useSettingsContext();
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // Ignore localStorage errors (e.g., quota exceeded, private browsing).
-    }
-  }, [key, value]);
+  // Capture default value on first render to avoid object identity issues.
+  const defaultRef = useRef(defaultValue);
+
+  const value = key in settings ? (settings[key] as T) : defaultRef.current;
+
+  const setValue = useCallback(
+    (value: T) => {
+      updateSetting(key, value);
+    },
+    [key, updateSetting],
+  );
 
   return [value, setValue];
 }


### PR DESCRIPTION
Creates a system for components to define custom persistent settings which are stored in the database for the active user or in localStorage when logged out.

Each setting has a string key and an arbitrary JSON value which are stored as jsonb in a new user_settings table. Settings from localStorage are synced to the database when a user logs in.