### PR TITLE
Don't flag teleport at the start of Sol fight

### DIFF
--- a/challenge-server/log.ts
+++ b/challenge-server/log.ts
@@ -43,7 +43,9 @@ const logger = winston.createLogger({
         })
       : winston.format.json(),
   ),
-  transports: [new winston.transports.Console()],
+  transports: [
+    new winston.transports.Console({ silent: process.env.NODE_ENV === 'test' }),
+  ],
 });
 
 export default logger;

--- a/challenge-server/merging/__tests__/client-events.test.ts
+++ b/challenge-server/merging/__tests__/client-events.test.ts
@@ -1026,6 +1026,197 @@ describe('ClientEvents', () => {
           });
         });
 
+        describe('Colosseum Sol Heredit start teleport', () => {
+          const colosseumChallengeInfo: ChallengeInfo = {
+            uuid: '11111111-2222-3333-4444-555555555555',
+            type: ChallengeType.COLOSSEUM,
+            party: ['player1'],
+          };
+
+          it('allows teleport to boss start tile during initial cutscene', () => {
+            const client = ClientEvents.fromRawEvents(
+              40,
+              colosseumChallengeInfo,
+              {
+                stage: Stage.COLOSSEUM_WAVE_12,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 1800,
+                  y: 3100,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 1825,
+                  y: 3103,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(false);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              false,
+            );
+            expect(client.isAccurate()).toBe(true);
+          });
+
+          it('allows teleport to boss start tile at tick 4', () => {
+            const client = ClientEvents.fromRawEvents(
+              41,
+              colosseumChallengeInfo,
+              {
+                stage: Stage.COLOSSEUM_WAVE_12,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 5,
+                serverTicks: { count: 5, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 3,
+                  name: 'player1',
+                  x: 1800,
+                  y: 3100,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 4,
+                  name: 'player1',
+                  x: 1825,
+                  y: 3103,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(false);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              false,
+            );
+            expect(client.isAccurate()).toBe(true);
+          });
+
+          it('flags teleport to boss start tile at tick 5 or later', () => {
+            const client = ClientEvents.fromRawEvents(
+              42,
+              colosseumChallengeInfo,
+              {
+                stage: Stage.COLOSSEUM_WAVE_12,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 6,
+                serverTicks: { count: 6, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 4,
+                  name: 'player1',
+                  x: 1800,
+                  y: 3100,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 5,
+                  name: 'player1',
+                  x: 1825,
+                  y: 3103,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+
+          it('flags teleport to different tile even during cutscene', () => {
+            const client = ClientEvents.fromRawEvents(
+              43,
+              colosseumChallengeInfo,
+              {
+                stage: Stage.COLOSSEUM_WAVE_12,
+                status: StageStatus.STARTED,
+                accurate: true,
+                recordedTicks: 2,
+                serverTicks: { count: 2, precise: true },
+              },
+              [
+                createPlayerUpdateEvent({
+                  tick: 0,
+                  name: 'player1',
+                  x: 1800,
+                  y: 3100,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+                createPlayerUpdateEvent({
+                  tick: 1,
+                  name: 'player1',
+                  x: 1830,
+                  y: 3110,
+                  stage: Stage.COLOSSEUM_WAVE_12,
+                }),
+              ],
+            );
+
+            expect(client.hasConsistencyIssues()).toBe(true);
+            expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+              true,
+            );
+          });
+
+          it('flags large movement in non-boss Colosseum waves', () => {
+            for (
+              let stage = Stage.COLOSSEUM_WAVE_1;
+              stage <= Stage.COLOSSEUM_WAVE_11;
+              stage++
+            ) {
+              const client = ClientEvents.fromRawEvents(
+                44,
+                colosseumChallengeInfo,
+                {
+                  stage,
+                  status: StageStatus.STARTED,
+                  accurate: true,
+                  recordedTicks: 2,
+                  serverTicks: { count: 2, precise: true },
+                },
+                [
+                  createPlayerUpdateEvent({
+                    tick: 0,
+                    name: 'player1',
+                    x: 1800,
+                    y: 3100,
+                    stage,
+                  }),
+                  createPlayerUpdateEvent({
+                    tick: 1,
+                    name: 'player1',
+                    x: 1825,
+                    y: 3103,
+                    stage,
+                  }),
+                ],
+              );
+
+              expect(client.hasConsistencyIssues()).toBe(true);
+              expect(client.hasAnomaly(ClientAnomaly.CONSISTENCY_ISSUES)).toBe(
+                true,
+              );
+            }
+          });
+        });
+
         describe('Verzik P3 webs push', () => {
           it('allows push out when player was inside Verzik', () => {
             const client = ClientEvents.fromRawEvents(

--- a/challenge-server/merging/client-events.ts
+++ b/challenge-server/merging/client-events.ts
@@ -93,6 +93,9 @@ const VERZIK_P2_CENTER_TILE = { x: 3168, y: 4314 };
 const VERZIK_P3_WEBS_AREA = { x: 3165, y: 4309, width: 7, height: 7 };
 const VERZIK_P3_WEBS_CENTER_TILE = { x: 3168, y: 4312 };
 
+// Tile to which players are teleported at the start of Colosseum's boss fight.
+const COLOSSEUM_BOSS_START_TILE = { x: 1825, y: 3103 };
+
 function isValidP2BounceDestination(coords: CoordsLike): boolean {
   const distance = chebyshev(coords, VERZIK_P2_CENTER_TILE);
   return distance === 5 || distance === 6;
@@ -673,7 +676,14 @@ export class ClientEvents {
     if (isMokhaiotlStage(this.stageInfo.stage)) {
       return false;
     }
+
     if (isColosseumStage(this.stageInfo.stage)) {
+      if (this.stageInfo.stage === Stage.COLOSSEUM_WAVE_12) {
+        // During the cutscene at the start of the boss, players remain on their
+        // original tile, and then are teleported to the fight start tile when
+        // the cutscene ends.
+        return tick < 5 && coordsEqual(current, COLOSSEUM_BOSS_START_TILE);
+      }
       return false;
     }
 


### PR DESCRIPTION
During the initial Sol Heredit cutscene players are teleported from their previous tile to a specific boss fight start tile. Allow this teleport.