### PR TITLE
 Make timeline start for tick 0; add display range

### DIFF
--- a/bcf/examples/113-p1.bcf.json
+++ b/bcf/examples/113-p1.bcf.json
@@ -4,6 +4,7 @@
   "description": "Standard trio money P1 chart",
   "config": {
     "totalTicks": 62,
+    "startTick": 1,
     "rowOrder": ["verzik", "p1", "p2", "p3"]
   },
   "timeline": {

--- a/bcf/schemas/bcf-1.0-strict.schema.json
+++ b/bcf/schemas/bcf-1.0-strict.schema.json
@@ -27,6 +27,8 @@
       "required": ["totalTicks"],
       "properties": {
         "totalTicks": { "type": "integer", "minimum": 1 },
+        "startTick": { "type": "integer", "minimum": 0 },
+        "endTick": { "type": "integer", "minimum": 0 },
         "rowOrder": {
           "type": "array",
           "items": { "$ref": "#/$defs/idString" },
@@ -99,7 +101,7 @@
       "additionalProperties": false,
       "required": ["tick", "cells"],
       "properties": {
-        "tick": { "type": "integer", "minimum": 1 },
+        "tick": { "type": "integer", "minimum": 0 },
         "cells": {
           "type": "array",
           "items": { "$ref": "#/$defs/cell" }
@@ -259,7 +261,7 @@
       "additionalProperties": false,
       "required": ["tick", "name"],
       "properties": {
-        "tick": { "type": "integer", "minimum": 1 },
+        "tick": { "type": "integer", "minimum": 0 },
         "name": { "type": "string", "minLength": 1 },
         "isImportant": { "type": "boolean", "default": true }
       }
@@ -270,7 +272,7 @@
       "additionalProperties": false,
       "required": ["tick", "color"],
       "properties": {
-        "tick": { "type": "integer", "minimum": 1 },
+        "tick": { "type": "integer", "minimum": 0 },
         "length": { "type": "integer", "minimum": 1, "default": 1 },
         "color": {
           "type": "string",
@@ -304,7 +306,7 @@
       "additionalProperties": false,
       "required": ["tick"],
       "properties": {
-        "tick": { "type": "integer", "minimum": 1 },
+        "tick": { "type": "integer", "minimum": 0 },
         "iconUrl": { "type": "string" },
         "label": { "type": "string", "minLength": 1, "maxLength": 3 },
         "opacity": {

--- a/bcf/schemas/bcf-1.x-lax.schema.json
+++ b/bcf/schemas/bcf-1.x-lax.schema.json
@@ -45,6 +45,14 @@
           "type": "integer",
           "minimum": 1
         },
+        "startTick": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "endTick": {
+          "type": "integer",
+          "minimum": 0
+        },
         "rowOrder": {
           "type": "array",
           "items": {
@@ -161,7 +169,7 @@
       "properties": {
         "tick": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "cells": {
           "type": "array",
@@ -443,7 +451,7 @@
       "properties": {
         "tick": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "name": {
           "type": "string",
@@ -464,7 +472,7 @@
       "properties": {
         "tick": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "length": {
           "type": "integer",
@@ -516,7 +524,7 @@
       "properties": {
         "tick": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "iconUrl": {
           "type": "string"

--- a/bcf/src/__tests__/validator.test.ts
+++ b/bcf/src/__tests__/validator.test.ts
@@ -307,6 +307,65 @@ describe('BCF Validator', () => {
         }
       });
 
+      it('should accept a valid display range', () => {
+        const doc = {
+          ...minimalValidBCF,
+          config: { totalTicks: 10, startTick: 2, endTick: 8 },
+        };
+        const result = validate(doc);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should allow endTick without startTick', () => {
+        const doc = {
+          ...minimalValidBCF,
+          config: { totalTicks: 10, endTick: 8 },
+        };
+        const result = validate(doc);
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject startTick greater than endTick', () => {
+        const doc = {
+          ...minimalValidBCF,
+          config: { totalTicks: 10, startTick: 8, endTick: 3 },
+        };
+        const result = validate(doc);
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.errors[0].path).toBe('/config/startTick');
+          expect(result.errors[0].message).toContain(
+            'less than or equal to endTick',
+          );
+        }
+      });
+
+      it('should reject startTick out of bounds', () => {
+        const doc = {
+          ...minimalValidBCF,
+          config: { totalTicks: 10, startTick: 10 },
+        };
+        const result = validate(doc);
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.errors[0].path).toBe('/config/startTick');
+          expect(result.errors[0].message).toContain('out of bounds');
+        }
+      });
+
+      it('should reject endTick out of bounds', () => {
+        const doc = {
+          ...minimalValidBCF,
+          config: { totalTicks: 10, endTick: 10 },
+        };
+        const result = validate(doc);
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.errors[0].path).toBe('/config/endTick');
+          expect(result.errors[0].message).toContain('out of bounds');
+        }
+      });
+
       it('should reject duplicate tick numbers', () => {
         const doc = {
           ...minimalValidBCF,

--- a/bcf/src/types.ts
+++ b/bcf/src/types.ts
@@ -30,6 +30,10 @@ export interface BlertChartFormat<
 export interface BCFConfig {
   /** Total number of ticks in the timeline. */
   totalTicks: number;
+  /** First display tick in the timeline. */
+  startTick?: number;
+  /** Last display tick in the timeline (inclusive). */
+  endTick?: number;
   /** Ordered list of actor/custom row IDs defining display order. */
   rowOrder?: string[];
   /** Pinned canonical definition sources. */
@@ -111,11 +115,10 @@ export interface BCFCell<ActionType extends { type: string } = BCFAction> {
 /**
  * An action performed by an actor on a tick.
  */
-export type BCFAction =
-  | BCFAttackAction
-  | BCFSpellAction
-  | BCFDeathAction
-  | BCFNpcAttackAction;
+export type BCFAction = BCFPlayerAction | BCFNpcAction;
+
+export type BCFPlayerAction = BCFAttackAction | BCFSpellAction | BCFDeathAction;
+export type BCFNpcAction = BCFNpcAttackAction;
 
 export type BCFLaxAction = BCFAction | BCFUnknownAction;
 


### PR DESCRIPTION
 Updates the BCF spec to define its overall timeline as starting from
 tick 0 up to `totalTicks - 1`. Introduces new config options to
 designate a subset of this range as the "display range" that should
 be rendered.