### PR TITLE
Fix expanded session challenge table on mobile

### DIFF
--- a/web/app/sessions/components/challenge-analysis.tsx
+++ b/web/app/sessions/components/challenge-analysis.tsx
@@ -411,7 +411,7 @@ function StatisticsDisplay({
   data: AggregatedData;
   selectedStat: StatOption;
 }) {
-  const formatter = selectedStat.formatter ?? ((value) => value.toString());
+  const formatter = selectedStat.formatter ?? ((value) => value.toFixed(2));
 
   return (
     <div className={styles.statisticsGrid}>

--- a/web/app/sessions/components/challenges-table.module.scss
+++ b/web/app/sessions/components/challenges-table.module.scss
@@ -308,6 +308,10 @@
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     padding: 1rem;
+    width: fit-content;
+    max-width: calc(100vw - 4rem);
+    position: sticky;
+    left: 6px;
   }
 }
 
@@ -327,6 +331,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  min-width: 0;
 }
 
 .detailLabel {
@@ -342,6 +347,8 @@
   font-weight: 500;
   color: var(--blert-font-color-primary);
   font-family: var(--font-roboto-mono), monospace;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .splitsSection {
@@ -658,6 +665,8 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     gap: 0.25rem;
@@ -720,8 +729,18 @@
   }
 }
 
+.playerDeaths {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.5rem;
+  font-weight: 500;
+  color: var(--blert-font-color-primary);
+  font-family: var(--font-roboto-mono), monospace;
+}
+
 .playerDeath {
   color: var(--blert-font-color-primary);
+  white-space: nowrap;
 }
 
 .detailLabel {

--- a/web/app/sessions/components/challenges-table.tsx
+++ b/web/app/sessions/components/challenges-table.tsx
@@ -182,14 +182,13 @@ function ExpandedChallengeDetails({
             <i className="fas fa-skull" />
             Player Deaths
           </span>
-          <span className={styles.detailValue}>
-            {Object.entries(playerDeaths).map(([username, deaths], index) => (
+          <div className={styles.playerDeaths}>
+            {Object.entries(playerDeaths).map(([username, deaths]) => (
               <span key={username} className={styles.playerDeath}>
                 {username}: {deaths}
-                {index < Object.entries(playerDeaths).length - 1 && ', '}
               </span>
             ))}
-          </span>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Constrain the expanded details container to viewport width and make it sticky so it stays visible when the table is horizontally scrolled. Also fix player deaths to wrap properly instead of overflowing.