### PR TITLE
Update styling of charts on challenge page

### DIFF
--- a/web/app/(challenges)/activity-dashboard.module.scss
+++ b/web/app/(challenges)/activity-dashboard.module.scss
@@ -44,19 +44,6 @@
   }
 }
 
-.cardHeader {
-  padding: 1.25rem 1.5rem 0.75rem;
-  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
-
-  h3 {
-    margin: 0;
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: var(--blert-font-color-primary);
-    text-shadow: 0 0 3px rgba(var(--blert-purple-base), 0.4);
-  }
-}
-
 .cardContent {
   padding: 1.5rem;
 }
@@ -65,13 +52,10 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   gap: 1rem;
+  justify-items: center;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     grid-template-columns: repeat(2, 1fr);
-  }
-
-  .statistic {
-    margin: 0 auto;
   }
 }
 
@@ -87,7 +71,7 @@
   gap: 0.75rem;
   font-size: 1.1rem;
   font-weight: 600;
-  margin: 0 0 1.5rem 0;
+  margin: 0 0 1rem 0;
   color: var(--blert-font-color-primary);
   padding-bottom: 0.75rem;
   border-bottom: 2px solid rgba(var(--blert-purple-base), 0.2);
@@ -109,55 +93,143 @@
   }
 }
 
-.chartContainer {
-  margin-bottom: 1.5rem;
-}
-
-.chartTitle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 1rem;
-  font-weight: 600;
-  margin: 0 0 1rem 0;
-  color: var(--blert-font-color-secondary);
-
-  i {
-    color: var(--blert-purple);
-  }
-}
-
-.chartContent {
-  position: relative;
-}
-
 .chartsGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1rem;
+  gap: 1rem;
+  margin-top: 0.75rem;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     grid-template-columns: 1fr;
-    gap: 1.5rem;
+    gap: 1rem;
   }
 }
 
-.pieChartContainer {
+.donutChartContainer {
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding: 0.5rem 1rem;
+  background: rgba(var(--blert-surface-dark-base), 0.3);
+  border: 1px solid rgba(var(--blert-surface-light-base), 0.3);
+  border-radius: 8px;
+}
 
-  .chartTitle {
-    font-size: 0.9rem;
-    margin-bottom: 0.5rem;
-    text-align: center;
-  }
+.donutWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.donutCenter {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.donutCenterTitle {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--blert-font-color-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  z-index: 1;
+}
+
+.compactLegend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(84px, 1fr));
+  gap: 0.25rem 0.5rem;
+  margin-top: 0.5rem;
+  width: 100%;
+  max-width: 220px;
 }
 
 .legendItem {
-  font-size: 0.8rem !important;
-  color: var(--blert-font-color-primary) !important;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+.legendSquare {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.legendText {
+  color: var(--blert-font-color-primary);
+}
+
+.legendCount {
+  color: var(--blert-font-color-secondary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  margin-left: auto;
+}
+
+.donutTooltip {
+  background: linear-gradient(
+    135deg,
+    var(--blert-panel-background-color) 0%,
+    rgba(var(--blert-surface-dark-base), 0.95) 100%
+  );
+  border: 1px solid rgba(var(--blert-purple-base), 0.2);
+  border-radius: 8px;
+  padding: 0.6rem 0.8rem;
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.4),
+    0 2px 4px rgba(0, 0, 0, 0.2);
+  min-width: 140px;
+}
+
+.tooltipHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid rgba(var(--blert-surface-light-base), 0.4);
+}
+
+.tooltipSquare {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.tooltipName {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+}
+
+.tooltipStats {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.tooltipValue {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--blert-font-color-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.tooltipPercent {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--blert-purple);
+  font-variant-numeric: tabular-nums;
 }
 
 // Skeleton Animations
@@ -173,39 +245,28 @@
   }
 }
 
-.pieChartSkeleton {
+.donutSkeletonWrapper {
+  position: relative;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  padding: 1rem;
-  min-height: 130px;
-  width: 200px;
   justify-content: center;
 }
 
-.skeletonCircle {
-  width: 100px;
-  height: 50px;
-  background: var(--blert-divider-color);
-  border-radius: 100px 100px 0 0;
-  animation: pulse 1.5s ease-in-out infinite;
-  margin-top: 1rem;
-}
-
 .skeletonLegend {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.35rem 0.5rem;
+  margin-top: 0.5rem;
+  width: 100%;
+  max-width: 220px;
 }
 
 .skeletonLegendItem {
-  width: 80px;
-  height: 12px;
+  height: 18px;
   background: var(--blert-divider-color);
-  border-radius: 6px;
+  border-radius: 4px;
   animation: pulse 1.5s ease-in-out infinite;
-  animation-delay: calc(var(--item-index, 0) * 200ms);
+  animation-delay: calc(var(--item-index, 0) * 100ms);
 
   &:nth-child(1) {
     --item-index: 0;
@@ -216,6 +277,24 @@
   &:nth-child(3) {
     --item-index: 2;
   }
+  &:nth-child(4) {
+    --item-index: 3;
+  }
+}
+
+.skeletonDonut {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--blert-divider-color) 0deg 90deg,
+    rgba(var(--blert-purple-base), 0.2) 90deg 180deg,
+    var(--blert-divider-color) 180deg 270deg,
+    rgba(var(--blert-purple-base), 0.15) 270deg 360deg
+  );
+  mask: radial-gradient(circle, transparent 40px, black 40px);
+  -webkit-mask: radial-gradient(circle, transparent 40px, black 40px);
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 .barChartSkeleton {


### PR DESCRIPTION
Makes the legend on the dashboard stats/scale charts flow better.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the activity dashboard charting UI and styling.
> 
> - Replace Recharts `Legend`-based pie charts with custom donut charts (`DonutChartComponent`) including center title, compact legend with counts, and `DonutTooltip` showing counts and percentages
> - Add/overhaul SCSS: new `chartsGrid`, `donutChartContainer`, legend/tooltip styles, and donut skeletons; remove old pie/legend styles; tighten `sectionTitle` spacing and center `statisticsGrid` items
> - Update copy: header uses `challengeTerm(...)`; chart titles shortened to `Scale` and `Status`; player tooltip pluralizes `run/raid` based on mode
> - Minor cleanup: remove unused `className` props on `Statistic`; adjust loading placeholders for donut charts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8bcfe9f657572718cd2cbfb0a6d671658b02e69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->