### PR TITLE
Several improvements to the web rate limiter

### DIFF
--- a/web/__tests__/utils/rate-limit.test.ts
+++ b/web/__tests__/utils/rate-limit.test.ts
@@ -14,6 +14,7 @@ type MockPipeline = {
   zRemRangeByScore: jest.Mock;
   zAdd: jest.Mock;
   zCard: jest.Mock;
+  zRangeWithScores: jest.Mock;
   expire: jest.Mock;
   exec: jest.Mock;
 };
@@ -22,6 +23,7 @@ type MockRedisClient = {
   multi: jest.Mock;
   zRemRangeByScore: jest.Mock;
   zCard: jest.Mock;
+  zRangeWithScores: jest.Mock;
 };
 
 const mockedRedis = redis as jest.MockedFunction<typeof redis>;
@@ -31,6 +33,7 @@ function createMockPipeline(): MockPipeline {
     zRemRangeByScore: jest.fn().mockReturnThis(),
     zAdd: jest.fn().mockReturnThis(),
     zCard: jest.fn().mockReturnThis(),
+    zRangeWithScores: jest.fn().mockReturnThis(),
     expire: jest.fn().mockReturnThis(),
     exec: jest.fn(),
   };
@@ -41,6 +44,7 @@ function createMockClient(): MockRedisClient {
     multi: jest.fn(),
     zRemRangeByScore: jest.fn(),
     zCard: jest.fn(),
+    zRangeWithScores: jest.fn(),
   };
 }
 
@@ -69,16 +73,24 @@ describe('rate-limit utils', () => {
     it('allows requests within the configured limit', async () => {
       const pipeline = createMockPipeline();
       const countAfterInsert = 3;
-      pipeline.exec.mockResolvedValue([null, null, countAfterInsert, 'OK']);
+      pipeline.exec.mockResolvedValue([
+        null,
+        null,
+        countAfterInsert,
+        [{ value: 'oldest', score: Date.now() }],
+        'OK',
+      ]);
       mockClient.multi.mockReturnValue(pipeline);
 
       const result = await rateLimit('ratelimit:test', 5, 60);
+      const expectedReset = Math.floor((Date.now() + 60 * 1000) / 1000);
 
       expect(result).toMatchObject({
         success: true,
         limit: 5,
         remaining: 2,
       });
+      expect(result.reset).toBe(expectedReset);
       expect(pipeline.zRemRangeByScore).toHaveBeenCalledWith(
         'ratelimit:test',
         0,
@@ -92,29 +104,60 @@ describe('rate-limit utils', () => {
           }),
         ]),
       );
+      expect(pipeline.zRangeWithScores).toHaveBeenCalledWith(
+        'ratelimit:test',
+        0,
+        0,
+      );
       expect(pipeline.expire).toHaveBeenCalledWith('ratelimit:test', 120);
     });
 
     it('blocks requests that exceed the limit', async () => {
       const pipeline = createMockPipeline();
-      pipeline.exec.mockResolvedValue([null, null, 7, 'OK']);
+      pipeline.exec.mockResolvedValue([
+        null,
+        null,
+        7,
+        [{ value: 'oldest', score: Date.now() }],
+        'OK',
+      ]);
       mockClient.multi.mockReturnValue(pipeline);
 
       const result = await rateLimit('ratelimit:test', 5, 60);
 
       expect(result.success).toBe(false);
       expect(result.remaining).toBe(0);
+      expect(result.reset).toBe(Math.floor((Date.now() + 60 * 1000) / 1000));
     });
 
-    it('fails open when Redis throws an error', async () => {
+    it('computes reset from the oldest retained request', async () => {
+      const pipeline = createMockPipeline();
+      const oldestScore = Date.now() - 30 * 1000;
+      pipeline.exec.mockResolvedValue([
+        null,
+        null,
+        2,
+        [{ value: 'oldest', score: oldestScore }],
+        'OK',
+      ]);
+      mockClient.multi.mockReturnValue(pipeline);
+
+      const result = await rateLimit('ratelimit:test', 5, 60);
+
+      expect(result.reset).toBe(Math.floor((oldestScore + 60 * 1000) / 1000));
+    });
+
+    it('fails open without debiting remaining quota when Redis throws an error', async () => {
       const pipeline = createMockPipeline();
       pipeline.exec.mockRejectedValue(new Error('redis down'));
       mockClient.multi.mockReturnValue(pipeline);
 
       const result = await rateLimit('ratelimit:test', 5, 60);
+      const expectedReset = Math.floor((Date.now() + 60 * 1000) / 1000);
 
       expect(result.success).toBe(true);
-      expect(result.remaining).toBe(4);
+      expect(result.remaining).toBe(5);
+      expect(result.reset).toBe(expectedReset);
     });
   });
 
@@ -122,19 +165,27 @@ describe('rate-limit utils', () => {
     it('returns remaining tokens without incrementing usage', async () => {
       mockClient.zRemRangeByScore.mockResolvedValue(undefined);
       mockClient.zCard.mockResolvedValue(12);
+      mockClient.zRangeWithScores.mockResolvedValue([]);
 
       const status = await getRateLimitStatus('ratelimit:test', 20, 60);
+      const expectedReset = Math.floor((Date.now() + 60 * 1000) / 1000);
 
       expect(status).toMatchObject({
         limit: 20,
         remaining: 8,
       });
+      expect(status.reset).toBe(expectedReset);
       expect(mockClient.zRemRangeByScore).toHaveBeenCalledWith(
         'ratelimit:test',
         0,
         Date.now() - 60 * 1000,
       );
       expect(mockClient.zCard).toHaveBeenCalledWith('ratelimit:test');
+      expect(mockClient.zRangeWithScores).toHaveBeenCalledWith(
+        'ratelimit:test',
+        0,
+        0,
+      );
     });
 
     it('returns a full window when Redis errors', async () => {
@@ -146,6 +197,7 @@ describe('rate-limit utils', () => {
         limit: 10,
         remaining: 10,
       });
+      expect(status.reset).toBe(Math.floor((Date.now() + 60 * 1000) / 1000));
       expect(mockClient.zCard).not.toHaveBeenCalled();
     });
   });

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -30,7 +30,7 @@ const RATE_LIMITS: RouteMatcher[] = [
   {
     test: (path) => /^\/api\/v1\/.+\/events/.test(path),
     config: {
-      limit: 25,
+      limit: 30,
       windowSec: 60,
       keyPrefix: 'ratelimit:v1:events',
     },
@@ -38,7 +38,7 @@ const RATE_LIMITS: RouteMatcher[] = [
   {
     test: (path) => path.startsWith('/api/v1/challenges/stats'),
     config: {
-      limit: 40,
+      limit: 60,
       windowSec: 60,
       keyPrefix: 'ratelimit:v1:challenge-stats',
     },
@@ -62,7 +62,7 @@ const RATE_LIMITS: RouteMatcher[] = [
   {
     test: (path) => path.startsWith('/api/v1/'),
     config: {
-      limit: 60,
+      limit: 80,
       windowSec: 60,
       keyPrefix: 'ratelimit:v1:default',
     },


### PR DESCRIPTION
- Don't decrement remaining quota when Redis fails
- Correctly use a sliding window for the reset timestamp
- Improve test coverage
- Increase rate limits for public API endpoints