### PR TITLE
Create personalized feed for users

### DIFF
--- a/common/migrations/20260121161114-create-user-follows-table.ts
+++ b/common/migrations/20260121161114-create-user-follows-table.ts
@@ -1,0 +1,21 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE TABLE user_follows (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      player_id INTEGER NOT NULL REFERENCES players(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE(user_id, player_id)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX idx_user_follows_player_id ON user_follows(player_id)
+  `;
+
+  await sql`
+    CREATE INDEX idx_user_follows_user_id_created_at_id ON user_follows(user_id, created_at DESC)
+  `;
+}

--- a/web/__tests__/api/feed/route.test.ts
+++ b/web/__tests__/api/feed/route.test.ts
@@ -1,0 +1,146 @@
+import { NextRequest } from 'next/server';
+
+import { AuthenticationError } from '@/actions/errors';
+import type { FeedResult } from '@/actions/feed';
+
+jest.mock('@/actions/feed', () => ({
+  loadFeed: jest.fn(),
+}));
+
+import { loadFeed } from '@/actions/feed';
+import { GET } from '@/api/feed/route';
+
+const mockLoadFeed = loadFeed as jest.MockedFunction<typeof loadFeed>;
+
+describe('GET /api/feed', () => {
+  beforeEach(() => {
+    mockLoadFeed.mockClear();
+  });
+
+  const createRequest = (params: Record<string, string> = {}) => {
+    const url = new URL('http://localhost:3000/api/feed');
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    return new NextRequest(url);
+  };
+
+  it('should return feed items on success', async () => {
+    const mockResult = {
+      items: [{ type: 'session', id: 1, timestamp: new Date().toISOString() }],
+      olderCursor: 'cursor123',
+      newerCursor: null,
+    } as unknown as FeedResult;
+    mockLoadFeed.mockResolvedValue(mockResult);
+
+    const request = createRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(mockResult);
+    expect(mockLoadFeed).toHaveBeenCalledWith({
+      cursor: undefined,
+      direction: 'older',
+      limit: 20,
+    });
+  });
+
+  it('should pass query parameters to loadFeed', async () => {
+    mockLoadFeed.mockResolvedValue({
+      items: [],
+      olderCursor: null,
+      newerCursor: null,
+    });
+
+    const request = createRequest({
+      cursor: 'abc123',
+      direction: 'newer',
+      limit: '30',
+    });
+    await GET(request);
+
+    expect(mockLoadFeed).toHaveBeenCalledWith({
+      cursor: 'abc123',
+      direction: 'newer',
+      limit: 30,
+    });
+  });
+
+  it('should default to older direction for invalid direction', async () => {
+    mockLoadFeed.mockResolvedValue({
+      items: [],
+      olderCursor: null,
+      newerCursor: null,
+    });
+
+    const request = createRequest({ direction: 'invalid' });
+    await GET(request);
+
+    expect(mockLoadFeed).toHaveBeenCalledWith({
+      cursor: undefined,
+      direction: 'older',
+      limit: 20,
+    });
+  });
+
+  it('should clamp limit to minimum of 1', async () => {
+    mockLoadFeed.mockResolvedValue({
+      items: [],
+      olderCursor: null,
+      newerCursor: null,
+    });
+
+    const request = createRequest({ limit: '0' });
+    await GET(request);
+
+    expect(mockLoadFeed).toHaveBeenCalledWith({
+      cursor: undefined,
+      direction: 'older',
+      limit: 1,
+    });
+  });
+
+  it('should clamp limit to maximum of 50', async () => {
+    mockLoadFeed.mockResolvedValue({
+      items: [],
+      olderCursor: null,
+      newerCursor: null,
+    });
+
+    const request = createRequest({ limit: '100' });
+    await GET(request);
+
+    expect(mockLoadFeed).toHaveBeenCalledWith({
+      cursor: undefined,
+      direction: 'older',
+      limit: 50,
+    });
+  });
+
+  it('should return 401 when user is not authenticated', async () => {
+    mockLoadFeed.mockRejectedValue(new AuthenticationError());
+
+    const request = createRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toBeNull();
+  });
+
+  it('should return 500 for unexpected errors', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockLoadFeed.mockRejectedValue(new Error('Database error'));
+
+    const request = createRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+    expect(response.body).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch personalized feed:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/web/__tests__/api/following/playerId.test.ts
+++ b/web/__tests__/api/following/playerId.test.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from 'next/server';
+
+import { AuthenticationError } from '@/actions/errors';
+
+jest.mock('@/actions/feed', () => ({
+  unfollowPlayer: jest.fn(),
+}));
+
+import { unfollowPlayer } from '@/actions/feed';
+import { DELETE } from '@/api/following/[playerId]/route';
+
+const mockUnfollowPlayer = unfollowPlayer as jest.MockedFunction<
+  typeof unfollowPlayer
+>;
+
+describe('DELETE /api/following/[playerId]', () => {
+  beforeEach(() => {
+    mockUnfollowPlayer.mockClear();
+  });
+
+  const createRequest = () => {
+    return new NextRequest('http://localhost:3000/api/following/123', {
+      method: 'DELETE',
+    });
+  };
+
+  const createParams = (playerId: string) => ({
+    params: Promise.resolve({ playerId }),
+  });
+
+  it('should unfollow player and return 204', async () => {
+    mockUnfollowPlayer.mockResolvedValue(undefined);
+
+    const request = createRequest();
+    const response = await DELETE(request, createParams('123'));
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+    expect(mockUnfollowPlayer).toHaveBeenCalledWith(123);
+  });
+
+  it('should return 400 for invalid player ID', async () => {
+    const request = createRequest();
+    const response = await DELETE(request, createParams('invalid'));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid player ID' });
+    expect(mockUnfollowPlayer).not.toHaveBeenCalled();
+  });
+
+  it('should return 400 for non-numeric player ID', async () => {
+    const request = createRequest();
+    const response = await DELETE(request, createParams('abc'));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid player ID' });
+  });
+
+  it('should return 400 for empty player ID', async () => {
+    const request = createRequest();
+    const response = await DELETE(request, createParams(''));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid player ID' });
+  });
+
+  it('should return 401 when user is not authenticated', async () => {
+    mockUnfollowPlayer.mockRejectedValue(new AuthenticationError());
+
+    const request = createRequest();
+    const response = await DELETE(request, createParams('123'));
+
+    expect(response.status).toBe(401);
+    expect(response.body).toBeNull();
+  });
+
+  it('should return 500 for unexpected errors', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockUnfollowPlayer.mockRejectedValue(new Error('Database error'));
+
+    const request = createRequest();
+    const response = await DELETE(request, createParams('123'));
+
+    expect(response.status).toBe(500);
+    expect(response.body).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to unfollow player:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/web/__tests__/api/following/route.test.ts
+++ b/web/__tests__/api/following/route.test.ts
@@ -1,0 +1,219 @@
+import { NextRequest } from 'next/server';
+
+import { AuthenticationError } from '@/actions/errors';
+import type { FollowedPlayer, FollowingResult } from '@/actions/feed';
+
+jest.mock('@/actions/feed', () => ({
+  followPlayer: jest.fn(),
+  getFollowing: jest.fn(),
+}));
+
+import { followPlayer, getFollowing } from '@/actions/feed';
+import { GET, POST } from '@/api/following/route';
+
+const mockFollowPlayer = followPlayer as jest.MockedFunction<
+  typeof followPlayer
+>;
+const mockGetFollowing = getFollowing as jest.MockedFunction<
+  typeof getFollowing
+>;
+
+describe('GET /api/following', () => {
+  beforeEach(() => {
+    mockGetFollowing.mockClear();
+  });
+
+  const createRequest = (params: Record<string, string> = {}) => {
+    const url = new URL('http://localhost:3000/api/following');
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    return new NextRequest(url);
+  };
+
+  it('should return following list on success', async () => {
+    const mockResult = {
+      players: [{ id: 1, username: 'Player1' }],
+      cursor: 'next-cursor',
+      totalCount: 5,
+    } as unknown as FollowingResult;
+    mockGetFollowing.mockResolvedValue(mockResult);
+
+    const request = createRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(mockResult);
+    expect(mockGetFollowing).toHaveBeenCalledWith({
+      cursor: undefined,
+      limit: undefined,
+    });
+  });
+
+  it('should pass query parameters to getFollowing', async () => {
+    mockGetFollowing.mockResolvedValue({
+      players: [],
+      cursor: null,
+      totalCount: 0,
+    });
+
+    const request = createRequest({ cursor: 'abc123', limit: '25' });
+    await GET(request);
+
+    expect(mockGetFollowing).toHaveBeenCalledWith({
+      cursor: 'abc123',
+      limit: 25,
+    });
+  });
+
+  it('should return 400 for invalid query parameters', async () => {
+    const request = createRequest({ limit: 'invalid' });
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('limit');
+  });
+
+  it('should return 401 when user is not authenticated', async () => {
+    mockGetFollowing.mockRejectedValue(new AuthenticationError());
+
+    const request = createRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toBeNull();
+  });
+
+  it('should return 500 for unexpected errors', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    mockGetFollowing.mockRejectedValue(new Error('Database error'));
+
+    const request = createRequest();
+    const response = await GET(request);
+
+    expect(response.status).toBe(500);
+    expect(response.body).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch following list:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('POST /api/following', () => {
+  beforeEach(() => {
+    mockFollowPlayer.mockClear();
+  });
+
+  const createRequest = (body: unknown) => {
+    return new NextRequest('http://localhost:3000/api/following', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  };
+
+  it('should follow players and return results', async () => {
+    const mockPlayer = {
+      id: 1,
+      username: 'Player1',
+    } as unknown as FollowedPlayer;
+    mockFollowPlayer.mockResolvedValue(mockPlayer);
+
+    const request = createRequest({ usernames: ['Player1', 'Player2'] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual([mockPlayer, mockPlayer]);
+    expect(mockFollowPlayer).toHaveBeenCalledTimes(2);
+    expect(mockFollowPlayer).toHaveBeenCalledWith('Player1');
+    expect(mockFollowPlayer).toHaveBeenCalledWith('Player2');
+  });
+
+  it('should return 400 when usernames is not an array', async () => {
+    const request = createRequest({ usernames: 'Player1' });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Usernames array is required',
+    });
+  });
+
+  it('should return 400 when usernames array is empty', async () => {
+    const request = createRequest({ usernames: [] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Usernames array is required',
+    });
+  });
+
+  it('should return 400 when usernames is missing', async () => {
+    const request = createRequest({});
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Usernames array is required',
+    });
+  });
+
+  it('should return 400 when more than 50 usernames', async () => {
+    const usernames = Array.from({ length: 51 }, (_, i) => `Player${i}`);
+    const request = createRequest({ usernames });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Maximum 50 usernames per request',
+    });
+  });
+
+  it('should return 400 when username is not a string', async () => {
+    const request = createRequest({ usernames: [123] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid username' });
+  });
+
+  it('should return 400 when username is empty', async () => {
+    const request = createRequest({ usernames: [''] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid username' });
+  });
+
+  it('should return 400 when username is longer than 12 characters', async () => {
+    const request = createRequest({ usernames: ['ThisNameIsTooLong'] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid username' });
+  });
+
+  it('should return 401 when user is not authenticated', async () => {
+    mockFollowPlayer.mockRejectedValue(new AuthenticationError());
+
+    const request = createRequest({ usernames: ['Player1'] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    expect(response.body).toBeNull();
+  });
+
+  it('should return 500 for unexpected errors', async () => {
+    mockFollowPlayer.mockRejectedValue(new Error('Database error'));
+
+    const request = createRequest({ usernames: ['Player1'] });
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+    expect(response.body).toBeNull();
+  });
+});

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -303,6 +303,8 @@ export type ChallengeQuery = {
   status?: Comparator<ChallengeStatus>;
   scale?: Comparator<number>;
   party?: string[];
+  /** Whether all players must be present ('all') or any player ('any'). Default: 'all' */
+  partyMatch?: 'all' | 'any';
   splits?: Map<SplitType, Comparator<number>>;
   sort?: SingleOrArray<SortQuery<SortableFields>>;
   startTime?: Comparator<Date>;
@@ -557,15 +559,26 @@ function applyFilters(
       );
       conditions.push(sql`lower(players.username) = ${username.toLowerCase()}`);
     } else {
-      baseTable = sql`(
-        SELECT challenges.*
-        FROM challenges
-        JOIN challenge_players ON challenges.id = challenge_players.challenge_id
-        JOIN players ON challenge_players.player_id = players.id
-        WHERE lower(players.username) = ANY(${query.party.map((u) => u.toLowerCase())})
-        GROUP BY challenges.id
-        HAVING COUNT(*) = ${query.party.length}
-      ) challenges`;
+      const matchAll = query.partyMatch !== 'any';
+      if (matchAll) {
+        baseTable = sql`(
+          SELECT challenges.*
+          FROM challenges
+          JOIN challenge_players ON challenges.id = challenge_players.challenge_id
+          JOIN players ON challenge_players.player_id = players.id
+          WHERE lower(players.username) = ANY(${query.party.map((u) => u.toLowerCase())})
+          GROUP BY challenges.id
+          HAVING COUNT(*) = ${query.party.length}
+        ) challenges`;
+      } else {
+        baseTable = sql`(
+          SELECT DISTINCT challenges.*
+          FROM challenges
+          JOIN challenge_players ON challenges.id = challenge_players.challenge_id
+          JOIN players ON challenge_players.player_id = players.id
+          WHERE lower(players.username) = ANY(${query.party.map((u) => u.toLowerCase())})
+        ) challenges`;
+      }
     }
   }
 
@@ -2225,6 +2238,7 @@ export async function loadEventsForStage(
 }
 
 export type PlayerWithStats = Pick<Player, 'username' | 'totalRecordings'> & {
+  id: number;
   stats: Omit<PlayerStats, 'playerId' | 'date'>;
   firstRecorded: Date;
 };
@@ -2245,11 +2259,13 @@ export async function loadPlayerWithStats(
 ): Promise<PlayerWithStats | null> {
   const [playerWithStats] = await sql<
     ({
+      player_id: number;
       username: string;
       total_recordings: number;
     } & PlayerStatsRow)[]
   >`
     SELECT
+      players.id as player_id,
       players.username,
       players.total_recordings,
       player_stats.*
@@ -2274,6 +2290,7 @@ export async function loadPlayerWithStats(
   const firstRecorded = firstStats?.date ?? new Date();
 
   return {
+    id: playerWithStats.player_id,
     username: playerWithStats.username,
     totalRecordings: playerWithStats.total_recordings,
     firstRecorded,

--- a/web/app/actions/errors.ts
+++ b/web/app/actions/errors.ts
@@ -4,3 +4,10 @@ export class InvalidQueryError extends Error {
     this.name = 'InvalidQueryError';
   }
 }
+
+export class AuthenticationError extends Error {
+  constructor(message: string = 'Not authenticated') {
+    super(message);
+    this.name = 'AuthenticationError';
+  }
+}

--- a/web/app/actions/feed.ts
+++ b/web/app/actions/feed.ts
@@ -1,0 +1,885 @@
+'use server';
+
+import {
+  ChallengeMode,
+  ChallengeType,
+  NameChangeStatus,
+  RELEVANT_PB_SPLITS,
+  SessionStatus,
+  SplitType,
+  splitName,
+} from '@blert/common';
+import type { SessionRow } from '@blert/common/dist/db/challenge';
+import postgres from 'postgres';
+
+import { clamp } from '@/utils/math';
+
+import { sql } from './db';
+import { AuthenticationError } from './errors';
+import {
+  ChallengeOverview,
+  SessionWithChallenges,
+  findChallenges,
+} from './challenge';
+import { getConnectedPlayers, getSignedInUserId } from './users';
+
+export type SessionFeedItem = {
+  type: 'session';
+  id: number;
+  timestamp: Date;
+  session: SessionWithChallenges;
+  followedPlayers: string[];
+  partyCurrentNames: string[];
+};
+
+export type PersonalBestFeedItem = {
+  type: 'personal_best';
+  id: number;
+  timestamp: Date;
+  player: string;
+  splitType: SplitType;
+  splitName: string;
+  scale: number;
+  ticks: number;
+  previousTicks: number | null;
+  challengeUuid: string;
+  challengeType: ChallengeType;
+  challengeMode: ChallengeMode;
+};
+
+export type NameChangeFeedItem = {
+  type: 'name_change';
+  id: number;
+  timestamp: Date;
+  playerId: number;
+  oldName: string;
+  newName: string;
+  currentName: string;
+};
+
+export type FeedItem =
+  | SessionFeedItem
+  | PersonalBestFeedItem
+  | NameChangeFeedItem;
+
+const FEED_ITEM_TYPE_PRIORITY: Record<FeedItem['type'], number> = {
+  session: 0,
+  personal_best: 1,
+  name_change: 2,
+};
+
+export type FollowedPlayer = {
+  id: number;
+  username: string;
+  followedAt: Date;
+};
+
+async function ensureAuthenticated(): Promise<number> {
+  const userId = await getSignedInUserId();
+  if (userId === null) {
+    throw new AuthenticationError();
+  }
+  return userId;
+}
+
+/**
+ * Follow a player by their username.
+ * Creates a new follow relationship if one doesn't exist.
+ * @param username The username of the player to follow.
+ * @returns The followed player, or null if the player doesn't exist.
+ */
+export async function followPlayer(
+  username: string,
+): Promise<FollowedPlayer | null> {
+  const userId = await ensureAuthenticated();
+
+  const [player] = await sql<{ id: number; username: string }[]>`
+    SELECT id, username
+    FROM players
+    WHERE lower(username) = ${username.toLowerCase()}
+  `;
+
+  if (!player) {
+    return null;
+  }
+
+  const [follow] = await sql<{ created_at: Date }[]>`
+    INSERT INTO user_follows (user_id, player_id)
+    VALUES (${userId}, ${player.id})
+    ON CONFLICT (user_id, player_id) DO UPDATE SET created_at = NOW()
+    RETURNING created_at
+  `;
+
+  return {
+    id: player.id,
+    username: player.username,
+    followedAt: follow.created_at,
+  };
+}
+
+/**
+ * Unfollow a player by their player ID.
+ * @param playerId The ID of the player to unfollow.
+ */
+export async function unfollowPlayer(playerId: number): Promise<void> {
+  const userId = await ensureAuthenticated();
+
+  await sql`
+    DELETE FROM user_follows
+    WHERE user_id = ${userId} AND player_id = ${playerId}
+  `;
+}
+
+export type FollowingResult = {
+  players: FollowedPlayer[];
+  totalCount: number;
+  cursor: string | null;
+};
+
+type FollowingCursor = {
+  timestamp: Date;
+  playerId: number;
+};
+
+function encodeFollowingCursor(cursor: FollowingCursor): string {
+  return `${cursor.timestamp.toISOString()}|${cursor.playerId}`;
+}
+
+function decodeFollowingCursor(cursor: string): FollowingCursor | null {
+  const parts = cursor.split('|');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const timestamp = new Date(parts[0]);
+  if (isNaN(timestamp.getTime())) {
+    return null;
+  }
+
+  const playerId = parseInt(parts[1], 10);
+  if (!Number.isInteger(playerId) || playerId <= 0) {
+    return null;
+  }
+
+  return { timestamp, playerId };
+}
+
+/**
+ * Get the list of players the current user is following.
+ * @param options Pagination options.
+ * @returns Paginated list of followed players sorted by most recently followed.
+ */
+export async function getFollowing(options?: {
+  cursor?: string;
+  limit?: number;
+}): Promise<FollowingResult> {
+  const userId = await ensureAuthenticated();
+  const limit = clamp(options?.limit ?? 50, 1, 100);
+
+  const cursor = options?.cursor ? decodeFollowingCursor(options.cursor) : null;
+
+  const cursorCondition =
+    cursor !== null
+      ? sql`AND (uf.created_at, uf.player_id) < (${cursor.timestamp}, ${cursor.playerId})`
+      : sql``;
+
+  const [follows, countResult] = await Promise.all([
+    sql<{ id: number; username: string; created_at: Date }[]>`
+      SELECT p.id, p.username, uf.created_at
+      FROM user_follows uf
+      JOIN players p ON uf.player_id = p.id
+      WHERE uf.user_id = ${userId}
+        ${cursorCondition}
+      ORDER BY uf.created_at DESC, uf.player_id DESC
+      LIMIT ${limit}
+    `,
+    sql<{ count: string }[]>`
+      SELECT COUNT(*) as count
+      FROM user_follows
+      WHERE user_id = ${userId}
+    `,
+  ]);
+
+  const players = follows.map((f) => ({
+    id: f.id,
+    username: f.username,
+    followedAt: f.created_at,
+  }));
+
+  const nextCursor =
+    follows.length > 0
+      ? encodeFollowingCursor({
+          timestamp: follows[follows.length - 1].created_at,
+          playerId: follows[follows.length - 1].id,
+        })
+      : null;
+
+  return {
+    players,
+    totalCount: parseInt(countResult[0].count, 10),
+    cursor: nextCursor,
+  };
+}
+
+/**
+ * Check if the current user is following a specific player.
+ * @param playerId The player ID to check.
+ * @returns True if the user is following the player.
+ */
+export async function isFollowing(playerId: number): Promise<boolean> {
+  const userId = await getSignedInUserId();
+  if (userId === null) {
+    return false;
+  }
+
+  const [follow] = await sql<{ user_id: number }[]>`
+    SELECT user_id
+    FROM user_follows
+    WHERE user_id = ${userId} AND player_id = ${playerId}
+    LIMIT 1
+  `;
+
+  return follow !== undefined;
+}
+
+/**
+ * Check if the current user is following a player by username.
+ * @param username The player username to check.
+ * @returns True if the user is following the player.
+ */
+export async function isFollowingByUsername(
+  username: string,
+): Promise<boolean> {
+  const userId = await getSignedInUserId();
+  if (userId === null) {
+    return false;
+  }
+
+  const [follow] = await sql<{ user_id: number }[]>`
+    SELECT uf.user_id
+    FROM user_follows uf
+    JOIN players p ON uf.player_id = p.id
+    WHERE uf.user_id = ${userId} AND lower(p.username) = ${username.toLowerCase()}
+    LIMIT 1
+  `;
+
+  return follow !== undefined;
+}
+
+type SessionWithPlayers = SessionRow & {
+  player_ids: number[];
+  player_usernames: string[];
+  player_current_usernames: string[];
+  followed_player_usernames: string[];
+};
+
+type PbHistoryRow = {
+  id: number;
+  created_at: Date;
+  username: string;
+  split_type: SplitType;
+  split_scale: number;
+  ticks: number;
+  previous_ticks: number | null;
+  challenge_uuid: string;
+  challenge_type: ChallengeType;
+  challenge_mode: ChallengeMode;
+};
+
+type NameChangeRow = {
+  id: number;
+  player_id: number;
+  old_name: string;
+  new_name: string;
+  current_name: string;
+  processed_at: Date;
+};
+
+type FeedCursor = {
+  timestamp: Date;
+  type: FeedItem['type'];
+  id: number;
+};
+
+export type FeedQuery = {
+  cursor?: string;
+  direction?: 'older' | 'newer';
+  limit?: number;
+};
+
+export type FeedResult = {
+  items: FeedItem[];
+  /** Cursor to fetch older items (for "load more"). */
+  olderCursor: FeedCursorString | null;
+  /** Cursor to fetch newer items (for polling). */
+  newerCursor: FeedCursorString | null;
+};
+
+/**
+ * Opaque string representation of a feed cursor.
+ * Format: "timestamp|type|id"
+ * - timestamp: ISO string
+ * - type: 'session', 'personal_best', 'name_change' (case-insensitive)
+ * - id: numeric ID of the item
+ */
+type FeedCursorString = `${string}|${FeedItem['type']}|${number}`;
+
+/**
+ * Encode a feed cursor as an opaque string.
+ */
+function encodeFeedCursor(cursor: FeedCursor): FeedCursorString {
+  return `${cursor.timestamp.toISOString()}|${cursor.type}|${cursor.id}`;
+}
+
+/**
+ * Decode a feed cursor from an opaque string.
+ */
+function decodeFeedCursor(cursor: string): FeedCursor | null {
+  const parts = cursor.split('|');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const [ts, typeStr, idStr] = parts;
+  const timestamp = new Date(ts);
+  if (isNaN(timestamp.getTime())) {
+    return null;
+  }
+
+  if (
+    typeStr !== 'session' &&
+    typeStr !== 'personal_best' &&
+    typeStr !== 'name_change'
+  ) {
+    return null;
+  }
+
+  const id = parseInt(idStr, 10);
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+
+  return { timestamp, type: typeStr, id };
+}
+
+/**
+ * Build a cursor from a feed response for subsequent pagination.
+ *
+ * For 'older' direction: cursor points to the oldest (last) item, used to load
+ * more historical items.
+ *
+ * For 'newer' direction: cursor points to the newest (first) item, used for
+ * polling for new items.
+ *
+ * @param items The feed items from the response.
+ * @param direction The direction for the next query using this cursor.
+ */
+function buildFeedCursor(
+  items: FeedItem[],
+  direction: 'older' | 'newer',
+): FeedCursorString | null {
+  if (items.length === 0) {
+    return null;
+  }
+  const boundaryItem =
+    direction === 'older' ? items[items.length - 1] : items[0];
+  return encodeFeedCursor(boundaryItem);
+}
+
+function buildCursorCondition(args: {
+  cursor: FeedCursor;
+  direction: 'older' | 'newer';
+  rowTime: postgres.Fragment;
+  rowId: postgres.Fragment;
+  rowType: FeedItem['type'];
+}): postgres.Fragment {
+  const { cursor, direction, rowTime, rowId, rowType } = args;
+
+  const rowPriority = FEED_ITEM_TYPE_PRIORITY[rowType];
+  const cursorPriority = FEED_ITEM_TYPE_PRIORITY[cursor.type];
+
+  if (direction === 'older') {
+    return sql`AND (
+      ${rowTime} < ${cursor.timestamp}
+      OR (
+        ${rowTime} = ${cursor.timestamp}
+        AND (
+          ${rowPriority} > ${cursorPriority}
+          OR (${rowPriority} = ${cursorPriority} AND ${rowId} < ${cursor.id})
+        )
+      )
+    )`;
+  }
+
+  return sql`AND (
+    ${rowTime} > ${cursor.timestamp}
+    OR (
+      ${rowTime} = ${cursor.timestamp}
+      AND (
+        ${rowPriority} < ${cursorPriority}
+        OR (${rowPriority} = ${cursorPriority} AND ${rowId} > ${cursor.id})
+      )
+    )
+  )`;
+}
+
+async function fetchSessionFeedItems(
+  userId: number,
+  cursor: FeedCursor | null,
+  direction: 'older' | 'newer',
+  limit: number,
+): Promise<SessionFeedItem[]> {
+  const cursorCondition =
+    cursor !== null
+      ? buildCursorCondition({
+          cursor,
+          direction,
+          rowTime: sql`COALESCE(cs.end_time, cs.start_time)`,
+          rowId: sql`cs.id`,
+          rowType: 'session',
+        })
+      : sql``;
+
+  const sessions = await sql<SessionWithPlayers[]>`
+    WITH followed_sessions AS (
+      SELECT DISTINCT
+        c.session_id,
+        cs.id as session_row_id,
+        COALESCE(cs.end_time, cs.start_time) as sort_time
+      FROM challenges c
+      JOIN challenge_players cp ON c.id = cp.challenge_id
+      JOIN challenge_sessions cs ON c.session_id = cs.id
+      JOIN user_follows uf
+        ON cp.player_id = uf.player_id AND uf.user_id = ${userId}
+      WHERE cs.status != ${SessionStatus.HIDDEN}
+        ${cursorCondition}
+      ORDER BY sort_time DESC, session_row_id DESC
+      LIMIT ${limit * 2}
+    ),
+    session_players AS (
+      SELECT
+        session_id,
+        array_agg(player_id ORDER BY player_id) as player_ids,
+        array_agg(username ORDER BY player_id) as player_usernames,
+        array_agg(current_username ORDER BY player_id) as player_current_usernames,
+        array_agg(current_username ORDER BY player_id)
+          FILTER (WHERE is_followed) as followed_player_usernames
+      FROM (
+        SELECT DISTINCT
+          c.session_id,
+          cp.player_id,
+          cp.username,
+          p.username as current_username,
+          uf.user_id IS NOT NULL as is_followed
+        FROM challenges c
+        JOIN challenge_players cp ON c.id = cp.challenge_id
+        JOIN players p ON cp.player_id = p.id
+        LEFT JOIN user_follows uf
+          ON cp.player_id = uf.player_id AND uf.user_id = ${userId}
+        WHERE c.session_id IN (SELECT session_id FROM followed_sessions)
+      ) unique_players
+      GROUP BY session_id
+    )
+    SELECT
+      cs.*,
+      sp.player_ids,
+      sp.player_usernames,
+      sp.player_current_usernames,
+      sp.followed_player_usernames
+    FROM challenge_sessions cs
+    JOIN followed_sessions fs ON cs.id = fs.session_id
+    JOIN session_players sp ON cs.id = sp.session_id
+    ORDER BY COALESCE(cs.end_time, cs.start_time) DESC, cs.id DESC
+  `;
+
+  if (sessions.length === 0) {
+    return [];
+  }
+
+  const sessionsByUuid = new Map(
+    sessions.map((s) => [
+      s.uuid,
+      {
+        ...s,
+        challenges: [] as ChallengeOverview[],
+        party: s.player_usernames,
+      },
+    ]),
+  );
+
+  const [challenges] = await findChallenges(null, {
+    session: sessions.map((s) => s.id),
+  });
+
+  for (const c of challenges) {
+    sessionsByUuid.get(c.sessionUuid)?.challenges.push(c);
+  }
+
+  const items: SessionFeedItem[] = [];
+  for (const session of sessions) {
+    const sessionData = sessionsByUuid.get(session.uuid);
+    if (!sessionData || sessionData.challenges.length === 0) {
+      continue;
+    }
+
+    const sessionWithChallenges: SessionWithChallenges = {
+      uuid: session.uuid,
+      challengeType: session.challenge_type,
+      challengeMode: session.challenge_mode,
+      scale: session.scale,
+      startTime: session.start_time,
+      endTime: session.end_time,
+      status: session.status,
+      party: session.player_usernames,
+      challenges: sessionData.challenges.toSorted(
+        (a, b) => b.startTime.getTime() - a.startTime.getTime(),
+      ),
+    };
+
+    items.push({
+      type: 'session',
+      id: session.id,
+      timestamp: session.end_time ?? session.start_time,
+      session: sessionWithChallenges,
+      followedPlayers: session.followed_player_usernames ?? [],
+      partyCurrentNames: session.player_current_usernames,
+    });
+  }
+
+  return items;
+}
+
+async function fetchPbFeedItems(
+  userId: number,
+  cursor: FeedCursor | null,
+  direction: 'older' | 'newer',
+  limit: number,
+): Promise<PersonalBestFeedItem[]> {
+  const cursorCondition =
+    cursor !== null
+      ? buildCursorCondition({
+          cursor,
+          direction,
+          rowTime: sql`pbh.created_at`,
+          rowId: sql`pbh.id`,
+          rowType: 'personal_best',
+        })
+      : sql``;
+
+  const pbs = await sql<PbHistoryRow[]>`
+    SELECT
+      pbh.id,
+      pbh.created_at,
+      p.username,
+      cs.type as split_type,
+      cs.scale as split_scale,
+      cs.ticks,
+      prev.previous_ticks,
+      c.uuid as challenge_uuid,
+      c.type as challenge_type,
+      c.mode as challenge_mode
+    FROM personal_best_history pbh
+    JOIN players p ON pbh.player_id = p.id
+    JOIN challenge_splits cs ON pbh.challenge_split_id = cs.id
+    JOIN challenges c ON cs.challenge_id = c.id
+    JOIN user_follows uf
+      ON pbh.player_id = uf.player_id AND uf.user_id = ${userId}
+    LEFT JOIN LATERAL (
+      SELECT cs2.ticks as previous_ticks
+      FROM personal_best_history pbh2
+      JOIN challenge_splits cs2 ON pbh2.challenge_split_id = cs2.id
+      WHERE pbh2.player_id = pbh.player_id
+        AND cs2.type = cs.type
+        AND cs2.scale = cs.scale
+        AND (pbh2.created_at, pbh2.id) < (pbh.created_at, pbh.id)
+      ORDER BY pbh2.created_at DESC, pbh2.id DESC
+      LIMIT 1
+    ) prev ON true
+    WHERE cs.type = ANY(${RELEVANT_PB_SPLITS})
+      ${cursorCondition}
+    ORDER BY pbh.created_at DESC, pbh.id DESC
+    LIMIT ${limit * 2}
+  `;
+
+  return pbs.map((pb) => ({
+    type: 'personal_best',
+    id: pb.id,
+    timestamp: pb.created_at,
+    player: pb.username,
+    splitType: pb.split_type,
+    splitName: splitName(pb.split_type, true),
+    scale: pb.split_scale,
+    ticks: pb.ticks,
+    previousTicks: pb.previous_ticks,
+    challengeUuid: pb.challenge_uuid,
+    challengeType: pb.challenge_type,
+    challengeMode: pb.challenge_mode,
+  }));
+}
+
+async function fetchNameChangeFeedItems(
+  userId: number,
+  cursor: FeedCursor | null,
+  direction: 'older' | 'newer',
+  limit: number,
+): Promise<NameChangeFeedItem[]> {
+  const cursorCondition =
+    cursor !== null
+      ? buildCursorCondition({
+          cursor,
+          direction,
+          rowTime: sql`nc.processed_at`,
+          rowId: sql`nc.id`,
+          rowType: 'name_change',
+        })
+      : sql``;
+
+  const nameChanges = await sql<NameChangeRow[]>`
+    SELECT
+      nc.id,
+      nc.player_id,
+      nc.old_name,
+      nc.new_name,
+      p.username as current_name,
+      nc.processed_at
+    FROM name_changes nc
+    JOIN players p ON nc.player_id = p.id
+    JOIN user_follows uf
+      ON nc.player_id = uf.player_id AND uf.user_id = ${userId}
+    WHERE nc.status = ${NameChangeStatus.ACCEPTED}
+      AND nc.hidden = FALSE
+      AND nc.processed_at IS NOT NULL
+      ${cursorCondition}
+    ORDER BY nc.processed_at DESC, nc.id DESC
+    LIMIT ${limit * 2}
+  `;
+
+  return nameChanges.map((nc) => ({
+    type: 'name_change',
+    id: nc.id,
+    timestamp: nc.processed_at,
+    playerId: nc.player_id,
+    oldName: nc.old_name,
+    newName: nc.new_name,
+    currentName: nc.current_name,
+  }));
+}
+
+/**
+ * Load the personalized feed for the current user.
+ * Combines sessions and personal bests from followed players into a single
+ * chronological feed.
+ * @param query Pagination options.
+ * @returns Feed items sorted by timestamp (most recent first), with cursor.
+ */
+export async function loadFeed(query: FeedQuery = {}): Promise<FeedResult> {
+  const userId = await ensureAuthenticated();
+  const limit = query.limit ?? 20;
+  const direction = query.direction ?? 'older';
+  const cursor = query.cursor ? decodeFeedCursor(query.cursor) : null;
+
+  const [sessionItems, pbItems, nameChangeItems] = await Promise.all([
+    fetchSessionFeedItems(userId, cursor, direction, limit),
+    fetchPbFeedItems(userId, cursor, direction, limit),
+    fetchNameChangeFeedItems(userId, cursor, direction, limit),
+  ]);
+
+  // Merge and sort by (timestamp DESC, type priority, id DESC).
+  const allItems: FeedItem[] = [
+    ...sessionItems,
+    ...pbItems,
+    ...nameChangeItems,
+  ];
+  allItems.sort((a, b) => {
+    const timeDiff = b.timestamp.getTime() - a.timestamp.getTime();
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+    const typeDiff =
+      FEED_ITEM_TYPE_PRIORITY[a.type] - FEED_ITEM_TYPE_PRIORITY[b.type];
+    if (typeDiff !== 0) {
+      return typeDiff;
+    }
+    return b.id - a.id;
+  });
+
+  const items = allItems.slice(0, limit);
+  const olderCursor = buildFeedCursor(items, 'older');
+  const newerCursor = buildFeedCursor(items, 'newer');
+  return { items, olderCursor, newerCursor };
+}
+
+export type SuggestedPlayer = {
+  id: number;
+  username: string;
+  totalChallenges: number;
+};
+
+const MIN_RECORDINGS_FOR_SUGGESTION = 3;
+const MAX_SUGGESTED_PLAYERS = 50;
+
+export type SuggestionsQuery = {
+  limit?: number;
+  exclude?: number[];
+};
+
+/**
+ * Get suggested players to follow for the current user.
+ *
+ * Suggestions are fetched fresh each time (no caching) to ensure accuracy.
+ * The FollowManager component handles client-side buffering for smooth UX.
+ *
+ * @param query Query options including limit and player IDs to exclude.
+ * @returns Suggested players.
+ */
+export async function getSuggestedPlayers(
+  query: SuggestionsQuery = {},
+): Promise<SuggestedPlayer[]> {
+  const userId = await getSignedInUserId();
+  if (userId === null) {
+    return [];
+  }
+
+  const limit = clamp(query.limit ?? 5, 1, MAX_SUGGESTED_PLAYERS);
+  const excludeIds = query.exclude ?? [];
+
+  const connectedPlayers = await getConnectedPlayers();
+  const connectedPlayerIds = connectedPlayers.map((p) => p.id);
+
+  // Combine connected players and explicit excludes.
+  const allExcludeIds = [...new Set([...connectedPlayerIds, ...excludeIds])];
+
+  let allPlayers: SuggestedPlayer[] = [];
+
+  // If user has connected players, find raid partners first.
+  // Only suggest partners who have enough recordings to provide feed value.
+  if (connectedPlayerIds.length > 0) {
+    const partnerResults = await sql<
+      { partner_id: number; username: string; total_challenges: number }[]
+    >`
+      WITH partner_stats AS (
+        SELECT
+          CASE
+            WHEN player_id_1 = ANY(${connectedPlayerIds}) THEN player_id_2
+            ELSE player_id_1
+          END AS partner_id,
+          SUM(challenge_count * EXP(-0.02 * (CURRENT_DATE - day_bucket))) AS score
+        FROM mv_daily_player_pairs
+        WHERE player_id_1 = ANY(${connectedPlayerIds})
+           OR player_id_2 = ANY(${connectedPlayerIds})
+        GROUP BY partner_id
+      )
+      SELECT
+        ps.partner_id,
+        p.username,
+        p.total_recordings AS total_challenges
+      FROM partner_stats ps
+      JOIN players p ON ps.partner_id = p.id
+      WHERE ps.partner_id != ALL(${allExcludeIds})
+        AND p.total_recordings >= ${MIN_RECORDINGS_FOR_SUGGESTION}
+        AND NOT EXISTS (
+          SELECT 1 FROM user_follows uf
+          WHERE uf.user_id = ${userId} AND uf.player_id = ps.partner_id
+        )
+      ORDER BY ps.score DESC
+      LIMIT ${limit}
+    `;
+
+    allPlayers = partnerResults.map((s) => ({
+      id: s.partner_id,
+      username: s.username,
+      totalChallenges: s.total_challenges,
+    }));
+  }
+
+  if (allPlayers.length < limit) {
+    const remaining = limit - allPlayers.length;
+    const activePlayers = await suggestActivePlayers(userId, remaining, [
+      ...allExcludeIds,
+      ...allPlayers.map((p) => p.id),
+    ]);
+    allPlayers.push(...activePlayers);
+  }
+
+  return allPlayers;
+}
+
+// Randomly sample from the most active and recently active players.
+async function suggestActivePlayers(
+  userId: number,
+  limit: number,
+  excludeIds: number[],
+): Promise<SuggestedPlayer[]> {
+  const mostActiveResults = await sql<
+    { player_id: number; username: string; total_challenges: number }[]
+  >`
+    SELECT
+      cp.player_id,
+      p.username,
+      p.total_recordings AS total_challenges
+    FROM challenge_players cp
+    JOIN challenges c ON c.id = cp.challenge_id
+    JOIN players p ON p.id = cp.player_id
+    WHERE c.start_time > NOW() - INTERVAL '6 months'
+      ${excludeIds.length > 0 ? sql`AND cp.player_id != ALL(${excludeIds})` : sql``}
+      AND NOT EXISTS (
+        SELECT 1 FROM user_follows uf
+        WHERE uf.user_id = ${userId} AND uf.player_id = cp.player_id
+      )
+    GROUP BY cp.player_id, p.username, p.total_recordings
+    ORDER BY COUNT(*) DESC
+    LIMIT ${MAX_SUGGESTED_PLAYERS}
+  `;
+
+  const mostActive = mostActiveResults.map((s) => ({
+    id: s.player_id,
+    username: s.username,
+    totalChallenges: s.total_challenges,
+  }));
+
+  const excludeFromRecent = [...excludeIds, ...mostActive.map((p) => p.id)];
+
+  const recentlyActiveResults = await sql<
+    { player_id: number; username: string; total_challenges: number }[]
+  >`
+    SELECT DISTINCT ON (cp.player_id)
+      cp.player_id,
+      p.username,
+      p.total_recordings AS total_challenges
+    FROM challenge_players cp
+    JOIN challenges c ON c.id = cp.challenge_id
+    JOIN players p ON p.id = cp.player_id
+    WHERE c.start_time > NOW() - INTERVAL '7 days'
+      ${excludeFromRecent.length > 0 ? sql`AND cp.player_id != ALL(${excludeFromRecent})` : sql``}
+      AND NOT EXISTS (
+        SELECT 1 FROM user_follows uf
+        WHERE uf.user_id = ${userId} AND uf.player_id = cp.player_id
+      )
+    ORDER BY cp.player_id, c.start_time DESC
+    LIMIT ${MAX_SUGGESTED_PLAYERS}
+  `;
+
+  const recentlyActive = recentlyActiveResults.map((s) => ({
+    id: s.player_id,
+    username: s.username,
+    totalChallenges: s.total_challenges,
+  }));
+
+  const allPlayers: SuggestedPlayer[] = [];
+  while (allPlayers.length < limit) {
+    let pool = Math.random() < 0.6 ? mostActive : recentlyActive;
+    if (pool.length === 0) {
+      pool = pool === mostActive ? recentlyActive : mostActive;
+      if (pool.length === 0) {
+        break;
+      }
+    }
+
+    const i = Math.floor(Math.random() * pool.length);
+    const last = pool.length - 1;
+    [pool[i], pool[last]] = [pool[last], pool[i]];
+    allPlayers.push(pool.pop()!);
+  }
+
+  return allPlayers;
+}

--- a/web/app/actions/settings.ts
+++ b/web/app/actions/settings.ts
@@ -3,6 +3,7 @@
 import { JSONValue } from 'postgres';
 
 import { sql } from './db';
+import { AuthenticationError } from './errors';
 import { getSignedInUserId } from './users';
 
 export type UserSettings = Record<string, unknown>;
@@ -40,7 +41,7 @@ export async function setUserSetting(
 ): Promise<void> {
   const userId = await getSignedInUserId();
   if (userId === null) {
-    throw new Error('Not authenticated');
+    throw new AuthenticationError();
   }
 
   const jsonValue = sql.json(value as JSONValue);
@@ -64,7 +65,7 @@ export async function syncSettings(
 ): Promise<UserSettings> {
   const userId = await getSignedInUserId();
   if (userId === null) {
-    throw new Error('Not authenticated');
+    throw new AuthenticationError();
   }
 
   const entries = Object.entries(settings);

--- a/web/app/api/feed/route.ts
+++ b/web/app/api/feed/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from 'next/server';
+
+import { AuthenticationError } from '@/actions/errors';
+import { loadFeed } from '@/actions/feed';
+import { clamp } from '@/utils/math';
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+
+  const limit = clamp(parseInt(searchParams.get('limit') ?? '20'), 1, 50);
+  const cursor = searchParams.get('cursor') ?? undefined;
+  const directionParam = searchParams.get('direction');
+
+  const direction =
+    directionParam === 'newer' || directionParam === 'older'
+      ? directionParam
+      : 'older';
+
+  try {
+    const result = await loadFeed({ cursor, direction, limit });
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return new Response(null, { status: 401 });
+    }
+
+    console.error('Failed to fetch personalized feed:', error);
+    return new Response(null, { status: 500 });
+  }
+}

--- a/web/app/api/following/[playerId]/route.ts
+++ b/web/app/api/following/[playerId]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+
+import { AuthenticationError } from '@/actions/errors';
+import { unfollowPlayer } from '@/actions/feed';
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ playerId: string }> },
+) {
+  const { playerId: playerIdStr } = await params;
+  const playerId = parseInt(playerIdStr, 10);
+
+  if (isNaN(playerId)) {
+    return Response.json({ error: 'Invalid player ID' }, { status: 400 });
+  }
+
+  try {
+    await unfollowPlayer(playerId);
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return new Response(null, { status: 401 });
+    }
+
+    console.error('Failed to unfollow player:', error);
+    return new Response(null, { status: 500 });
+  }
+}

--- a/web/app/api/following/route.ts
+++ b/web/app/api/following/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from 'next/server';
+
+import { AuthenticationError, InvalidQueryError } from '@/actions/errors';
+import { followPlayer, getFollowing } from '@/actions/feed';
+import { expectSingle, numericParam } from '@/api/query';
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = Object.fromEntries(request.nextUrl.searchParams);
+    const cursor = expectSingle(searchParams, 'cursor');
+    const limit = numericParam(searchParams, 'limit');
+
+    const result = await getFollowing({ cursor, limit });
+    return Response.json(result);
+  } catch (error) {
+    if (error instanceof InvalidQueryError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    if (error instanceof AuthenticationError) {
+      return new Response(null, { status: 401 });
+    }
+
+    console.error('Failed to fetch following list:', error);
+    return new Response(null, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { usernames?: string[] };
+    const usernames = body.usernames;
+
+    if (!Array.isArray(usernames) || usernames.length === 0) {
+      return Response.json(
+        { error: 'Usernames array is required' },
+        { status: 400 },
+      );
+    }
+
+    if (usernames.length > 50) {
+      return Response.json(
+        { error: 'Maximum 50 usernames per request' },
+        { status: 400 },
+      );
+    }
+
+    for (const username of usernames) {
+      if (typeof username !== 'string' || username.length === 0) {
+        return Response.json({ error: 'Invalid username' }, { status: 400 });
+      }
+      if (username.length > 12) {
+        return Response.json({ error: 'Invalid username' }, { status: 400 });
+      }
+    }
+
+    const results = await Promise.all(usernames.map((u) => followPlayer(u)));
+    return Response.json(results, { status: 201 });
+  } catch (error) {
+    if (error instanceof AuthenticationError) {
+      return new Response(null, { status: 401 });
+    }
+
+    console.error('Failed to follow player:', error);
+    return new Response(null, { status: 500 });
+  }
+}

--- a/web/app/components/following-list/following-list.module.scss
+++ b/web/app/components/following-list/following-list.module.scss
@@ -1,0 +1,161 @@
+.followingList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.playerList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.playerItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background: var(--blert-surface-dark);
+  }
+}
+
+.playerInfo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+  text-decoration: none;
+
+  &:hover .playerName {
+    color: var(--blert-purple);
+  }
+}
+
+.playerName {
+  font-size: 0.9rem;
+  color: var(--blert-font-color-primary);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+
+.unfollowButton,
+.followButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  i {
+    position: relative;
+    top: 1px;
+    font-size: 0.8rem;
+  }
+}
+
+.unfollowButton {
+  background: rgba(var(--blert-red-base), 0.15);
+  color: rgba(var(--blert-red-base), 0.75);
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-red-base), 0.25);
+    color: var(--blert-red);
+  }
+}
+
+.followButton {
+  background: rgba(var(--blert-purple-base), 0.15);
+  color: var(--blert-purple);
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-purple-base), 0.25);
+  }
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px 16px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  color: var(--blert-font-color-secondary);
+  text-align: center;
+
+  i {
+    font-size: 1.25em;
+    opacity: 0.6;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9rem;
+  }
+}
+
+.sentinel {
+  height: 1px;
+  width: 100%;
+}
+
+// Skeleton styles
+.skeleton {
+  background: var(--blert-surface-dark);
+  border-radius: 4px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.skeletonAvatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.skeletonName {
+  width: 100px;
+  height: 16px;
+}
+
+.skeletonButton {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}

--- a/web/app/components/following-list/following-list.tsx
+++ b/web/app/components/following-list/following-list.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import PlayerAvatar from '@/components/player-avatar';
+import PlayerLink from '@/components/player-link';
+import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
+
+import styles from './following-list.module.scss';
+
+export type PlayerItem = {
+  id: number;
+  username: string;
+  isFollowed: boolean;
+  isPending?: boolean;
+};
+
+type FollowingListProps = {
+  players: PlayerItem[];
+  onFollow: (player: PlayerItem) => void | Promise<void>;
+  onUnfollow: (player: PlayerItem) => void | Promise<void>;
+  onLoadMore?: () => void | Promise<void>;
+  isLoading?: boolean;
+  hasMore?: boolean;
+};
+
+function PlayerRowSkeleton() {
+  return (
+    <li className={styles.playerItem}>
+      <div className={styles.playerInfo}>
+        <div className={`${styles.skeleton} ${styles.skeletonAvatar}`} />
+        <div className={`${styles.skeleton} ${styles.skeletonName}`} />
+      </div>
+      <div className={`${styles.skeleton} ${styles.skeletonButton}`} />
+    </li>
+  );
+}
+
+export default function FollowingList({
+  players,
+  onFollow,
+  onUnfollow,
+  onLoadMore,
+  isLoading,
+  hasMore,
+}: FollowingListProps) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (sentinel === null || !hasMore || onLoadMore === undefined) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && !isLoading) {
+          void onLoadMore();
+        }
+      },
+      { rootMargin: '100px' },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, onLoadMore]);
+
+  if (players.length === 0 && !isLoading) {
+    return (
+      <div className={styles.emptyState}>
+        <i className="fas fa-user-plus" />
+        <p>No players to show.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.followingList}>
+      <ul className={styles.playerList}>
+        {players.map((player) => {
+          const buttonClass = player.isFollowed
+            ? styles.unfollowButton
+            : styles.followButton;
+          const buttonIcon = player.isFollowed ? 'fas fa-times' : 'fas fa-plus';
+          const buttonTooltip = player.isFollowed ? 'Unfollow' : 'Follow';
+          const handleClick = () => {
+            void (player.isFollowed ? onUnfollow(player) : onFollow(player));
+          };
+
+          return (
+            <li key={player.id} className={styles.playerItem}>
+              <PlayerLink
+                className={styles.playerInfo}
+                username={player.username}
+              >
+                <PlayerAvatar id={player.id} username={player.username} />
+                <span className={styles.playerName}>{player.username}</span>
+              </PlayerLink>
+              <button
+                onClick={handleClick}
+                disabled={player.isPending}
+                className={buttonClass}
+                data-tooltip-id={GLOBAL_TOOLTIP_ID}
+                data-tooltip-content={buttonTooltip}
+              >
+                {player.isPending ? (
+                  <i className="fas fa-spinner fa-spin" />
+                ) : (
+                  <i className={buttonIcon} />
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Sentinel element for infinite scroll */}
+      {hasMore && <div ref={sentinelRef} className={styles.sentinel} />}
+
+      {isLoading && (
+        <ul className={styles.playerList}>
+          <PlayerRowSkeleton />
+          <PlayerRowSkeleton />
+          <PlayerRowSkeleton />
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/app/components/following-list/index.ts
+++ b/web/app/components/following-list/index.ts
@@ -1,0 +1,2 @@
+export { default } from './following-list';
+export { type PlayerItem } from './following-list';

--- a/web/app/components/player-avatar/index.ts
+++ b/web/app/components/player-avatar/index.ts
@@ -1,0 +1,1 @@
+export { default, getAvatarColor } from './player-avatar';

--- a/web/app/components/player-avatar/player-avatar.module.scss
+++ b/web/app/components/player-avatar/player-avatar.module.scss
@@ -1,0 +1,27 @@
+.avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  flex-shrink: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.small {
+  width: 24px;
+  height: 24px;
+  font-size: 0.75rem;
+}
+
+.medium {
+  width: 28px;
+  height: 28px;
+  font-size: 0.85rem;
+}
+
+.large {
+  width: 36px;
+  height: 36px;
+  font-size: 1rem;
+}

--- a/web/app/components/player-avatar/player-avatar.tsx
+++ b/web/app/components/player-avatar/player-avatar.tsx
@@ -1,0 +1,41 @@
+import styles from './player-avatar.module.scss';
+
+const AVATAR_COLORS = [
+  { bg: 'rgba(var(--blert-purple-base), 0.2)', fg: 'var(--blert-purple)' },
+  { bg: 'rgba(var(--blert-green-base), 0.2)', fg: 'var(--blert-green)' },
+  { bg: 'rgba(var(--blert-blue-base), 0.2)', fg: 'var(--blert-blue)' },
+  { bg: 'rgba(249, 115, 22, 0.2)', fg: 'rgb(249, 115, 22)' }, // orange
+  { bg: 'rgba(236, 72, 153, 0.2)', fg: 'rgb(236, 72, 153)' }, // pink
+  { bg: 'rgba(20, 184, 166, 0.2)', fg: 'rgb(20, 184, 166)' }, // teal
+  { bg: 'rgba(var(--blert-yellow-base), 0.2)', fg: 'var(--blert-yellow)' },
+  { bg: 'rgba(139, 92, 246, 0.2)', fg: 'rgb(139, 92, 246)' }, // violet
+];
+
+export function getAvatarColor(id: number) {
+  return AVATAR_COLORS[id % AVATAR_COLORS.length];
+}
+
+type PlayerAvatarProps = {
+  id: number;
+  username: string;
+  size?: 'small' | 'medium' | 'large';
+  className?: string;
+};
+
+export default function PlayerAvatar({
+  id,
+  username,
+  size = 'medium',
+  className,
+}: PlayerAvatarProps) {
+  const color = getAvatarColor(id);
+
+  return (
+    <span
+      className={`${styles.avatar} ${styles[size]} ${className ?? ''}`}
+      style={{ background: color.bg, color: color.fg }}
+    >
+      {username.charAt(0).toUpperCase()}
+    </span>
+  );
+}

--- a/web/app/components/player-link/player-link.tsx
+++ b/web/app/components/player-link/player-link.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { MouseEventHandler } from 'react';
 
 import { playerUrl } from '@/utils/url';
 
@@ -10,15 +11,22 @@ type PlayerLinkProps = {
   username: string;
   className?: string;
   children?: React.ReactNode;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
 };
 
-export function PlayerLink({ username, className, children }: PlayerLinkProps) {
+export function PlayerLink({
+  username,
+  className,
+  children,
+  onClick,
+}: PlayerLinkProps) {
   return (
     <Link
       href={playerUrl(username)}
       className={className}
       data-tooltip-id={PLAYER_LINK_TOOLTIP_ID}
       data-tooltip-username={username}
+      onClick={onClick}
     >
       {children ?? <span className={styles.playerLink}>{username}</span>}
     </Link>

--- a/web/app/dashboard/feed-page.tsx
+++ b/web/app/dashboard/feed-page.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { FeedItem, FollowedPlayer, SuggestedPlayer } from '@/actions/feed';
+import Card from '@/components/card';
+
+import Feed from './feed/feed';
+import EmptyFeed from './feed/empty-feed';
+import FollowManager from './feed/follow-manager';
+import PlayerPicker from './feed/player-picker';
+
+import styles from './style.module.scss';
+
+const SCROLL_THRESHOLD_FOR_REFRESH = 500;
+const PICKER_PLAYER_COUNT = 8;
+const PICKER_TTL_MS = 15 * 60 * 1000;
+
+function pickerStorageKey(userId: number): string {
+  return `blert:picker-suggestions:${userId}`;
+}
+
+type StoredPickerSuggestions = {
+  suggestions: SuggestedPlayer[];
+  storedAt: number;
+};
+
+function loadPickerSuggestions(userId: number): SuggestedPlayer[] | null {
+  try {
+    const stored = localStorage.getItem(pickerStorageKey(userId));
+    if (stored === null) {
+      return null;
+    }
+    const parsed = JSON.parse(stored) as StoredPickerSuggestions;
+    if (Date.now() - parsed.storedAt > PICKER_TTL_MS) {
+      localStorage.removeItem(pickerStorageKey(userId));
+      return null;
+    }
+    return parsed.suggestions;
+  } catch {
+    return null;
+  }
+}
+
+function savePickerSuggestions(
+  userId: number,
+  suggestions: SuggestedPlayer[],
+): void {
+  try {
+    const data: StoredPickerSuggestions = {
+      suggestions,
+      storedAt: Date.now(),
+    };
+    localStorage.setItem(pickerStorageKey(userId), JSON.stringify(data));
+  } catch {
+    // Ignore storage errors.
+  }
+}
+
+function clearPickerSuggestions(userId: number): void {
+  try {
+    localStorage.removeItem(pickerStorageKey(userId));
+  } catch {
+    // Ignore storage errors.
+  }
+}
+
+type FeedPageProps = {
+  userId: number;
+  initialFeed: FeedItem[];
+  initialOlderCursor: string | null;
+  initialNewerCursor: string | null;
+  following: FollowedPlayer[];
+  followingCount: number;
+  suggestions: SuggestedPlayer[];
+};
+
+export default function FeedPage({
+  initialFeed,
+  initialOlderCursor,
+  initialNewerCursor,
+  following,
+  followingCount,
+  suggestions,
+  userId,
+}: FeedPageProps) {
+  const [pickerDismissed, setPickerDismissed] = useState(false);
+  const [pickerSuggestions, setPickerSuggestions] = useState<
+    SuggestedPlayer[] | null
+  >(null);
+
+  const [localFollowing, setLocalFollowing] = useState(following);
+  const [localFollowingCount, setLocalFollowingCount] =
+    useState(followingCount);
+  const [feedRefetchKey, setFeedRefetchKey] = useState(0);
+
+  // On mount, load persisted picker suggestions or save current ones.
+  useEffect(() => {
+    if (following.length > 0) {
+      clearPickerSuggestions(userId);
+      setPickerSuggestions([]);
+      return;
+    }
+
+    const stored = loadPickerSuggestions(userId);
+    if (stored !== null && stored.length > 0) {
+      setPickerSuggestions(stored);
+    } else if (suggestions.length > 0) {
+      const toStore = suggestions.slice(0, PICKER_PLAYER_COUNT);
+      savePickerSuggestions(userId, toStore);
+      setPickerSuggestions(toStore);
+    } else {
+      setPickerSuggestions([]);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const showPicker =
+    localFollowing.length === 0 &&
+    pickerSuggestions !== null &&
+    pickerSuggestions.length > 0 &&
+    !pickerDismissed;
+
+  const pickerLoading =
+    localFollowing.length === 0 && pickerSuggestions === null;
+
+  const handlePlayerFollowed = useCallback((player: FollowedPlayer) => {
+    setLocalFollowing((prev) => [player, ...prev]);
+    setLocalFollowingCount((c) => c + 1);
+    if (window.scrollY < SCROLL_THRESHOLD_FOR_REFRESH) {
+      setFeedRefetchKey((k) => k + 1);
+    }
+  }, []);
+
+  const handlePlayerUnfollowed = useCallback((playerId: number) => {
+    setLocalFollowing((prev) => prev.filter((p) => p.id !== playerId));
+    setLocalFollowingCount((c) => c - 1);
+    if (window.scrollY < SCROLL_THRESHOLD_FOR_REFRESH) {
+      setFeedRefetchKey((k) => k + 1);
+    }
+  }, []);
+
+  const handlePickerComplete = useCallback(
+    (followedPlayers: FollowedPlayer[]) => {
+      clearPickerSuggestions(userId);
+      setPickerDismissed(true);
+
+      if (followedPlayers.length > 0) {
+        setLocalFollowing((prev) => [...followedPlayers, ...prev]);
+        setLocalFollowingCount((c) => c + followedPlayers.length);
+        setFeedRefetchKey((k) => k + 1);
+      }
+    },
+    [userId],
+  );
+
+  return (
+    <div className={styles.feedPage}>
+      <h2>Your Feed</h2>
+      <div className={styles.content}>
+        <main className={styles.main}>
+          {showPicker ? (
+            <div className={styles.pickerContainer}>
+              <EmptyFeed reason="no-follows" />
+              <Card>
+                <PlayerPicker
+                  suggestions={pickerSuggestions}
+                  onComplete={handlePickerComplete}
+                />
+              </Card>
+            </div>
+          ) : (
+            <Feed
+              initialFeed={initialFeed}
+              initialOlderCursor={initialOlderCursor}
+              initialNewerCursor={initialNewerCursor}
+              following={localFollowing}
+              refetchKey={feedRefetchKey}
+            />
+          )}
+        </main>
+        <aside className={styles.sidebar}>
+          <FollowManager
+            initialFollowing={localFollowing}
+            initialFollowingCount={localFollowingCount}
+            initialSuggestions={showPicker || pickerLoading ? [] : suggestions}
+            onPlayerFollowed={handlePlayerFollowed}
+            onPlayerUnfollowed={handlePlayerUnfollowed}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/empty-feed.tsx
+++ b/web/app/dashboard/feed/empty-feed.tsx
@@ -1,0 +1,31 @@
+import styles from './feed.module.scss';
+
+type EmptyFeedProps = {
+  reason: 'no-follows' | 'no-activity';
+};
+
+export default function EmptyFeed({ reason }: EmptyFeedProps) {
+  if (reason === 'no-follows') {
+    return (
+      <div className={styles.emptyState}>
+        <i className="fas fa-user-plus" />
+        <h3>Start Following Players</h3>
+        <p>
+          Follow your friends and favorite players to see their challenges and
+          personal bests in your feed.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.emptyState}>
+      <i className="fas fa-hourglass" />
+      <h3>No Recent Activity</h3>
+      <p>
+        The players you follow haven&apos;t recorded any challenges yet. Check
+        back later or follow more players to see more activity.
+      </p>
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/feed.module.scss
+++ b/web/app/dashboard/feed/feed.module.scss
@@ -1,0 +1,566 @@
+@use '@/mixins.scss' as *;
+
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.feedList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.feedItem {
+  @include panel;
+  flex-direction: column;
+  padding: 16px;
+  transition: all 0.2s ease;
+
+  &:hover {
+    border-color: rgba(var(--blert-purple-base), 0.3);
+  }
+}
+
+.feedCard {
+  @include panel;
+  flex-direction: column;
+  padding: 14px 16px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+
+  &:hover {
+    background: rgba(var(--blert-surface-light-base), 0.5);
+
+    .cardArrow {
+      transform: translateX(2px);
+      color: var(--blert-purple);
+    }
+  }
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.cardHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.cardArrow {
+  font-size: 0.75rem;
+  color: var(--blert-font-color-secondary);
+  transition: all 0.2s ease;
+}
+
+.sessionCard {
+  border-left-color: var(--blert-purple);
+
+  &.active {
+    border-left-color: var(--blert-green);
+    background: linear-gradient(
+      135deg,
+      rgba(var(--blert-green-base), 0.03) 0%,
+      var(--blert-panel-background-color) 50%
+    );
+
+    &:hover {
+      background: linear-gradient(
+        135deg,
+        rgba(var(--blert-green-base), 0.05) 0%,
+        rgba(var(--blert-surface-light-base), 0.5) 50%
+      );
+    }
+  }
+}
+
+.sessionInfo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.challengeIcon {
+  font-size: 1.2em;
+  color: var(--blert-purple);
+  object-fit: contain;
+}
+
+.sessionTitle {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--blert-font-color-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.sessionMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+  flex-wrap: wrap;
+}
+
+.separator {
+  color: var(--blert-divider-color);
+}
+
+.liveIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--blert-green);
+  font-weight: 600;
+}
+
+.pulsingDot {
+  width: 8px;
+  height: 8px;
+  background: var(--blert-green);
+  border-radius: 50%;
+  animation: livePulse 2s ease-in-out infinite;
+}
+
+@keyframes livePulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--blert-green-base), 0.7);
+    transform: scale(1);
+    background: var(--blert-green);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(var(--blert-green-base), 0);
+    transform: scale(1.2);
+    background: rgba(var(--blert-green-base), 0.9);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--blert-green-base), 0);
+    transform: scale(1);
+    background: var(--blert-green);
+  }
+}
+
+.timestamp {
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+  white-space: nowrap;
+}
+
+.sessionBody {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.partyList {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.partyMember {
+  display: inline;
+}
+
+.comma {
+  color: var(--blert-font-color-secondary);
+  margin-right: 6px;
+}
+
+.playerName {
+  font-size: 0.9rem;
+  color: var(--blert-font-color-secondary);
+  text-decoration: none;
+
+  &:hover {
+    color: var(--blert-purple);
+    text-decoration: underline;
+  }
+}
+
+.followed {
+  font-size: 0.9rem;
+  color: var(--blert-purple);
+  font-weight: 500;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.sessionStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.stat {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+
+  i {
+    font-size: 0.9em;
+    width: 16px;
+    text-align: center;
+  }
+
+  &.statCompleted i {
+    color: var(--blert-green);
+  }
+
+  &.statReset i {
+    color: var(--blert-font-color-primary);
+  }
+
+  &.statWiped i {
+    color: var(--blert-red);
+  }
+
+  &.statDeaths i {
+    color: rgba(var(--blert-red-base), 0.7);
+  }
+}
+
+.pbCard {
+  border-left-color: var(--blert-yellow);
+
+  &:hover {
+    border-left-color: var(--blert-yellow);
+  }
+}
+
+.pbHeadline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+
+  i {
+    font-size: 1rem;
+    color: var(--blert-yellow);
+    flex-shrink: 0;
+  }
+}
+
+.pbSplitName {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pbBody {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.pbContext {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pbChallenge {
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pbTime {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.newTime {
+  font-family: var(--font-roboto-mono), monospace;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--blert-font-color-primary);
+}
+
+.improvement {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--font-roboto-mono), monospace;
+  font-size: 0.8rem;
+  color: var(--blert-green);
+
+  i {
+    position: relative;
+    top: 1px;
+    font-size: 0.75em;
+  }
+}
+
+.nameChangeCard {
+  border-left-color: var(--blert-font-color-secondary);
+}
+
+.nameChangeBadge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  i {
+    font-size: 1rem;
+    color: var(--blert-font-color-secondary);
+  }
+
+  span {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--blert-font-color-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+}
+
+.nameChangeBody {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1rem;
+
+  i {
+    color: var(--blert-font-color-secondary);
+    font-size: 0.85em;
+  }
+
+  .oldName {
+    color: var(--blert-font-color-secondary);
+    text-decoration: line-through;
+    text-decoration-color: rgba(var(--blert-font-color-secondary-base), 0.5);
+  }
+
+  .newName {
+    color: var(--blert-font-color-primary);
+    font-weight: 500;
+  }
+}
+
+.emptyState {
+  @include panel;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  text-align: center;
+  gap: 16px;
+
+  i {
+    font-size: 2.5rem;
+    color: var(--blert-font-color-secondary);
+    opacity: 0.5;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--blert-font-color-primary);
+  }
+
+  p {
+    margin: 0;
+    color: var(--blert-font-color-secondary);
+    font-size: 0.95rem;
+    max-width: 400px;
+  }
+}
+
+.newItemsBanner {
+  position: sticky;
+  top: 20px;
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+  margin-bottom: 8px;
+}
+
+.newItemsButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background: linear-gradient(
+    135deg,
+    var(--blert-purple) 0%,
+    rgba(var(--blert-purple-base), 0.8) 100%
+  );
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow:
+    0 4px 12px rgba(var(--blert-purple-base), 0.3),
+    0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: all 0.2s ease;
+  animation: pulse 2s ease-in-out infinite;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 6px 16px rgba(var(--blert-purple-base), 0.4),
+      0 3px 6px rgba(0, 0, 0, 0.3);
+    animation: none;
+  }
+
+  i {
+    font-size: 0.85em;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 4px 12px rgba(var(--blert-purple-base), 0.3),
+      0 2px 4px rgba(0, 0, 0, 0.2);
+  }
+  50% {
+    box-shadow:
+      0 4px 20px rgba(var(--blert-purple-base), 0.5),
+      0 2px 8px rgba(0, 0, 0, 0.25);
+  }
+}
+
+.sentinel {
+  height: 1px;
+  width: 100%;
+}
+
+.loadMore {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.loadMoreButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  background: var(--blert-surface-dark);
+  color: var(--blert-font-color-primary);
+  border: 1px solid var(--blert-divider-color);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: var(--blert-panel-background-color);
+    border-color: var(--blert-purple);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  i {
+    font-size: 0.85em;
+  }
+}
+
+.loadingSkeletons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.skeleton {
+  background: var(--blert-surface-dark);
+  border-radius: 4px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.skeletonHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.skeletonIcon {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+}
+
+.skeletonTitle {
+  width: 200px;
+  height: 20px;
+}
+
+.skeletonTime {
+  width: 80px;
+  height: 16px;
+  margin-left: auto;
+}
+
+.skeletonBody {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.skeletonLine {
+  width: 100%;
+  height: 16px;
+}
+
+.skeletonLineShort {
+  width: 60%;
+  height: 16px;
+}

--- a/web/app/dashboard/feed/feed.tsx
+++ b/web/app/dashboard/feed/feed.tsx
@@ -1,0 +1,426 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { FeedItem, FeedResult, FollowedPlayer } from '@/actions/feed';
+
+import EmptyFeed from './empty-feed';
+import NameChangeFeedCard from './name-change-feed-card';
+import NewItemsBanner from './new-items-banner';
+import PbFeedCard from './pb-feed-card';
+import SessionFeedCard from './session-feed-card';
+
+import styles from './feed.module.scss';
+
+const POLL_INTERVAL_MS = 30_000;
+const LOAD_MORE_SIZE = 20;
+const SCROLL_THRESHOLD_FOR_AUTO_MERGE = 200;
+
+/**
+ * Unique ID for a feed item for deduplication.
+ */
+function getFeedItemId(item: FeedItem): string {
+  return `${item.type}:${item.id}`;
+}
+
+/**
+ * Parse string dates in feed items from JSON.
+ */
+function parseFeedItemDates(items: FeedItem[]): FeedItem[] {
+  return items.map((item) => {
+    if (item.type === 'session') {
+      return {
+        ...item,
+        timestamp: new Date(item.timestamp),
+        session: {
+          ...item.session,
+          startTime: new Date(item.session.startTime),
+          endTime: item.session.endTime ? new Date(item.session.endTime) : null,
+          challenges: item.session.challenges.map((c) => ({
+            ...c,
+            startTime: new Date(c.startTime),
+          })),
+        },
+      };
+    } else {
+      return {
+        ...item,
+        timestamp: new Date(item.timestamp),
+      };
+    }
+  });
+}
+
+type FeedCursor = {
+  cursor: string;
+  direction: 'older' | 'newer';
+};
+
+async function fetchFeed(
+  limit: number,
+  cursor?: FeedCursor,
+  signal?: AbortSignal,
+): Promise<FeedResult | null> {
+  const params = new URLSearchParams();
+  params.set('limit', limit.toString());
+  if (cursor !== undefined) {
+    params.set('cursor', cursor.cursor);
+    params.set('direction', cursor.direction);
+  }
+
+  const response = await fetch(`/api/feed?${params.toString()}`, {
+    cache: 'no-store',
+    signal,
+  });
+  if (!response.ok) {
+    return null;
+  }
+
+  try {
+    const data = (await response.json()) as FeedResult;
+    return {
+      items: parseFeedItemDates(data.items),
+      olderCursor: data.olderCursor,
+      newerCursor: data.newerCursor,
+    };
+  } catch (error) {
+    console.error('Failed to fetch feed:', error);
+    return null;
+  }
+}
+
+type FeedProps = {
+  initialFeed: FeedItem[];
+  initialOlderCursor: string | null;
+  initialNewerCursor: string | null;
+  following: FollowedPlayer[];
+  refetchKey?: number;
+};
+
+function FeedItemSkeleton() {
+  return (
+    <div className={styles.feedItem}>
+      <div className={styles.skeletonHeader}>
+        <div className={`${styles.skeleton} ${styles.skeletonIcon}`} />
+        <div className={`${styles.skeleton} ${styles.skeletonTitle}`} />
+        <div className={`${styles.skeleton} ${styles.skeletonTime}`} />
+      </div>
+      <div className={styles.skeletonBody}>
+        <div className={`${styles.skeleton} ${styles.skeletonLine}`} />
+        <div className={`${styles.skeleton} ${styles.skeletonLineShort}`} />
+      </div>
+    </div>
+  );
+}
+
+export default function Feed({
+  initialFeed,
+  initialOlderCursor,
+  initialNewerCursor,
+  following,
+  refetchKey = 0,
+}: FeedProps) {
+  const [items, setItems] = useState<FeedItem[]>(initialFeed);
+  const [pendingItems, setPendingItems] = useState<FeedItem[]>([]);
+  const [olderCursor, setOlderCursor] = useState<string | null>(
+    initialOlderCursor,
+  );
+  const [newerCursor, setNewerCursor] = useState<string | null>(
+    initialNewerCursor,
+  );
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(initialOlderCursor !== null);
+  const [loadError, setLoadError] = useState(false);
+  const [isNearTop, setIsNearTop] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Tracks all seen item IDs for deduplication in polling.
+  const seenIdsRef = useRef<Set<string>>(
+    new Set(initialFeed.map(getFeedItemId)),
+  );
+
+  useEffect(() => {
+    setItems(initialFeed);
+    setPendingItems([]);
+    setOlderCursor(initialOlderCursor);
+    setNewerCursor(initialNewerCursor);
+    setHasMore(initialOlderCursor !== null);
+    setLoadError(false);
+    seenIdsRef.current = new Set(initialFeed.map(getFeedItemId));
+  }, [initialFeed, initialOlderCursor, initialNewerCursor]);
+
+  useEffect(() => {
+    if (refetchKey === 0) {
+      return;
+    }
+
+    const refetch = async () => {
+      try {
+        const result = await fetchFeed(LOAD_MORE_SIZE);
+        if (result === null) {
+          return;
+        }
+
+        seenIdsRef.current = new Set(result.items.map(getFeedItemId));
+        setItems(result.items);
+        setPendingItems([]);
+        setOlderCursor(result.olderCursor);
+        setNewerCursor(result.newerCursor);
+        setHasMore(result.olderCursor !== null);
+        setLoadError(false);
+      } catch (error) {
+        console.error('Failed to refetch feed:', error);
+      }
+    };
+
+    void refetch();
+  }, [refetchKey]);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsNearTop(window.scrollY < SCROLL_THRESHOLD_FOR_AUTO_MERGE);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Auto-merge pending items when user is near the top.
+  useEffect(() => {
+    if (isNearTop && pendingItems.length > 0) {
+      setItems((prev) => [...pendingItems, ...prev]);
+      setPendingItems([]);
+    }
+  }, [isNearTop, pendingItems]);
+
+  const pollCursorRef = useRef<string | null>(newerCursor);
+  useEffect(() => {
+    pollCursorRef.current = newerCursor;
+  }, [newerCursor]);
+  const pollInFlight = useRef(false);
+
+  const hasFollows = following.length > 0;
+
+  // Poll for new feed items.
+  useEffect(() => {
+    if (!hasFollows) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    let timeoutId: number | null = null;
+
+    const poll = async () => {
+      if (pollInFlight.current) {
+        return;
+      }
+      pollInFlight.current = true;
+
+      try {
+        let result: FeedResult | null;
+        if (pollCursorRef.current !== null) {
+          result = await fetchFeed(
+            50,
+            { cursor: pollCursorRef.current, direction: 'newer' },
+            abortController.signal,
+          );
+        } else {
+          result = await fetchFeed(50, undefined, abortController.signal);
+        }
+
+        if (abortController.signal.aborted || result === null) {
+          return;
+        }
+
+        if (result.newerCursor !== null) {
+          setNewerCursor(result.newerCursor);
+        }
+
+        if (result.items.length === 0) {
+          return;
+        }
+
+        const newItems = result.items.filter((item) => {
+          const id = getFeedItemId(item);
+          if (seenIdsRef.current.has(id)) {
+            return false;
+          }
+          seenIdsRef.current.add(id);
+          return true;
+        });
+
+        if (newItems.length > 0) {
+          setPendingItems((prev) => [...newItems, ...prev]);
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        console.error('Failed to poll for new feed items:', error);
+      } finally {
+        pollInFlight.current = false;
+        if (!abortController.signal.aborted) {
+          timeoutId = window.setTimeout(() => void poll(), POLL_INTERVAL_MS);
+        }
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        // Clear pending timeout and poll immediately when tab becomes visible.
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (!pollInFlight.current) {
+          void poll();
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    timeoutId = window.setTimeout(() => void poll(), POLL_INTERVAL_MS);
+
+    return () => {
+      abortController.abort();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [hasFollows]);
+
+  const loadPendingItems = useCallback(() => {
+    setItems((prev) => [...pendingItems, ...prev]);
+    setPendingItems([]);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [pendingItems]);
+
+  const loadMoreInFlight = useRef(false);
+
+  const loadMore = useCallback(async () => {
+    if (loadMoreInFlight.current || !hasMore || olderCursor === null) {
+      return;
+    }
+
+    loadMoreInFlight.current = true;
+    setIsLoadingMore(true);
+    setLoadError(false);
+
+    try {
+      const result = await fetchFeed(LOAD_MORE_SIZE, {
+        cursor: olderCursor,
+        direction: 'older',
+      });
+      if (result === null) {
+        setLoadError(true);
+        return;
+      }
+
+      if (result.olderCursor === null) {
+        setHasMore(false);
+      } else {
+        setOlderCursor(result.olderCursor);
+      }
+
+      if (result.items.length > 0) {
+        const newItems = result.items.filter((item) => {
+          const id = getFeedItemId(item);
+          if (seenIdsRef.current.has(id)) {
+            return false;
+          }
+          seenIdsRef.current.add(id);
+          return true;
+        });
+        if (newItems.length > 0) {
+          setItems((prev) => [...prev, ...newItems]);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load more feed items:', error);
+      setLoadError(true);
+    } finally {
+      loadMoreInFlight.current = false;
+      setIsLoadingMore(false);
+    }
+  }, [hasMore, olderCursor]);
+
+  // Infinite scroll.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (sentinel === null || !hasMore) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          void loadMore();
+        }
+      },
+      { rootMargin: '100px' },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loadMore]);
+
+  if (!hasFollows) {
+    return <EmptyFeed reason="no-follows" />;
+  }
+
+  if (items.length === 0 && pendingItems.length === 0) {
+    return <EmptyFeed reason="no-activity" />;
+  }
+
+  return (
+    <div className={styles.feed}>
+      {pendingItems.length > 0 && !isNearTop && (
+        <NewItemsBanner
+          count={pendingItems.length}
+          onClick={loadPendingItems}
+        />
+      )}
+
+      <div className={styles.feedList}>
+        {items.map((item) => {
+          const key = getFeedItemId(item);
+          switch (item.type) {
+            case 'session':
+              return <SessionFeedCard key={key} item={item} />;
+            case 'personal_best':
+              return <PbFeedCard key={key} item={item} />;
+            case 'name_change':
+              return <NameChangeFeedCard key={key} item={item} />;
+          }
+        })}
+      </div>
+
+      {/* Sentinel element for infinite scroll. */}
+      {hasMore && !loadError && (
+        <div ref={sentinelRef} className={styles.sentinel} />
+      )}
+
+      {loadError && hasMore && (
+        <div className={styles.loadMore}>
+          <button
+            onClick={() => void loadMore()}
+            disabled={isLoadingMore}
+            className={styles.loadMoreButton}
+          >
+            <i className="fas fa-exclamation-triangle" />
+            Failed to load. Tap to retry.
+          </button>
+        </div>
+      )}
+
+      {isLoadingMore && (
+        <div className={styles.loadingSkeletons}>
+          <FeedItemSkeleton />
+          <FeedItemSkeleton />
+          <FeedItemSkeleton />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/follow-manager.module.scss
+++ b/web/app/dashboard/feed/follow-manager.module.scss
@@ -1,0 +1,105 @@
+@use '@/mixins.scss' as *;
+
+.followManager {
+  @include panel;
+  flex-direction: column;
+  padding: 16px;
+  gap: 20px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
+
+  > i {
+    font-size: 0.85rem;
+    color: var(--blert-purple);
+  }
+}
+
+.sectionTitle {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--blert-font-color-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.count {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--blert-font-color-secondary);
+
+  &::before {
+    content: '·';
+    margin-right: 8px;
+  }
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px 16px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  color: var(--blert-font-color-secondary);
+  text-align: center;
+
+  i {
+    font-size: 1.25em;
+    opacity: 0.6;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9rem;
+  }
+}
+
+.playerList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.viewAllLink {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 0.85rem;
+  color: var(--blert-purple);
+  text-decoration: none;
+  background: rgba(var(--blert-purple-base), 0.08);
+  border-radius: 6px;
+  transition: all 0.2s ease;
+
+  i {
+    font-size: 0.75rem;
+    transition: transform 0.2s ease;
+  }
+
+  &:hover {
+    background: rgba(var(--blert-purple-base), 0.15);
+
+    i {
+      transform: translateX(3px);
+    }
+  }
+}

--- a/web/app/dashboard/feed/follow-manager.tsx
+++ b/web/app/dashboard/feed/follow-manager.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+
+import {
+  FollowedPlayer,
+  SuggestedPlayer,
+  followPlayer,
+  getSuggestedPlayers,
+  unfollowPlayer,
+} from '@/actions/feed';
+import FollowingList, { type PlayerItem } from '@/components/following-list';
+import { useToast } from '@/components/toast';
+
+import styles from './follow-manager.module.scss';
+
+const SUGGESTIONS_DISPLAY_LIMIT = 5;
+const SUGGESTIONS_FETCH_SIZE = 20;
+const SUGGESTIONS_REFETCH_THRESHOLD = 10;
+
+type FollowManagerProps = {
+  initialFollowing: FollowedPlayer[];
+  initialFollowingCount: number;
+  initialSuggestions: SuggestedPlayer[];
+  onPlayerFollowed?: (player: FollowedPlayer) => void;
+  onPlayerUnfollowed?: (playerId: number) => void;
+};
+
+export default function FollowManager({
+  initialFollowing,
+  initialFollowingCount,
+  initialSuggestions,
+  onPlayerFollowed,
+  onPlayerUnfollowed,
+}: FollowManagerProps) {
+  const [following, setFollowing] = useState(initialFollowing);
+  const [followingCount, setFollowingCount] = useState(initialFollowingCount);
+  const [suggestionPool, setSuggestionPool] = useState(initialSuggestions);
+  const [pendingActions, setPendingActions] = useState<Set<number>>(new Set());
+  const isFetchingSuggestions = useRef(false);
+  const showToast = useToast();
+
+  useEffect(() => {
+    setFollowing(initialFollowing);
+    setFollowingCount(initialFollowingCount);
+  }, [initialFollowing, initialFollowingCount]);
+
+  useEffect(() => {
+    setSuggestionPool(initialSuggestions);
+  }, [initialSuggestions]);
+
+  // Fetch more suggestions when pool runs low.
+  const fetchMoreSuggestions = useCallback(
+    async (currentPool: SuggestedPlayer[]) => {
+      if (isFetchingSuggestions.current) {
+        return;
+      }
+
+      isFetchingSuggestions.current = true;
+
+      try {
+        const excludeIds = currentPool.map((p) => p.id);
+        const newSuggestions = await getSuggestedPlayers({
+          limit: SUGGESTIONS_FETCH_SIZE,
+          exclude: excludeIds,
+        });
+
+        if (newSuggestions.length > 0) {
+          setSuggestionPool((prev) => [...prev, ...newSuggestions]);
+        }
+      } finally {
+        isFetchingSuggestions.current = false;
+      }
+    },
+    [],
+  );
+
+  const handleUnfollow = useCallback(
+    async (player: PlayerItem) => {
+      setPendingActions((prev) => new Set(prev).add(player.id));
+
+      try {
+        await unfollowPlayer(player.id);
+        setFollowing((prev) => prev.filter((p) => p.id !== player.id));
+        setFollowingCount((prev) => prev - 1);
+        onPlayerUnfollowed?.(player.id);
+      } catch {
+        showToast('Failed to unfollow player. Please try again.', 'error');
+      } finally {
+        setPendingActions((prev) => {
+          const next = new Set(prev);
+          next.delete(player.id);
+          return next;
+        });
+      }
+    },
+    [onPlayerUnfollowed, showToast],
+  );
+
+  const handleFollow = useCallback(
+    async (player: PlayerItem) => {
+      setPendingActions((prev) => new Set(prev).add(player.id));
+
+      try {
+        const followed = await followPlayer(player.username);
+        if (followed !== null) {
+          setFollowing((prev) => [followed, ...prev]);
+          setFollowingCount((prev) => prev + 1);
+
+          // Remove from pool.
+          const newPool = suggestionPool.filter((p) => p.id !== player.id);
+          setSuggestionPool(newPool);
+
+          // Trigger refetch if pool is running low.
+          if (newPool.length < SUGGESTIONS_REFETCH_THRESHOLD) {
+            void fetchMoreSuggestions(newPool);
+          }
+
+          onPlayerFollowed?.(followed);
+        }
+      } catch {
+        showToast('Failed to follow player. Please try again.', 'error');
+      } finally {
+        setPendingActions((prev) => {
+          const next = new Set(prev);
+          next.delete(player.id);
+          return next;
+        });
+      }
+    },
+    [fetchMoreSuggestions, onPlayerFollowed, showToast, suggestionPool],
+  );
+
+  const followingItems: PlayerItem[] = following.slice(0, 10).map((p) => ({
+    id: p.id,
+    username: p.username,
+    isFollowed: true,
+    isPending: pendingActions.has(p.id),
+  }));
+
+  const followingIds = new Set(following.map((f) => f.id));
+  const displayedSuggestions = suggestionPool
+    .filter((p) => !followingIds.has(p.id))
+    .slice(0, SUGGESTIONS_DISPLAY_LIMIT);
+  const suggestionItems: PlayerItem[] = displayedSuggestions.map((p) => ({
+    id: p.id,
+    username: p.username,
+    isFollowed: false,
+    isPending: pendingActions.has(p.id),
+  }));
+
+  return (
+    <div className={styles.followManager}>
+      <div className={styles.section}>
+        <div className={styles.sectionHeader}>
+          <i className="fas fa-users" />
+          <span className={styles.sectionTitle}>Following</span>
+          <span className={styles.count}>{followingCount}</span>
+        </div>
+
+        <FollowingList
+          players={followingItems}
+          onFollow={handleFollow}
+          onUnfollow={handleUnfollow}
+        />
+
+        {followingCount > 10 && (
+          <Link href="/settings/following" className={styles.viewAllLink}>
+            View all {followingCount} followed players
+            <i className="fas fa-arrow-right" />
+          </Link>
+        )}
+      </div>
+
+      {suggestionPool.length > 0 && (
+        <div className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <i className="fas fa-user-plus" />
+            <span className={styles.sectionTitle}>Suggested</span>
+          </div>
+
+          <FollowingList
+            players={suggestionItems}
+            onFollow={handleFollow}
+            onUnfollow={handleUnfollow}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/name-change-feed-card.tsx
+++ b/web/app/dashboard/feed/name-change-feed-card.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import TimeAgo from 'react-timeago';
+
+import { NameChangeFeedItem } from '@/actions/feed';
+import { useClientOnly } from '@/hooks/client-only';
+
+import styles from './feed.module.scss';
+
+type NameChangeFeedCardProps = {
+  item: NameChangeFeedItem;
+};
+
+export default function NameChangeFeedCard({ item }: NameChangeFeedCardProps) {
+  const router = useRouter();
+  const isClient = useClientOnly();
+
+  const handleCardClick = () => {
+    router.push(`/players/${encodeURIComponent(item.currentName)}`);
+  };
+
+  return (
+    <div
+      className={`${styles.feedCard} ${styles.nameChangeCard}`}
+      onClick={handleCardClick}
+    >
+      <div className={styles.cardHeader}>
+        <div className={styles.nameChangeBadge}>
+          <i className="fas fa-id-card" />
+          <span>Name Change</span>
+        </div>
+        <div className={styles.cardHeaderRight}>
+          <span className={styles.timestamp}>
+            {isClient && <TimeAgo date={item.timestamp} />}
+          </span>
+          <i className={`fas fa-chevron-right ${styles.cardArrow}`} />
+        </div>
+      </div>
+
+      <div className={styles.nameChangeBody}>
+        <span className={styles.oldName}>{item.oldName}</span>
+        <i className="fas fa-arrow-right" />
+        <span className={styles.newName}>{item.newName}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/new-items-banner.tsx
+++ b/web/app/dashboard/feed/new-items-banner.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import styles from './feed.module.scss';
+
+type NewItemsBannerProps = {
+  count: number;
+  onClick: () => void;
+};
+
+export default function NewItemsBanner({
+  count,
+  onClick,
+}: NewItemsBannerProps) {
+  return (
+    <div className={styles.newItemsBanner}>
+      <button className={styles.newItemsButton} onClick={onClick}>
+        <i className="fas fa-arrow-up" />
+        {count} new {count === 1 ? 'item' : 'items'}
+      </button>
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/pb-feed-card.tsx
+++ b/web/app/dashboard/feed/pb-feed-card.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { ChallengeMode, challengeName, splitName } from '@blert/common';
+import { useRouter } from 'next/navigation';
+import { MouseEvent } from 'react';
+import TimeAgo from 'react-timeago';
+
+import { PersonalBestFeedItem } from '@/actions/feed';
+import PlayerLink from '@/components/player-link';
+import { useClientOnly } from '@/hooks/client-only';
+import { scaleNameAndColor } from '@/utils/challenge';
+import { ticksToFormattedSeconds } from '@/utils/tick';
+import { challengeUrl } from '@/utils/url';
+
+import styles from './feed.module.scss';
+
+type PbFeedCardProps = {
+  item: PersonalBestFeedItem;
+};
+
+function formatSplitName(item: PersonalBestFeedItem): string {
+  const name = splitName(item.splitType);
+  switch (item.challengeMode) {
+    case ChallengeMode.TOB_ENTRY:
+      return `${name} (Entry)`;
+    case ChallengeMode.TOB_HARD:
+      return `${name} (HM)`;
+  }
+  return name;
+}
+
+export default function PbFeedCard({ item }: PbFeedCardProps) {
+  const router = useRouter();
+  const isClient = useClientOnly();
+
+  const [scaleString] = scaleNameAndColor(item.scale);
+  const formattedTime = ticksToFormattedSeconds(item.ticks);
+
+  const improvement =
+    item.previousTicks !== undefined && item.previousTicks !== null
+      ? item.previousTicks - item.ticks
+      : null;
+
+  const url = challengeUrl(item.challengeType, item.challengeUuid);
+
+  const handleCardClick = () => {
+    router.push(url);
+  };
+
+  const splitHeadline = `${scaleString} ${formatSplitName(item)} PB`;
+
+  return (
+    <div
+      className={`${styles.feedCard} ${styles.pbCard}`}
+      onClick={handleCardClick}
+    >
+      <div className={styles.cardHeader}>
+        <div className={styles.pbHeadline}>
+          <i className="fas fa-trophy" />
+          <span className={styles.pbSplitName}>{splitHeadline}</span>
+        </div>
+        <div className={styles.cardHeaderRight}>
+          <span className={styles.timestamp}>
+            {isClient && <TimeAgo date={item.timestamp} />}
+          </span>
+          <i className={`fas fa-chevron-right ${styles.cardArrow}`} />
+        </div>
+      </div>
+
+      <div className={styles.pbBody}>
+        <div className={styles.pbContext}>
+          <PlayerLink
+            username={item.player}
+            className={styles.followed}
+            onClick={(e: MouseEvent) => {
+              e.stopPropagation();
+            }}
+          />
+          <span className={styles.pbChallenge}>
+            {challengeName(item.challengeType)}
+          </span>
+        </div>
+
+        <div className={styles.pbTime}>
+          <span className={styles.newTime}>{formattedTime}</span>
+          {improvement !== null && improvement > 0 && (
+            <span className={styles.improvement}>
+              <i className="fas fa-arrow-down" />
+              {ticksToFormattedSeconds(improvement)}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/player-picker.module.scss
+++ b/web/app/dashboard/feed/player-picker.module.scss
@@ -1,0 +1,185 @@
+@use '@/mixins.scss' as *;
+
+.playerPicker {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.header {
+  text-align: center;
+
+  h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    color: var(--blert-font-color-primary);
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--blert-font-color-secondary);
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.playerCard {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--blert-surface-dark);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-align: left;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    padding: 10px 12px;
+  }
+
+  &:hover:not(:disabled) {
+    background: var(--blert-surface-light);
+    border-color: rgba(var(--blert-purple-base), 0.3);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &.selected {
+    border-color: var(--blert-purple);
+    background: rgba(var(--blert-purple-base), 0.1);
+
+    .checkbox {
+      background: var(--blert-purple);
+      border-color: var(--blert-purple);
+    }
+  }
+}
+
+.checkbox {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--blert-divider-color);
+  border-radius: 4px;
+  transition: all 0.15s ease;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    width: 18px;
+    height: 18px;
+  }
+
+  i {
+    position: relative;
+    top: 1px;
+    font-size: 0.7rem;
+    color: #fff;
+  }
+}
+
+.playerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.playerName {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--blert-font-color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  width: fit-content;
+
+  &:hover {
+    color: var(--blert-purple);
+    text-decoration: underline;
+  }
+}
+
+.playerStat {
+  font-size: 0.75rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.followButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px;
+  background: var(--blert-purple);
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-purple-base), 0.8);
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  i {
+    font-size: 0.9rem;
+  }
+}
+
+.skipButton {
+  padding: 8px 16px;
+  background: transparent;
+  border: none;
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+  cursor: pointer;
+  transition: color 0.2s ease;
+
+  &:hover:not(:disabled) {
+    color: var(--blert-font-color-primary);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}

--- a/web/app/dashboard/feed/player-picker.tsx
+++ b/web/app/dashboard/feed/player-picker.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { MouseEvent, useState } from 'react';
+
+import { FollowedPlayer, SuggestedPlayer } from '@/actions/feed';
+import PlayerAvatar from '@/components/player-avatar';
+import PlayerLink from '@/components/player-link';
+import { useToast } from '@/components/toast';
+
+import styles from './player-picker.module.scss';
+
+type PlayerPickerProps = {
+  suggestions: SuggestedPlayer[];
+  onComplete: (followedPlayers: FollowedPlayer[]) => void;
+};
+
+export default function PlayerPicker({
+  suggestions,
+  onComplete,
+}: PlayerPickerProps) {
+  const showToast = useToast();
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const togglePlayer = (playerId: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(playerId)) {
+        next.delete(playerId);
+      } else {
+        next.add(playerId);
+      }
+      return next;
+    });
+  };
+
+  const handleFollowSelected = async () => {
+    if (selected.size === 0) {
+      onComplete([]);
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const selectedPlayers = suggestions.filter((p) => selected.has(p.id));
+    const usernames = selectedPlayers.map((p) => p.username);
+
+    try {
+      const response = await fetch('/api/following', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ usernames }),
+      });
+
+      if (!response.ok) {
+        showToast('Failed to follow players', 'error');
+        onComplete([]);
+        return;
+      }
+
+      const results = (await response.json()) as (FollowedPlayer | null)[];
+      const followedPlayers = results.filter(
+        (r): r is FollowedPlayer => r !== null,
+      );
+
+      if (followedPlayers.length > 0) {
+        showToast(
+          `Now following ${followedPlayers.length} player${followedPlayers.length > 1 ? 's' : ''}`,
+          'success',
+        );
+      }
+
+      if (followedPlayers.length < selected.size) {
+        showToast('Some players could not be followed', 'error');
+      }
+
+      onComplete(followedPlayers);
+    } catch {
+      showToast('Failed to follow players', 'error');
+      onComplete([]);
+    }
+  };
+
+  const handleSkip = () => {
+    onComplete([]);
+  };
+
+  return (
+    <div className={styles.playerPicker}>
+      <div className={styles.header}>
+        <h3>Players You Might Like</h3>
+        <p>Select players to follow and populate your feed</p>
+      </div>
+
+      <div className={styles.grid}>
+        {suggestions.map((player) => {
+          const isSelected = selected.has(player.id);
+          return (
+            <button
+              key={player.id}
+              className={`${styles.playerCard} ${isSelected ? styles.selected : ''}`}
+              onClick={() => togglePlayer(player.id)}
+              disabled={isSubmitting}
+            >
+              <div className={styles.checkbox}>
+                {isSelected && <i className="fas fa-check" />}
+              </div>
+              <PlayerAvatar
+                id={player.id}
+                username={player.username}
+                size="large"
+              />
+              <div className={styles.playerInfo}>
+                <PlayerLink
+                  username={player.username}
+                  className={styles.playerName}
+                  onClick={(e: MouseEvent) => e.stopPropagation()}
+                >
+                  {player.username}
+                </PlayerLink>
+                <span className={styles.playerStat}>
+                  {player.totalChallenges} challenge
+                  {player.totalChallenges !== 1 ? 's' : ''}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.actions}>
+        <button
+          className={styles.followButton}
+          onClick={() => void handleFollowSelected()}
+          disabled={isSubmitting || selected.size === 0}
+        >
+          {isSubmitting ? (
+            <>
+              <i className="fas fa-spinner fa-spin" />
+              Following...
+            </>
+          ) : (
+            <>
+              <i className="fas fa-user-plus" />
+              Follow {selected.size} Player{selected.size !== 1 ? 's' : ''} &
+              Continue
+            </>
+          )}
+        </button>
+        <button
+          className={styles.skipButton}
+          onClick={handleSkip}
+          disabled={isSubmitting}
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/app/dashboard/feed/session-feed-card.tsx
+++ b/web/app/dashboard/feed/session-feed-card.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import {
+  ChallengeMode,
+  ChallengeStatus,
+  SessionStatus,
+  challengeName,
+} from '@blert/common';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { MouseEvent } from 'react';
+import TimeAgo from 'react-timeago';
+
+import { SessionFeedItem } from '@/actions/feed';
+import PlayerLink from '@/components/player-link';
+import { useClientOnly } from '@/hooks/client-only';
+import { challengeLogo } from '@/logo';
+import { modeNameAndColor, scaleNameAndColor } from '@/utils/challenge';
+import { formatDuration } from '@/utils/time';
+
+import styles from './feed.module.scss';
+
+type SessionFeedCardProps = {
+  item: SessionFeedItem;
+};
+
+export default function SessionFeedCard({ item }: SessionFeedCardProps) {
+  const router = useRouter();
+  const isClient = useClientOnly();
+  const { session, partyCurrentNames, followedPlayers } = item;
+
+  const followedUsernames = new Set(
+    followedPlayers.map((u) => u.toLowerCase()),
+  );
+
+  const currentNameForLink = (index: number): string => {
+    return partyCurrentNames[index] ?? session.party[index];
+  };
+
+  const isActive = session.status === SessionStatus.ACTIVE;
+  const totalChallenges = session.challenges.length;
+
+  let completedChallenges = 0;
+  let resetChallenges = 0;
+  let wipedChallenges = 0;
+  let totalDeaths = 0;
+  for (const c of session.challenges) {
+    if (c.status === ChallengeStatus.COMPLETED) {
+      completedChallenges += 1;
+    } else if (c.status === ChallengeStatus.RESET) {
+      resetChallenges += 1;
+    } else if (c.status === ChallengeStatus.WIPED) {
+      wipedChallenges += 1;
+    }
+    totalDeaths += c.totalDeaths;
+  }
+
+  const endTime = session.endTime ?? new Date();
+  const sessionDuration = formatDuration(
+    endTime.getTime() - session.startTime.getTime(),
+  );
+
+  const [modeString] = modeNameAndColor(
+    session.challengeType,
+    session.challengeMode,
+    false,
+  );
+  const [scaleString] = scaleNameAndColor(session.scale);
+
+  const handleCardClick = () => {
+    router.push(`/sessions/${session.uuid}`);
+  };
+
+  return (
+    <div
+      className={`${styles.feedCard} ${styles.sessionCard} ${isActive ? styles.active : ''}`}
+      onClick={handleCardClick}
+    >
+      <div className={styles.cardHeader}>
+        <div className={styles.sessionInfo}>
+          <Image
+            src={challengeLogo(session.challengeType)}
+            alt={challengeName(session.challengeType)}
+            width={24}
+            height={24}
+            className={styles.challengeIcon}
+          />
+          <div className={styles.sessionTitle}>
+            <h3>
+              {challengeName(session.challengeType)} ({scaleString}
+              {session.challengeMode !== ChallengeMode.NO_MODE &&
+                `, ${modeString}`}
+              )
+            </h3>
+            <div className={styles.sessionMeta}>
+              {isActive && (
+                <>
+                  <span className={styles.liveIndicator}>
+                    <span className={styles.pulsingDot} />
+                    Live
+                  </span>
+                  <span className={styles.separator}>•</span>
+                </>
+              )}
+              <span>
+                {totalChallenges} run{totalChallenges !== 1 ? 's' : ''}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className={styles.cardHeaderRight}>
+          <span className={styles.timestamp}>
+            {isClient && <TimeAgo date={item.timestamp} />}
+          </span>
+          <i className={`fas fa-chevron-right ${styles.cardArrow}`} />
+        </div>
+      </div>
+
+      <div className={styles.sessionBody}>
+        <div className={styles.partyList}>
+          {session.party.map((player, index) => {
+            const currentName = currentNameForLink(index);
+            const isFollowed = followedUsernames.has(currentName.toLowerCase());
+            return (
+              <span key={player} className={styles.partyMember}>
+                <PlayerLink
+                  username={currentName}
+                  className={isFollowed ? styles.followed : styles.playerName}
+                  onClick={(e: MouseEvent) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  {player}
+                </PlayerLink>
+                {index < session.party.length - 1 && (
+                  <span className={styles.comma}>,</span>
+                )}
+              </span>
+            );
+          })}
+        </div>
+
+        <div className={styles.sessionStats}>
+          <div className={`${styles.stat} ${styles.statCompleted}`}>
+            <i className="fas fa-flag-checkered" />
+            <span>{completedChallenges} completed</span>
+          </div>
+          {resetChallenges > 0 && (
+            <div className={`${styles.stat} ${styles.statReset}`}>
+              <i className="fas fa-rotate-left" />
+              <span>{resetChallenges} reset</span>
+            </div>
+          )}
+          {wipedChallenges > 0 && (
+            <div className={`${styles.stat} ${styles.statWiped}`}>
+              <i className="fas fa-x" />
+              <span>{wipedChallenges} wiped</span>
+            </div>
+          )}
+          <div className={`${styles.stat} ${styles.statDeaths}`}>
+            <i className="fas fa-skull" />
+            <span>
+              {totalDeaths} death{totalDeaths !== 1 ? 's' : ''}
+            </span>
+          </div>
+          {sessionDuration && (
+            <div className={styles.stat}>
+              <i className="fas fa-clock" />
+              <span>{sessionDuration}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/dashboard/onboarding-card.module.scss
+++ b/web/app/dashboard/onboarding-card.module.scss
@@ -1,0 +1,123 @@
+@use '@/mixins.scss' as *;
+
+.onboarding {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    color: var(--blert-font-color-primary);
+  }
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.9rem;
+}
+
+.steps {
+  display: flex;
+  gap: 16px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+  }
+}
+
+.step {
+  flex: 1;
+  display: flex;
+  gap: 12px;
+  padding: 16px;
+  background: var(--blert-surface-dark);
+  border-radius: 8px;
+}
+
+.stepNumber {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: rgba(var(--blert-purple-base), 0.2);
+  color: var(--blert-purple);
+  border-radius: 50%;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.stepContent {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+
+  h3 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--blert-font-color-primary);
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--blert-font-color-secondary);
+    line-height: 1.4;
+  }
+}
+
+.command {
+  padding: 2px 6px;
+  background: var(--blert-surface-light);
+  border-radius: 4px;
+  font-family: var(--font-roboto-mono), monospace;
+  font-size: 0.8rem;
+  color: var(--blert-purple);
+}
+
+.discordLink,
+.settingsLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  width: fit-content;
+  color: #fff;
+
+  i {
+    font-size: 1rem;
+  }
+}
+
+.discordLink {
+  background: var(--blert-purple);
+
+  &:hover {
+    background: rgba(var(--blert-purple-base), 0.8);
+  }
+}
+
+.settingsLink {
+  background: var(--blert-surface-light);
+  color: var(--blert-font-color-primary);
+  border: 1px solid var(--blert-divider-color);
+
+  &:hover {
+    background: var(--blert-panel-background-color);
+    border-color: var(--blert-purple);
+  }
+}

--- a/web/app/dashboard/onboarding-card.tsx
+++ b/web/app/dashboard/onboarding-card.tsx
@@ -1,0 +1,72 @@
+import Link from 'next/link';
+
+import styles from './onboarding-card.module.scss';
+
+const DISCORD_INVITE_URL = 'https://discord.gg/c5Hgv3NnYe';
+
+type OnboardingCardProps = {
+  username: string;
+};
+
+export default function OnboardingCard({ username }: OnboardingCardProps) {
+  return (
+    <div className={styles.onboarding}>
+      <div className={styles.header}>
+        <h1>Welcome to Blert, {username}</h1>
+        <p className={styles.subtitle}>
+          Link your account to start tracking your raids
+        </p>
+      </div>
+
+      <div className={styles.steps}>
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>1</div>
+          <div className={styles.stepContent}>
+            <h3>Join the Discord</h3>
+            <p>
+              Join our Discord server and run{' '}
+              <code className={styles.command}>/link-discord</code> to connect
+              your account.
+            </p>
+            <a
+              href={DISCORD_INVITE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.discordLink}
+            >
+              <i className="fab fa-discord" />
+              Join Discord
+            </a>
+          </div>
+        </div>
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>2</div>
+          <div className={styles.stepContent}>
+            <h3>Get Plugin Access</h3>
+            <p>
+              Once verified, ask a{' '}
+              <strong style={{ color: '#e91e63' }}>@Support</strong> member in
+              Discord to grant API key access.
+            </p>
+          </div>
+        </div>
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>3</div>
+          <div className={styles.stepContent}>
+            <h3>Create an API Key</h3>
+            <p>
+              Generate an API key in settings and paste it into the Blert
+              RuneLite plugin.
+            </p>
+            <Link href="/settings/api-keys" className={styles.settingsLink}>
+              <i className="fas fa-key" />
+              Go to Settings
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,0 +1,197 @@
+import { ChallengeMode, ChallengeStatus, ChallengeType } from '@blert/common';
+import { redirect } from 'next/navigation';
+import { ResolvingMetadata } from 'next';
+
+import {
+  aggregateChallenges,
+  ChallengeOverview,
+  findChallenges,
+} from '@/actions/challenge';
+import { getFollowing, getSuggestedPlayers, loadFeed } from '@/actions/feed';
+import { getConnectedPlayers, getSignedInUser } from '@/actions/users';
+import Card from '@/components/card';
+import { basicMetadata } from '@/utils/metadata';
+import { ticksToFormattedDuration } from '@/utils/tick';
+
+import FeedPage from './feed-page';
+import OnboardingCard from './onboarding-card';
+import WelcomeStats from './welcome-stats';
+
+import styles from './style.module.scss';
+
+const INITIAL_FEED_SIZE = 20;
+
+async function getLastChallenge(
+  usernames: string[],
+): Promise<ChallengeOverview | null> {
+  if (usernames.length === 0) {
+    return null;
+  }
+
+  const [challenges] = await findChallenges(1, {
+    party: usernames,
+    partyMatch: 'any',
+    sort: '-startTime',
+  });
+
+  return challenges[0] ?? null;
+}
+
+type WeekActivity = {
+  type: ChallengeType;
+  mode: ChallengeMode;
+  scale: number;
+  count: number;
+};
+
+async function getThisWeekActivity(
+  usernames: string[],
+  limit: number = 3,
+): Promise<WeekActivity[]> {
+  if (usernames.length === 0) {
+    return [];
+  }
+
+  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  const result = await aggregateChallenges(
+    {
+      party: usernames,
+      partyMatch: 'any',
+      startTime: ['>=', oneWeekAgo],
+    },
+    { '*': 'count' },
+    {},
+    ['type', 'mode', 'scale'] as const,
+  );
+
+  if (result === null) {
+    return [];
+  }
+
+  // Flatten the nested grouped result into an array.
+  const activities: WeekActivity[] = [];
+  for (const [typeStr, byMode] of Object.entries(result)) {
+    for (const [modeStr, byScale] of Object.entries(byMode)) {
+      for (const [scaleStr, data] of Object.entries(byScale)) {
+        activities.push({
+          type: parseInt(typeStr) as ChallengeType,
+          mode: parseInt(modeStr) as ChallengeMode,
+          scale: parseInt(scaleStr),
+          count: data['*'].count,
+        });
+      }
+    }
+  }
+
+  activities.sort((a, b) => b.count - a.count);
+  return activities.slice(0, limit);
+}
+
+type QuickStats = {
+  recordings: number;
+  completions: number;
+  timeRecorded: string;
+};
+
+async function getQuickStats(usernames: string[]): Promise<QuickStats> {
+  if (usernames.length === 0) {
+    return { recordings: 0, completions: 0, timeRecorded: '0m' };
+  }
+
+  const [allStats, completedStats] = await Promise.all([
+    aggregateChallenges(
+      { party: usernames, partyMatch: 'any' },
+      { '*': 'count', challengeTicks: 'sum' },
+    ),
+    aggregateChallenges(
+      {
+        party: usernames,
+        partyMatch: 'any',
+        status: ['==', ChallengeStatus.COMPLETED],
+      },
+      { '*': 'count' },
+    ),
+  ]);
+
+  const recordings = allStats?.['*']?.count ?? 0;
+  const completions = completedStats?.['*']?.count ?? 0;
+  const totalTicks = allStats?.challengeTicks?.sum ?? 0;
+  const timeRecorded = ticksToFormattedDuration(totalTicks);
+
+  return { recordings, completions, timeRecorded };
+}
+
+export default async function Dashboard() {
+  const user = await getSignedInUser();
+  if (user === null) {
+    redirect('/login');
+  }
+
+  const connectedPlayers = await getConnectedPlayers();
+  const connectedUsernames = connectedPlayers.map((p) => p.username);
+
+  const [
+    feedResult,
+    followingResult,
+    suggestions,
+    quickStats,
+    lastChallenge,
+    thisWeek,
+  ] = await Promise.all([
+    loadFeed({ limit: INITIAL_FEED_SIZE }),
+    getFollowing(),
+    getSuggestedPlayers({ limit: 20 }),
+    getQuickStats(connectedUsernames),
+    getLastChallenge(connectedUsernames),
+    getThisWeekActivity(connectedUsernames),
+  ]);
+  const {
+    items: initialFeed,
+    olderCursor: initialOlderCursor,
+    newerCursor: initialNewerCursor,
+  } = feedResult;
+  const { players: following, totalCount: followingCount } = followingResult;
+
+  const hasConnectedPlayers = connectedPlayers.length > 0;
+  const displayName = user.displayUsername ?? user.username;
+
+  return (
+    <div className={styles.dashboard}>
+      <Card className={styles.welcomeSection}>
+        {hasConnectedPlayers ? (
+          <WelcomeStats
+            username={displayName}
+            stats={quickStats}
+            lastChallenge={lastChallenge}
+            thisWeek={thisWeek}
+          />
+        ) : (
+          <OnboardingCard username={displayName} />
+        )}
+      </Card>
+
+      <FeedPage
+        userId={user.id}
+        initialFeed={initialFeed}
+        initialOlderCursor={initialOlderCursor}
+        initialNewerCursor={initialNewerCursor}
+        following={following}
+        followingCount={followingCount}
+        suggestions={suggestions}
+      />
+    </div>
+  );
+}
+
+export async function generateMetadata(
+  _props: Record<string, never>,
+  parent: ResolvingMetadata,
+) {
+  return basicMetadata(await parent, {
+    title: 'Dashboard',
+    description: 'Your personal Blert activity dashboard.',
+  });
+}
+
+export const dynamic = 'force-dynamic';

--- a/web/app/dashboard/style.module.scss
+++ b/web/app/dashboard/style.module.scss
@@ -1,0 +1,57 @@
+@use '@/mixins.scss' as *;
+
+.dashboard {
+  padding: 2rem 1rem;
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    padding: 1rem 0.5rem;
+  }
+}
+
+.welcomeSection {
+  margin-bottom: 24px;
+}
+
+.feedPage {
+  h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0 0 16px 0;
+    color: var(--blert-font-color-primary);
+  }
+}
+
+.content {
+  display: flex;
+  gap: 24px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+  }
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+}
+
+.pickerContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  align-self: flex-start;
+  position: sticky;
+  top: 20px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    display: none;
+  }
+}

--- a/web/app/dashboard/welcome-stats.module.scss
+++ b/web/app/dashboard/welcome-stats.module.scss
@@ -1,0 +1,242 @@
+@use '@/mixins.scss' as *;
+
+.welcomeStats {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.welcomeMain {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+}
+
+.welcomeText {
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0 0 4px 0;
+    color: var(--blert-font-color-primary);
+  }
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.9rem;
+}
+
+.quickStats {
+  display: flex;
+  gap: 24px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    gap: 20px;
+  }
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.statValue {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.statLabel {
+  font-size: 0.75rem;
+  color: var(--blert-font-color-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.welcomeBottom {
+  display: flex;
+  gap: 24px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(var(--blert-purple-base), 0.15);
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--blert-font-color-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+
+  i {
+    color: var(--blert-purple);
+    font-size: 0.8rem;
+  }
+}
+
+.lastChallenge {
+  flex-shrink: 0;
+}
+
+.lastChallengeContent {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 12px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  text-decoration: none;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: var(--blert-surface-light);
+
+    .viewChallenge i {
+      transform: translateX(3px);
+    }
+  }
+}
+
+.challengeTop {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.challengeBottom {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.challengeType {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--blert-font-color-primary);
+}
+
+.challengeTime {
+  font-family: var(--font-roboto-mono), monospace;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--blert-green);
+}
+
+.challengeDate {
+  font-size: 0.75rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.viewChallenge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: var(--blert-purple);
+  margin-left: auto;
+
+  i {
+    font-size: 0.65rem;
+    transition: transform 0.2s ease;
+  }
+}
+
+.thisWeek {
+  flex: 1;
+  min-width: 0;
+  padding-left: 24px;
+  border-left: 1px solid rgba(var(--blert-purple-base), 0.15);
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    padding-left: 0;
+    padding-top: 16px;
+    border-left: none;
+    border-top: 1px solid rgba(var(--blert-purple-base), 0.15);
+  }
+}
+
+.thisWeekContent {
+  display: flex;
+  gap: 10px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-wrap: wrap;
+  }
+}
+
+.activityCard {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  min-width: 0;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex: 1;
+    min-width: 120px;
+  }
+}
+
+.activityIcon {
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.activityInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.activityName {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--blert-font-color-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.activityCount {
+  font-size: 0.75rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.noActivity {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.85rem;
+
+  i {
+    color: var(--blert-purple);
+    font-size: 1rem;
+  }
+}

--- a/web/app/dashboard/welcome-stats.tsx
+++ b/web/app/dashboard/welcome-stats.tsx
@@ -1,0 +1,177 @@
+import { ChallengeMode, challengeName, ChallengeType } from '@blert/common';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { ChallengeOverview } from '@/actions/challenge';
+import { challengeLogo } from '@/logo';
+import { scaleNameAndColor } from '@/utils/challenge';
+import { ticksToFormattedSeconds } from '@/utils/tick';
+import { challengeUrl } from '@/utils/url';
+
+import styles from './welcome-stats.module.scss';
+
+/**
+ * Formats a challenge name with scale and mode for display.
+ * e.g., "ToB 4s", "HMT 4s", "Colosseum", "Inferno"
+ *
+ * @param type The challenge type.
+ * @param scale The challenge scale.
+ * @param mode The challenge mode.
+ * @returns The formatted challenge name.
+ */
+function formatChallengeName(
+  type: ChallengeType,
+  scale: number,
+  mode: ChallengeMode,
+): string {
+  const [scaleName] = scaleNameAndColor(scale);
+
+  if (
+    type === ChallengeType.COLOSSEUM ||
+    type === ChallengeType.INFERNO ||
+    type === ChallengeType.MOKHAIOTL
+  ) {
+    return challengeName(type);
+  }
+
+  if (mode === ChallengeMode.TOB_REGULAR) {
+    return `ToB ${scaleName}`;
+  }
+  if (mode === ChallengeMode.TOB_HARD) {
+    return `HMT ${scaleName}`;
+  }
+  if (mode === ChallengeMode.TOB_ENTRY) {
+    return `ToB entry ${scaleName}`;
+  }
+
+  return `ToB ${scaleName}`;
+}
+
+type QuickStats = {
+  recordings: number;
+  completions: number;
+  timeRecorded: string;
+};
+
+type WeekActivity = {
+  type: ChallengeType;
+  mode: ChallengeMode;
+  scale: number;
+  count: number;
+};
+
+type WelcomeStatsProps = {
+  username: string;
+  stats: QuickStats;
+  lastChallenge: ChallengeOverview | null;
+  thisWeek: WeekActivity[];
+};
+
+export default function WelcomeStats({
+  username,
+  stats,
+  lastChallenge,
+  thisWeek,
+}: WelcomeStatsProps) {
+  const welcome = stats.recordings > 0 ? 'Welcome back' : 'Welcome to Blert';
+
+  return (
+    <div className={styles.welcomeStats}>
+      <div className={styles.welcomeMain}>
+        <div className={styles.welcomeText}>
+          <h1>
+            {welcome}, {username}
+          </h1>
+          <p className={styles.subtitle}>Your activity at a glance</p>
+        </div>
+        <div className={styles.quickStats}>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{stats.recordings}</span>
+            <span className={styles.statLabel}>Challenges</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{stats.completions}</span>
+            <span className={styles.statLabel}>Completions</span>
+          </div>
+          <div className={styles.stat}>
+            <span className={styles.statValue}>{stats.timeRecorded}</span>
+            <span className={styles.statLabel}>Time Played</span>
+          </div>
+        </div>
+      </div>
+      <div className={styles.welcomeBottom}>
+        {lastChallenge !== null && (
+          <div className={styles.lastChallenge}>
+            <div className={styles.sectionHeader}>
+              <i className="fas fa-clock-rotate-left" />
+              <span>Last Challenge</span>
+            </div>
+            <Link
+              href={challengeUrl(lastChallenge.type, lastChallenge.uuid)}
+              className={styles.lastChallengeContent}
+            >
+              <div className={styles.challengeTop}>
+                <span className={styles.challengeType}>
+                  {formatChallengeName(
+                    lastChallenge.type,
+                    lastChallenge.scale,
+                    lastChallenge.mode,
+                  )}
+                </span>
+                <span className={styles.challengeTime}>
+                  {ticksToFormattedSeconds(lastChallenge.challengeTicks)}
+                </span>
+              </div>
+              <div className={styles.challengeBottom}>
+                <span className={styles.challengeDate}>
+                  {lastChallenge.startTime.toLocaleDateString()}
+                </span>
+                <span className={styles.viewChallenge}>
+                  View <i className="fas fa-arrow-right" />
+                </span>
+              </div>
+            </Link>
+          </div>
+        )}
+        <div className={styles.thisWeek}>
+          <div className={styles.sectionHeader}>
+            <i className="fas fa-calendar-week" />
+            <span>This Week</span>
+          </div>
+          <div className={styles.thisWeekContent}>
+            {thisWeek.length > 0 ? (
+              thisWeek.map((activity, i) => (
+                <div key={i} className={styles.activityCard}>
+                  <Image
+                    src={challengeLogo(activity.type)}
+                    alt=""
+                    width={24}
+                    height={24}
+                    className={styles.activityIcon}
+                  />
+                  <div className={styles.activityInfo}>
+                    <span className={styles.activityName}>
+                      {formatChallengeName(
+                        activity.type,
+                        activity.scale,
+                        activity.mode,
+                      )}
+                    </span>
+                    <span className={styles.activityCount}>
+                      {activity.count} {activity.count === 1 ? 'run' : 'runs'}
+                    </span>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className={styles.noActivity}>
+                <i className="fas fa-person-running" />
+                <span>Time to get some raids in!</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/players/[username]/follow-button.tsx
+++ b/web/app/players/[username]/follow-button.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+
+import { followPlayer, unfollowPlayer } from '@/actions/feed';
+import { useToast } from '@/components/toast';
+
+import styles from './style.module.scss';
+
+type FollowButtonProps = {
+  playerId: number;
+  username: string;
+  isFollowing: boolean;
+  isSignedIn: boolean;
+};
+
+export default function FollowButton({
+  playerId,
+  username,
+  isFollowing: initialIsFollowing,
+  isSignedIn,
+}: FollowButtonProps) {
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const showToast = useToast();
+
+  if (!isSignedIn) {
+    return null;
+  }
+
+  const handleClick = async () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+    const previousState = isFollowing;
+
+    setIsFollowing(!isFollowing);
+
+    try {
+      if (previousState) {
+        await unfollowPlayer(playerId);
+      } else {
+        await followPlayer(username);
+      }
+    } catch {
+      setIsFollowing(previousState);
+      showToast('Failed to update follow status. Please try again.', 'error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getButtonContent = () => {
+    if (isLoading) {
+      return <i className="fas fa-spinner fa-spin" />;
+    }
+
+    if (isFollowing) {
+      if (isHovered) {
+        return (
+          <>
+            <i className="fas fa-user-minus" />
+            <span>Unfollow</span>
+          </>
+        );
+      }
+      return (
+        <>
+          <i className="fas fa-user-check" />
+          <span>Following</span>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <i className="fas fa-user-plus" />
+        <span>Follow</span>
+      </>
+    );
+  };
+
+  return (
+    <button
+      className={`${styles.followButton} ${isFollowing ? styles.following : ''}`}
+      onClick={() => void handleClick()}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      disabled={isLoading}
+    >
+      {getButtonContent()}
+    </button>
+  );
+}

--- a/web/app/players/[username]/style.module.scss
+++ b/web/app/players/[username]/style.module.scss
@@ -49,6 +49,20 @@ $NAV_MARGIN: 10px;
     flex: 1;
     min-width: 0;
 
+    .nameRow {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+
+      h1 {
+        font-size: 2.4em;
+        margin: 0;
+        color: var(--blert-font-color-primary);
+      }
+    }
+
     h1 {
       font-size: 2.4em;
       margin: 0 0 16px 0;
@@ -86,6 +100,88 @@ $NAV_MARGIN: 10px;
         }
       }
     }
+  }
+}
+
+.followButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background: linear-gradient(
+    135deg,
+    var(--blert-purple) 0%,
+    rgba(var(--blert-purple-base), 0.85) 100%
+  );
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(var(--blert-purple-base), 0.3);
+
+  & > span {
+    position: relative;
+    top: -1px;
+    min-width: 70px;
+  }
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(var(--blert-purple-base), 0.4);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  &.following {
+    background: rgba(var(--blert-green-base), 0.15);
+    color: var(--blert-green);
+    border: 1px solid rgba(var(--blert-green-base), 0.3);
+    box-shadow: none;
+
+    &:hover:not(:disabled) {
+      background: rgba(var(--blert-red-base), 0.15);
+      border-color: rgba(var(--blert-red-base), 0.4);
+      color: var(--blert-red);
+      transform: none;
+      box-shadow: none;
+
+      i {
+        color: var(--blert-red);
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(var(--blert-green-base), 0.5);
+      outline-offset: 2px;
+    }
+
+    &:hover:focus-visible {
+      outline-color: rgba(var(--blert-red-base), 0.5);
+    }
+
+    i {
+      color: var(--blert-green);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(var(--blert-purple-base), 0.5);
+    outline-offset: 2px;
+  }
+
+  i {
+    font-size: 0.95em;
   }
 }
 
@@ -175,6 +271,16 @@ $NAV_MARGIN: 10px;
     }
 
     .playerInfoText {
+      .nameRow {
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+
+        h1 {
+          font-size: 2em;
+        }
+      }
+
       h1 {
         font-size: 2em;
         margin-bottom: 12px;


### PR DESCRIPTION
Allows users to follow players and get a feed of their activity, showing their sessions, PBs, and name changes. Creates a feed API route and a dashboard page which renders a player's feed with infinite scroll. Additionally, adds a simple activity summary to the top of the dashboard with onboarding steps for new users.