### PR TITLE
Add BCF validation endpoint

### DIFF
--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -60,8 +60,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build common (dependency)
-        run: npm run -w common build
+      - name: Build local dependencies
+        run: |
+          npm run -w bcf build
+          npm run -w common build
 
       - name: Run database migrations
         run: npm run -w common migration:run

--- a/bcf/src/validator.ts
+++ b/bcf/src/validator.ts
@@ -751,6 +751,11 @@ export function parseAndValidate(
 export function parseAndValidate(
   json: string,
   options?: ValidateOptions,
+): ValidationResultLax | ValidationResultStrict;
+
+export function parseAndValidate(
+  json: string,
+  options?: ValidateOptions,
 ): ValidationResultStrict | ValidationResultLax {
   let data: unknown;
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23531,6 +23531,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.587.0",
+        "@blert/bcf": "file:../bcf",
         "@blert/common": "file:../common",
         "@next/third-parties": "^16.0.7",
         "@react-three/drei": "^10.4.2",

--- a/web/app/api/v1/bcf/validate/route.ts
+++ b/web/app/api/v1/bcf/validate/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server';
+
+import {
+  BCFVersion,
+  parseAndValidate,
+  SUPPORTED_VERSIONS,
+  ValidationError,
+} from '@blert/bcf';
+
+const MAX_BODY_SIZE = 5 * 1024 * 1024;
+
+type ValidateResponse =
+  | { valid: true; version: string }
+  | { valid: false; errors: ValidationError[] };
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
+    return Response.json({ error: 'payload_too_large' }, { status: 413 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+
+  const versionParam = searchParams.get('version');
+  let version: BCFVersion | undefined;
+  if (versionParam !== null) {
+    if (!SUPPORTED_VERSIONS.includes(versionParam as BCFVersion)) {
+      return Response.json(
+        {
+          error: 'invalid_version',
+          supportedVersions: SUPPORTED_VERSIONS,
+        },
+        { status: 400 },
+      );
+    }
+    version = versionParam as BCFVersion;
+  }
+
+  const strictParam = searchParams.get('strict');
+  let strict: boolean | undefined;
+  if (strictParam !== null) {
+    if (strictParam !== 'true' && strictParam !== 'false') {
+      return Response.json({ error: 'invalid_strict_param' }, { status: 400 });
+    }
+    strict = strictParam === 'true';
+  }
+
+  let body: string;
+  try {
+    body = await request.text();
+  } catch {
+    return Response.json({ error: 'invalid_body' }, { status: 400 });
+  }
+
+  const result = parseAndValidate(body, { version, strict });
+
+  let response: ValidateResponse;
+  if (result.valid) {
+    response = { valid: true, version: result.version };
+  } else {
+    response = { valid: false, errors: result.errors };
+  }
+
+  return Response.json(response);
+}

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.587.0",
+    "@blert/bcf": "file:../bcf",
     "@blert/common": "file:../common",
     "@next/third-parties": "^16.0.7",
     "@react-three/drei": "^10.4.2",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -12,6 +12,14 @@ type RouteMatcher = {
 
 const RATE_LIMITS: RouteMatcher[] = [
   {
+    test: (path) => path.startsWith('/api/v1/bcf'),
+    config: {
+      limit: 15,
+      windowSec: 60,
+      keyPrefix: 'ratelimit:v1:bcf',
+    },
+  },
+  {
     test: (path) => path.startsWith('/api/admin/verify-link'),
     config: {
       limit: 5,


### PR DESCRIPTION
Creates a POST /api/v1/bcf/validate which validates a document, returning the validation result from the bcf library.