### PR TITLE
Check if stage is processed before pushing events

### DIFF
--- a/common/db/redis.ts
+++ b/common/db/redis.ts
@@ -208,6 +208,24 @@ export function challengeStreamsSetKey(uuid: string) {
   return `challenge-streams:${uuid}`;
 }
 
+/**
+ * Returns the Redis key for the processed stages set for a challenge.
+ * @param uuid ID of the challenge.
+ */
+export function challengeProcessedStagesKey(uuid: string) {
+  return `challenge:${uuid}:processed-stages`;
+}
+
+/**
+ * Returns the identifier for a stage attempt stored in the processed stages
+ * set.
+ * @param stage Stage of the challenge.
+ * @param attempt Attempt number of the stage, if any.
+ */
+export function stageAttemptKey(stage: Stage, attempt: number | null): string {
+  return `${String(stage)}${attempt !== null ? `:${attempt}` : ''}`;
+}
+
 export function stageStreamToRecord(
   event: ClientStageStream,
 ): Record<string, string | Buffer> {

--- a/common/index.ts
+++ b/common/index.ts
@@ -202,6 +202,7 @@ export {
   type StageStreamEvents,
   type StageUpdate,
   activePlayerKey,
+  challengeProcessedStagesKey,
   challengeStreamsSetKey,
   challengeStageStreamKey,
   challengesKey,
@@ -209,6 +210,7 @@ export {
   partyHash,
   partyKeyChallengeList,
   sessionKey,
+  stageAttemptKey,
   stageStreamFromRecord,
   stageStreamToRecord,
 } from './db/redis';


### PR DESCRIPTION
Updates the socket server to check wehther thechallenge server has already processed a stage via Redis before pushing stream events.

If a stage has already been processed, its stream will no longer be read by the challenge server, which could cause orphaned data in Redis. This change ensures that data will not be written in these cases.