### PR TITLE
Await result of Redis transaction

### DIFF
--- a/challenge-server/redis-client.ts
+++ b/challenge-server/redis-client.ts
@@ -1186,12 +1186,14 @@ export class RedisClient implements ChallengeReadOperations {
     while (true) {
       attempt++;
       try {
-        const result = this.client.executeIsolated(async (isolatedClient) => {
-          const txn = ctor(isolatedClient);
-          const res = await fn(txn);
-          await txn.exec();
-          return res;
-        });
+        const result = await this.client.executeIsolated(
+          async (isolatedClient) => {
+            const txn = ctor(isolatedClient);
+            const res = await fn(txn);
+            await txn.exec();
+            return res;
+          },
+        );
         return result;
       } catch (e) {
         if (e instanceof WatchError) {


### PR DESCRIPTION
Errors were not correctly being caught since the promise was returned without awaiting it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures errors from Redis transactions are caught and retried.
> 
> - In `retryTransaction`, now `await`s `client.executeIsolated(...)` so exceptions surface to the surrounding try/catch, preserving `WatchError` retry logic and proper error propagation
> - No other functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 565e46d182f8dc9a6479de5d62410e2527dc6367. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->