### PR TITLE
Add current username to leaderboards API response

### DIFF
--- a/web/app/home-cards.tsx
+++ b/web/app/home-cards.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactTimeago, { Unit } from 'react-timeago';
 
 import { ActivityFeedItem, ChallengeEndFeedItem } from './actions/activity';
-import { RankedSplit } from './actions/challenge';
+import { PlayerWithCurrentUsername, RankedSplit } from './actions/challenge';
 import { SetupListItem } from './actions/setup';
 import ActivityChart from './components/activity-chart';
 import Card, { CardLink } from './components/card';
@@ -695,7 +695,7 @@ export function GuidesCard() {
 type LeaderboardEntry = {
   rank: number;
   time: number;
-  party: string[];
+  party: PlayerWithCurrentUsername[];
   uuid: string;
   date: Date;
 };
@@ -746,7 +746,9 @@ function Leaderboard({ leaderboard }: { leaderboard: ScaleLeaderboard }) {
                 </div>
               </div>
               <div className={styles.partyInfo}>
-                <div className={styles.party}>{entry.party.join(', ')}</div>
+                <div className={styles.party}>
+                  {entry.party.map((p) => p.username).join(', ')}
+                </div>
               </div>
             </Link>
           ))

--- a/web/app/leaderboards/[challenge]/[[...options]]/page.tsx
+++ b/web/app/leaderboards/[challenge]/[[...options]]/page.tsx
@@ -10,7 +10,11 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { notFound, redirect } from 'next/navigation';
 
-import { findBestSplitTimes, findChallenges } from '@/actions/challenge';
+import {
+  findBestSplitTimes,
+  findChallenges,
+  PlayerWithCurrentUsername,
+} from '@/actions/challenge';
 import Card from '@/components/card';
 import { challengeLogo } from '@/logo';
 import { scaleNameAndColor } from '@/utils/challenge';
@@ -33,7 +37,7 @@ function modeName(mode: ChallengeMode) {
 type Rank = {
   uuid: string;
   date: Date;
-  party: string[];
+  party: PlayerWithCurrentUsername[];
   value: number | string;
 };
 
@@ -82,7 +86,9 @@ function Leaderboard({ challengeType, ranks, title }: LeaderboardProps) {
                   })}
                 </span>
               </div>
-              <div className={styles.party}>{rank.party.join(', ')}</div>
+              <div className={styles.party}>
+                {rank.party.map((p) => p.username).join(', ')}
+              </div>
             </div>
           </Link>
         ))}
@@ -251,7 +257,10 @@ export default async function LeaderboardsPage(props: LeaderboardsPageProps) {
         ranks: topDelves.map((challenge) => ({
           uuid: challenge.uuid,
           date: challenge.startTime,
-          party: challenge.party.map((player) => player.username),
+          party: challenge.party.map((player) => ({
+            username: player.username,
+            currentUsername: player.currentUsername,
+          })),
           value: challenge.mokhaiotlStats?.maxCompletedDelve
             ? `Delve ${challenge.mokhaiotlStats.maxCompletedDelve}`
             : 'N/A',


### PR DESCRIPTION
Updates the leaderboards API and endpoint to return both the player's original and current usernames.