### PR TITLE
Allow expanding timeline on boss pages

### DIFF
--- a/web/app/components/attack-timeline/style.module.scss
+++ b/web/app/components/attack-timeline/style.module.scss
@@ -70,7 +70,7 @@
     width: 100%;
 
     &:not(:first-child) {
-      margin-top: 56px;
+      margin-top: 61px;
     }
   }
 

--- a/web/app/components/boss-page-attack-timeline/styles.module.scss
+++ b/web/app/components/boss-page-attack-timeline/styles.module.scss
@@ -10,7 +10,6 @@
     button {
       margin: 0 0 0 auto;
       text-align: center;
-      width: 100px;
       font-size: 16px;
       transition: all 0.2s ease;
       color: var(--blert-purple);
@@ -21,6 +20,16 @@
 
       i {
         margin-right: 5px;
+
+        @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+          margin-right: 0;
+        }
+      }
+
+      span {
+        @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+          display: none;
+        }
       }
     }
   }
@@ -31,11 +40,17 @@
   padding: 4px 0;
 }
 
+.fullScreenModal {
+  max-height: 95vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .timelineModal {
   @include styledScrollbar;
 
   width: 100%;
-  max-height: 90vh;
+  flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/web/app/components/modal/modal.tsx
+++ b/web/app/components/modal/modal.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 type ModalProps = {
   children: React.ReactNode;
   className?: string;
+  header?: string;
   onClose: () => void;
   open: boolean;
   width?: number | string;
@@ -106,6 +107,15 @@ export function Modal(props: ModalProps) {
 
   return createPortal(
     <div className={className} ref={modalRef} style={{ width: props.width }}>
+      {props.header !== undefined && (
+        <div className={styles.header}>
+          <h2>{props.header}</h2>
+          <button onClick={onClose}>
+            <i className="fas fa-times" />
+            <span className="sr-only">Close</span>
+          </button>
+        </div>
+      )}
       {props.children}
     </div>,
     modalPortal.current,

--- a/web/app/components/modal/style.module.scss
+++ b/web/app/components/modal/style.module.scss
@@ -24,6 +24,40 @@
     transition:
       transform 0.2s ease,
       opacity 0.2s ease;
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 20px 24px;
+      border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
+      background: linear-gradient(
+        135deg,
+        var(--blert-panel-background-color) 0%,
+        rgba(var(--blert-surface-dark-base), 0.8) 100%
+      );
+
+      h2 {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--blert-font-color-primary);
+      }
+
+      button {
+        background: none;
+        border: none;
+        padding: 8px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        font-size: 16px;
+        color: var(--blert-font-color-secondary);
+
+        &:hover {
+          color: var(--blert-font-color-primary);
+        }
+      }
+    }
   }
 
   &.closing .modal {

--- a/web/app/setups/[id]/edit/setup-creator.tsx
+++ b/web/app/setups/[id]/edit/setup-creator.tsx
@@ -982,14 +982,12 @@ function KeyboardShortcutsModal({
   ];
 
   return (
-    <Modal className={styles.shortcutsModal} open={open} onClose={onClose}>
-      <div className={styles.modalHeader}>
-        <h2>Keyboard Shortcuts</h2>
-        <button onClick={onClose}>
-          <i className="fas fa-times" />
-          <span className="sr-only">Close</span>
-        </button>
-      </div>
+    <Modal
+      className={styles.shortcutsModal}
+      header="Keyboard Shortcuts"
+      open={open}
+      onClose={onClose}
+    >
       <div className={styles.shortcutsContent}>
         {shortcuts.map((category) => (
           <div key={category.category} className={styles.shortcutCategory}>

--- a/web/app/setups/[id]/edit/style.module.scss
+++ b/web/app/setups/[id]/edit/style.module.scss
@@ -772,62 +772,6 @@
     border-radius: 0;
   }
 
-  .modalHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1.5rem;
-    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
-    background: linear-gradient(
-      135deg,
-      var(--blert-panel-background-color) 0%,
-      rgba(var(--blert-surface-dark-base), 0.8) 100%
-    );
-
-    h2 {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      margin: 0;
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--blert-font-color-primary);
-
-      i {
-        color: var(--blert-purple);
-        font-size: 1.25rem;
-      }
-
-      @media (max-width: 940px) {
-        font-size: 1.25rem;
-
-        i {
-          font-size: 1.1rem;
-        }
-      }
-    }
-
-    button {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 36px;
-      height: 36px;
-      background: none;
-      border: none;
-      border-radius: 6px;
-      color: var(--blert-font-color-secondary);
-      font-size: 1.25rem;
-      cursor: pointer;
-      transition: all 0.2s ease;
-
-      &:hover {
-        background: var(--blert-surface-dark);
-        color: var(--blert-red);
-      }
-    }
-  }
-
   .publishDialog {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Adds a user setting to expand the room timeline inline on a boss page for viewing the full timeline without opening a modal.