### PR TITLE
Configurable limit for active API key permissions

### DIFF
--- a/web/app/api/admin/grant-api-access/route.ts
+++ b/web/app/api/admin/grant-api-access/route.ts
@@ -37,7 +37,14 @@ export async function POST(request: NextRequest) {
     const result = await grantApiAccess(discordId);
 
     if (!result.success) {
-      return Response.json({ error: result.error }, { status: 404 });
+      switch (result.error) {
+        case 'user_not_found':
+          return Response.json({ error: result.error }, { status: 404 });
+        case 'limit_reached':
+          return Response.json({ error: result.error }, { status: 403 });
+        case 'unavailable':
+          return Response.json({ error: result.error }, { status: 503 });
+      }
     }
 
     return Response.json(result);


### PR DESCRIPTION
Adds a Redis-backed limit for the total number of users who have API key permissions at a time, with fallback to env var if Redis is unreachable. Updates the admin API to grant access to signal if the limit is reached.