### PR TITLE
Poll active session status in feed

### DIFF
--- a/web/app/api/v1/sessions/status/route.ts
+++ b/web/app/api/v1/sessions/status/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from 'next/server';
+
+import { getSessionStatuses } from '@/actions/challenge';
+
+export async function GET(request: NextRequest) {
+  const uuids = request.nextUrl.searchParams.get('uuids');
+  if (uuids === null || uuids === '') {
+    return Response.json([]);
+  }
+
+  const uuidList = uuids.split(',');
+  const statuses = await getSessionStatuses(uuidList);
+  return Response.json(statuses);
+}

--- a/web/app/leaderboards/[challenge]/[[...options]]/leaderboard.tsx
+++ b/web/app/leaderboards/[challenge]/[[...options]]/leaderboard.tsx
@@ -154,7 +154,9 @@ function TieBadge({ rank, rankIndex, challengeType, mode }: TieBadgeProps) {
       >
         <div className={styles.popoverHeader}>
           <i className="fas fa-users" />
-          <span>{tieCount} other challenges with this time</span>
+          <span>
+            {tieCount} other challenge{tieCount !== 1 ? 's' : ''} with this time
+          </span>
         </div>
         <div className={styles.popoverList}>
           {displayedTeams.map((team) => (


### PR DESCRIPTION
Updates the feed to poll all currently active sessions to check if they have ended so that it can render them as finished without a page refresh.