### PR TITLE
Add loading state to sidebar account status

### DIFF
--- a/web/app/components/left-nav/__tests__/account-status.test.tsx
+++ b/web/app/components/left-nav/__tests__/account-status.test.tsx
@@ -1,0 +1,387 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import AccountStatus, { AccountStatusSkeleton } from '../account-status';
+
+const mockReplace = jest.fn();
+const mockSignOut = jest.fn<Promise<{ url: string }>, [unknown]>();
+const mockSearchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/'),
+  useRouter: jest.fn(() => ({
+    replace: mockReplace,
+  })),
+  useSearchParams: jest.fn(() => mockSearchParams),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn((...args: [unknown]) => mockSignOut(...args)),
+}));
+
+import { useSession } from 'next-auth/react';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+const mockUseSession = useSession as jest.Mock;
+const mockUsePathname = usePathname as jest.Mock;
+const mockUseSearchParams = useSearchParams as jest.Mock;
+
+describe('AccountStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePathname.mockReturnValue('/');
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+  });
+
+  describe('loading state', () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue({ status: 'loading', data: null });
+    });
+
+    it('renders skeleton UI when loading', () => {
+      const { container } = render(<AccountStatus />);
+
+      const skeleton = container.querySelector('[class*="skeleton"]');
+      expect(skeleton).toBeInTheDocument();
+    });
+
+    it('renders skeleton avatar', () => {
+      const { container } = render(<AccountStatus />);
+
+      const avatar = container.querySelector('[class*="avatar"]');
+      expect(avatar).toBeInTheDocument();
+      expect(avatar?.className).toContain('skeleton');
+    });
+
+    it('renders skeleton text elements', () => {
+      const { container } = render(<AccountStatus />);
+
+      const skeletonTexts = container.querySelectorAll(
+        '[class*="skeletonText"]',
+      );
+      expect(skeletonTexts).toHaveLength(2);
+    });
+
+    it('renders skeleton action buttons', () => {
+      const { container } = render(<AccountStatus />);
+
+      const skeletonActions = container.querySelectorAll(
+        '[class*="skeletonAction"]',
+      );
+      expect(skeletonActions).toHaveLength(2);
+    });
+
+    it('does not render login or signup buttons', () => {
+      render(<AccountStatus />);
+
+      expect(screen.queryByText('Log In')).not.toBeInTheDocument();
+      expect(screen.queryByText('Sign Up')).not.toBeInTheDocument();
+    });
+
+    it('does not render user info', () => {
+      render(<AccountStatus />);
+
+      expect(screen.queryByText('Signed in as')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('AccountStatusSkeleton', () => {
+    it('renders skeleton UI independently', () => {
+      const { container } = render(<AccountStatusSkeleton />);
+
+      const skeleton = container.querySelector('[class*="skeleton"]');
+      expect(skeleton).toBeInTheDocument();
+    });
+
+    it('renders skeleton avatar', () => {
+      const { container } = render(<AccountStatusSkeleton />);
+
+      const avatar = container.querySelector('[class*="avatar"]');
+      expect(avatar).toBeInTheDocument();
+      expect(avatar?.className).toContain('skeleton');
+    });
+
+    it('renders skeleton text elements', () => {
+      const { container } = render(<AccountStatusSkeleton />);
+
+      const skeletonTexts = container.querySelectorAll(
+        '[class*="skeletonText"]',
+      );
+      expect(skeletonTexts).toHaveLength(2);
+    });
+
+    it('renders skeleton action buttons', () => {
+      const { container } = render(<AccountStatusSkeleton />);
+
+      const skeletonActions = container.querySelectorAll(
+        '[class*="skeletonAction"]',
+      );
+      expect(skeletonActions).toHaveLength(2);
+    });
+  });
+
+  describe('authenticated state', () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue({
+        status: 'authenticated',
+        data: { user: { name: 'TestUser' } },
+      });
+    });
+
+    it('displays "Signed in as" label', () => {
+      render(<AccountStatus />);
+
+      expect(screen.getByText('Signed in as')).toBeInTheDocument();
+    });
+
+    it('displays the username', () => {
+      render(<AccountStatus />);
+
+      expect(screen.getByText('TestUser')).toBeInTheDocument();
+    });
+
+    it('displays "Unknown" when username is null', () => {
+      mockUseSession.mockReturnValue({
+        status: 'authenticated',
+        data: { user: { name: null } },
+      });
+
+      render(<AccountStatus />);
+
+      expect(screen.getByText('Unknown')).toBeInTheDocument();
+    });
+
+    it('renders settings link', () => {
+      render(<AccountStatus />);
+
+      const settingsLink = screen.getByText('Settings').closest('a');
+      expect(settingsLink).toBeInTheDocument();
+      expect(settingsLink).toHaveAttribute('href', '/settings');
+    });
+
+    it('renders logout button', () => {
+      render(<AccountStatus />);
+
+      expect(screen.getByText('Log Out')).toBeInTheDocument();
+    });
+
+    it('renders user avatar icon', () => {
+      const { container } = render(<AccountStatus />);
+
+      const avatarIcon = container.querySelector('.fa-user');
+      expect(avatarIcon).toBeInTheDocument();
+    });
+
+    it('renders settings icon', () => {
+      const { container } = render(<AccountStatus />);
+
+      const settingsIcon = container.querySelector('.fa-gear');
+      expect(settingsIcon).toBeInTheDocument();
+    });
+
+    it('renders logout icon', () => {
+      const { container } = render(<AccountStatus />);
+
+      const logoutIcon = container.querySelector('.fa-right-from-bracket');
+      expect(logoutIcon).toBeInTheDocument();
+    });
+
+    it('does not render login or signup buttons', () => {
+      render(<AccountStatus />);
+
+      expect(screen.queryByText('Log In')).not.toBeInTheDocument();
+      expect(screen.queryByText('Sign Up')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('unauthenticated state', () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue({ status: 'unauthenticated', data: null });
+    });
+
+    it('renders login button', () => {
+      render(<AccountStatus />);
+
+      expect(screen.getByText('Log In')).toBeInTheDocument();
+    });
+
+    it('renders signup button', () => {
+      render(<AccountStatus />);
+
+      expect(screen.getByText('Sign Up')).toBeInTheDocument();
+    });
+
+    it('login link includes current path as next parameter', () => {
+      mockUsePathname.mockReturnValue('/some/page');
+
+      render(<AccountStatus />);
+
+      const loginLink = screen.getByText('Log In').closest('a');
+      expect(loginLink).toHaveAttribute('href', '/login?next=%2Fsome%2Fpage');
+    });
+
+    it('signup link includes current path as next parameter', () => {
+      mockUsePathname.mockReturnValue('/another/page');
+
+      render(<AccountStatus />);
+
+      const signupLink = screen.getByText('Sign Up').closest('a');
+      expect(signupLink).toHaveAttribute(
+        'href',
+        '/register?next=%2Fanother%2Fpage',
+      );
+    });
+
+    it('login link includes search params in next parameter', () => {
+      mockUsePathname.mockReturnValue('/raids/tob');
+      mockUseSearchParams.mockReturnValue(
+        new URLSearchParams('scale=5&status=1'),
+      );
+
+      render(<AccountStatus />);
+
+      const loginLink = screen.getByText('Log In').closest('a');
+      expect(loginLink).toHaveAttribute(
+        'href',
+        '/login?next=%2Fraids%2Ftob%3Fscale%3D5%26status%3D1',
+      );
+    });
+
+    it('signup link includes search params in next parameter', () => {
+      mockUsePathname.mockReturnValue('/leaderboards/tob/regular/5');
+      mockUseSearchParams.mockReturnValue(new URLSearchParams('limit=10'));
+
+      render(<AccountStatus />);
+
+      const signupLink = screen.getByText('Sign Up').closest('a');
+      expect(signupLink).toHaveAttribute(
+        'href',
+        '/register?next=%2Fleaderboards%2Ftob%2Fregular%2F5%3Flimit%3D10',
+      );
+    });
+
+    it('does not append ? when there are no search params', () => {
+      mockUsePathname.mockReturnValue('/raids/tob/123');
+      mockUseSearchParams.mockReturnValue(new URLSearchParams());
+
+      render(<AccountStatus />);
+
+      const loginLink = screen.getByText('Log In').closest('a');
+      expect(loginLink).toHaveAttribute(
+        'href',
+        '/login?next=%2Fraids%2Ftob%2F123',
+      );
+    });
+
+    it('renders login icon', () => {
+      const { container } = render(<AccountStatus />);
+
+      const loginIcon = container.querySelector('.fa-right-to-bracket');
+      expect(loginIcon).toBeInTheDocument();
+    });
+
+    it('renders signup icon', () => {
+      const { container } = render(<AccountStatus />);
+
+      const signupIcon = container.querySelector('.fa-user-plus');
+      expect(signupIcon).toBeInTheDocument();
+    });
+
+    it('does not render user info', () => {
+      render(<AccountStatus />);
+
+      expect(screen.queryByText('Signed in as')).not.toBeInTheDocument();
+    });
+
+    it('does not render settings or logout', () => {
+      render(<AccountStatus />);
+
+      expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+      expect(screen.queryByText('Log Out')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('logout functionality', () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue({
+        status: 'authenticated',
+        data: { user: { name: 'TestUser' } },
+      });
+    });
+
+    it('calls signOut when logout button is clicked', async () => {
+      mockSignOut.mockResolvedValue({ url: '/' });
+
+      render(<AccountStatus />);
+
+      fireEvent.click(screen.getByText('Log Out'));
+
+      await waitFor(() => {
+        expect(mockSignOut).toHaveBeenCalled();
+      });
+    });
+
+    it('redirects to home when on protected route', async () => {
+      mockUsePathname.mockReturnValue('/dashboard');
+      mockSignOut.mockResolvedValue({ url: '/' });
+
+      render(<AccountStatus />);
+
+      fireEvent.click(screen.getByText('Log Out'));
+
+      await waitFor(() => {
+        expect(mockSignOut).toHaveBeenCalledWith({
+          redirect: false,
+          callbackUrl: '/',
+        });
+      });
+    });
+
+    it('redirects to current page when on non-protected route', async () => {
+      mockUsePathname.mockReturnValue('/raids/123');
+      mockSignOut.mockResolvedValue({ url: '/raids/123' });
+
+      render(<AccountStatus />);
+
+      fireEvent.click(screen.getByText('Log Out'));
+
+      await waitFor(() => {
+        expect(mockSignOut).toHaveBeenCalledWith({
+          redirect: false,
+          callbackUrl: '/raids/123',
+        });
+      });
+    });
+
+    it('redirects to home when on settings page', async () => {
+      mockUsePathname.mockReturnValue('/settings');
+      mockSignOut.mockResolvedValue({ url: '/' });
+
+      render(<AccountStatus />);
+
+      fireEvent.click(screen.getByText('Log Out'));
+
+      await waitFor(() => {
+        expect(mockSignOut).toHaveBeenCalledWith({
+          redirect: false,
+          callbackUrl: '/',
+        });
+      });
+    });
+
+    it('calls router.replace with signOut url', async () => {
+      mockSignOut.mockResolvedValue({ url: '/custom-redirect' });
+
+      render(<AccountStatus />);
+
+      fireEvent.click(screen.getByText('Log Out'));
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/custom-redirect');
+      });
+    });
+  });
+});

--- a/web/app/components/left-nav/account-status.tsx
+++ b/web/app/components/left-nav/account-status.tsx
@@ -1,17 +1,49 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 
 const PROTECTED_ROUTES = ['/dashboard', '/settings'];
 
 import styles from './styles.module.scss';
 
+export function AccountStatusSkeleton() {
+  return (
+    <div className={styles.account}>
+      <div className={styles.userWrapper}>
+        <div className={styles.userInfo}>
+          <div className={`${styles.avatar} ${styles.skeleton}`} />
+          <div className={styles.details}>
+            <div className={`${styles.skeletonText} ${styles.skeletonLabel}`} />
+            <div
+              className={`${styles.skeletonText} ${styles.skeletonUsername}`}
+            />
+          </div>
+        </div>
+        <div className={styles.actions}>
+          <div className={`${styles.skeletonAction}`} />
+          <div className={`${styles.skeletonAction}`} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function AccountStatus() {
   const currentPath = usePathname();
+  const searchParams = useSearchParams();
   const router = useRouter();
   const session = useSession();
+
+  const currentUrl =
+    searchParams.size > 0
+      ? `${currentPath}?${searchParams.toString()}`
+      : currentPath;
+
+  if (session.status === 'loading') {
+    return <AccountStatusSkeleton />;
+  }
 
   return (
     <div className={styles.account}>
@@ -41,7 +73,7 @@ export default function AccountStatus() {
                     redirect: false,
                     callbackUrl: PROTECTED_ROUTES.includes(currentPath)
                       ? '/'
-                      : currentPath,
+                      : currentUrl,
                   });
                   router.replace(url);
                 })()
@@ -56,14 +88,14 @@ export default function AccountStatus() {
         <div className={styles.authActions}>
           <Link
             className={`${styles.authAction} ${styles.login}`}
-            href="/login"
+            href={`/login?next=${encodeURIComponent(currentUrl)}`}
           >
             <i className="fa-solid fa-right-to-bracket" />
             <span>Log In</span>
           </Link>
           <Link
             className={`${styles.authAction} ${styles.signup}`}
-            href="/register"
+            href={`/register?next=${encodeURIComponent(currentUrl)}`}
           >
             <i className="fa-solid fa-user-plus" />
             <span>Sign Up</span>

--- a/web/app/components/left-nav/left-nav.tsx
+++ b/web/app/components/left-nav/left-nav.tsx
@@ -1,9 +1,10 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { Suspense } from 'react';
 
 import { MAIN_LOGO } from '@/logo';
 
-import AccountStatus from './account-status';
+import AccountStatus, { AccountStatusSkeleton } from './account-status';
 import { LEFT_NAV_WIDTH } from './definitions';
 import { LeftNavWrapper } from './left-nav-wrapper';
 import NavPlayerSearch from './nav-player-search';
@@ -226,7 +227,9 @@ export function LeftNav() {
           </li>
         </ul>
 
-        <AccountStatus />
+        <Suspense fallback={<AccountStatusSkeleton />}>
+          <AccountStatus />
+        </Suspense>
 
         <div className={styles.leftNav__externalLinks}>
           <div className={styles.leftNav__externalLink}>

--- a/web/app/components/left-nav/styles.module.scss
+++ b/web/app/components/left-nav/styles.module.scss
@@ -128,6 +128,55 @@
       }
     }
 
+    @keyframes accountStatusPulse {
+      0% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.4;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+
+    .skeleton {
+      background: var(--blert-surface-light);
+      animation: accountStatusPulse 1.5s ease-in-out infinite;
+    }
+
+    .skeletonText {
+      background: var(--blert-surface-light);
+      border-radius: 4px;
+      animation: accountStatusPulse 1.5s ease-in-out infinite;
+    }
+
+    .skeletonLabel {
+      width: 70px;
+      height: 12px;
+      margin-bottom: 6px;
+    }
+
+    .skeletonUsername {
+      width: 100px;
+      height: 14px;
+    }
+
+    .skeletonAction {
+      height: 30px;
+      border-radius: 6px;
+      background: var(--blert-surface-light);
+      animation: accountStatusPulse 1.5s ease-in-out infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .skeleton,
+      .skeletonText,
+      .skeletonAction {
+        animation: none;
+      }
+    }
+
     .authActions {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
Handles the auth loading state by showing a skeleton account status panel and updates login/register to redirect back to the current URL after the user logs in.