### PR TITLE
Track events beyond recorded tick count

### DIFF
--- a/socket-server/__tests__/json-converter.test.ts
+++ b/socket-server/__tests__/json-converter.test.ts
@@ -770,6 +770,22 @@ describe('jsonToServerMessage', () => {
       expect(conf?.getPartyList()).toEqual(['Player1', 'Player2']);
     });
 
+    it('converts minimal invalid challenge state confirmation', () => {
+      const json: ServerMessageJson = {
+        type: ServerMessage.Type.CHALLENGE_STATE_CONFIRMATION,
+        challengeStateConfirmation: {
+          isValid: false,
+        },
+      };
+
+      const proto = jsonToServerMessage(json);
+      const conf = proto.getChallengeStateConfirmation();
+
+      expect(conf?.getIsValid()).toBe(false);
+      expect(conf?.getUsername()).toBe('');
+      expect(conf?.getPartyList()).toEqual([]);
+    });
+
     it('converts recent recordings from JSON', () => {
       const json: ServerMessageJson = {
         type: ServerMessage.Type.HISTORY_RESPONSE,

--- a/socket-server/protocol/json-converter.ts
+++ b/socket-server/protocol/json-converter.ts
@@ -139,12 +139,24 @@ function serverMessageJsonToProto(json: ServerMessageJson): ServerMessage {
   if (json.challengeStateConfirmation !== undefined) {
     const conf = new ServerMessage.ChallengeStateConfirmation();
     conf.setIsValid(json.challengeStateConfirmation.isValid);
-    conf.setUsername(json.challengeStateConfirmation.username);
-    conf.setChallenge(json.challengeStateConfirmation.challenge as AnyEnum);
-    conf.setMode(json.challengeStateConfirmation.mode as AnyEnum);
-    conf.setStage(json.challengeStateConfirmation.stage as AnyEnum);
-    conf.setPartyList(json.challengeStateConfirmation.party);
-    conf.setSpectator(json.challengeStateConfirmation.spectator);
+    if (json.challengeStateConfirmation.username !== undefined) {
+      conf.setUsername(json.challengeStateConfirmation.username);
+    }
+    if (json.challengeStateConfirmation.challenge !== undefined) {
+      conf.setChallenge(json.challengeStateConfirmation.challenge as AnyEnum);
+    }
+    if (json.challengeStateConfirmation.mode !== undefined) {
+      conf.setMode(json.challengeStateConfirmation.mode as AnyEnum);
+    }
+    if (json.challengeStateConfirmation.stage !== undefined) {
+      conf.setStage(json.challengeStateConfirmation.stage as AnyEnum);
+    }
+    if (json.challengeStateConfirmation.party !== undefined) {
+      conf.setPartyList(json.challengeStateConfirmation.party);
+    }
+    if (json.challengeStateConfirmation.spectator !== undefined) {
+      conf.setSpectator(json.challengeStateConfirmation.spectator);
+    }
     msg.setChallengeStateConfirmation(conf);
   }
 

--- a/socket-server/protocol/json-schemas.ts
+++ b/socket-server/protocol/json-schemas.ts
@@ -82,12 +82,12 @@ export const playerStateSchema = z.object({
 // ServerMessage.ChallengeStateConfirmation
 export const challengeStateConfirmationSchema = z.object({
   isValid: z.boolean(),
-  username: z.string(),
-  challenge: enumValueSchema,
-  mode: enumValueSchema,
-  stage: enumValueSchema,
-  party: z.array(z.string()),
-  spectator: z.boolean(),
+  username: z.string().optional(),
+  challenge: enumValueSchema.optional(),
+  mode: enumValueSchema.optional(),
+  stage: enumValueSchema.optional(),
+  party: z.array(z.string()).optional(),
+  spectator: z.boolean().optional(),
 });
 
 // ChallengeStartRequest


### PR DESCRIPTION
If a client sends events greater than its recorded tick count, ignore them and flag the client as anomalous. Additionally, don't allow a single bad client to stop a stage merge.

On the socket server, corrects stage confirmation events received from the client to not require any fields except `isValid`.