### PR TITLE
Identify connected clients via API key

### DIFF
--- a/challenge-server/api.ts
+++ b/challenge-server/api.ts
@@ -124,6 +124,7 @@ async function challengeApiHandler(
 
 type NewChallengeRequest = {
   userId: number;
+  clientId: number;
   type: ChallengeType;
   mode: ChallengeMode;
   stage: Stage;
@@ -138,10 +139,11 @@ async function newChallenge(req: Request, res: Response): Promise<void> {
     req,
     res,
     '/challenges/new',
-    { userId: request.userId, action: 'new' },
+    { userId: request.userId, clientId: request.clientId, action: 'new' },
     async () => {
       const result = await res.locals.challengeManager.createOrJoin(
         request.userId,
+        request.clientId,
         request.type,
         request.mode,
         request.stage,
@@ -155,6 +157,7 @@ async function newChallenge(req: Request, res: Response): Promise<void> {
 
 type UpdateChallengeRequest = {
   userId: number;
+  clientId: number;
   update: ChallengeUpdate;
 };
 
@@ -166,11 +169,17 @@ async function updateChallenge(req: Request, res: Response): Promise<void> {
     req,
     res,
     '/challenges/:challengeId',
-    { challengeUuid: challengeId, userId: request.userId, action: 'update' },
+    {
+      challengeUuid: challengeId,
+      userId: request.userId,
+      clientId: request.clientId,
+      action: 'update',
+    },
     async () => {
       const result = await res.locals.challengeManager.update(
         challengeId,
         request.userId,
+        request.clientId,
         request.update,
       );
       if (result === null) {
@@ -184,6 +193,7 @@ async function updateChallenge(req: Request, res: Response): Promise<void> {
 
 type FinishChallengeRequest = {
   userId: number;
+  clientId: number;
   times: ReportedTimes | null;
   soft: boolean;
 };
@@ -196,11 +206,17 @@ async function finishChallenge(req: Request, res: Response): Promise<void> {
     req,
     res,
     '/challenges/:challengeId/finish',
-    { challengeUuid: challengeId, userId: request.userId, action: 'finish' },
+    {
+      challengeUuid: challengeId,
+      userId: request.userId,
+      clientId: request.clientId,
+      action: 'finish',
+    },
     async () => {
       await res.locals.challengeManager.finish(
         challengeId,
         request.userId,
+        request.clientId,
         request.times,
         request.soft,
       );
@@ -211,6 +227,7 @@ async function finishChallenge(req: Request, res: Response): Promise<void> {
 
 type JoinChallengeRequest = {
   userId: number;
+  clientId: number;
   recordingType: RecordingType;
 };
 
@@ -222,11 +239,17 @@ async function joinChallenge(req: Request, res: Response): Promise<void> {
     req,
     res,
     '/challenges/:challengeId/join',
-    { challengeUuid: challengeId, userId: request.userId, action: 'join' },
+    {
+      challengeUuid: challengeId,
+      userId: request.userId,
+      clientId: request.clientId,
+      action: 'join',
+    },
     async () => {
       const status = await res.locals.challengeManager.addClient(
         challengeId,
         request.userId,
+        request.clientId,
         request.recordingType,
       );
       res.json(status);

--- a/common/db/redis.ts
+++ b/common/db/redis.ts
@@ -144,6 +144,7 @@ export enum ClientStatus {
 export type ClientEvent = {
   type: ClientEventType;
   userId: number;
+  clientId: number;
 };
 
 export type ClientStatusEvent = ClientEvent & {

--- a/common/migrations/20260207232603-add-unique-constraint-to-recorded-challenges.ts
+++ b/common/migrations/20260207232603-add-unique-constraint-to-recorded-challenges.ts
@@ -1,0 +1,9 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    ALTER TABLE recorded_challenges
+    ADD CONSTRAINT uq_recorded_challenges_challenge_recorder
+    UNIQUE (challenge_id, recorder_id)
+  `;
+}

--- a/common/user.ts
+++ b/common/user.ts
@@ -12,14 +12,13 @@ export type User = {
   createdAt: Date;
   email: string;
   emailVerified: boolean;
-
-  // TODO(frolv): This is temporary for controlling initial access to the API.
   canCreateApiKey: boolean;
-
   discordId: string | null;
   discordUsername: string | null;
 };
 
+// The ordering in this enum is significant as it is used for prioritization in
+// the database.
 export enum RecordingType {
   SPECTATOR = 0,
   PARTICIPANT = 1,

--- a/socket-server/client.ts
+++ b/socket-server/client.ts
@@ -208,6 +208,14 @@ export default class Client {
   }
 
   /**
+   * Returns a stable unique identifier for the client.
+   * @returns The client ID.
+   */
+  public getClientId(): number {
+    return this.user.keyId;
+  }
+
+  /**
    * Returns the username of this client's user.
    * @returns The user's name.
    */
@@ -421,6 +429,7 @@ export default class Client {
   private logContext(extra?: Record<string, unknown>): Record<string, unknown> {
     return {
       userId: this.user.id,
+      clientId: this.getClientId(),
       username: this.user.username,
       sessionId: this.sessionId,
       loggedInRsn: this.loggedInRsn ?? undefined,

--- a/socket-server/remote-challenge-manager.ts
+++ b/socket-server/remote-challenge-manager.ts
@@ -83,6 +83,7 @@ export class RemoteChallengeManager extends ChallengeManager {
       },
       body: JSON.stringify({
         userId: client.getUserId(),
+        clientId: client.getClientId(),
         type: challengeType,
         mode,
         party,
@@ -129,6 +130,7 @@ export class RemoteChallengeManager extends ChallengeManager {
           },
           body: JSON.stringify({
             userId: client.getUserId(),
+            clientId: client.getClientId(),
             times,
             soft,
           }),
@@ -171,7 +173,7 @@ export class RemoteChallengeManager extends ChallengeManager {
           if (canWrite) {
             const endEvent: StageStreamEnd = {
               type: StageStreamType.STAGE_END,
-              clientId: client.getUserId(),
+              clientId: client.getClientId(),
               update: update.stage,
             };
             const streamKey = challengeStageStreamKey(
@@ -198,6 +200,7 @@ export class RemoteChallengeManager extends ChallengeManager {
         },
         body: JSON.stringify({
           userId: client.getUserId(),
+          clientId: client.getClientId(),
           update,
         }),
       });
@@ -333,7 +336,7 @@ export class RemoteChallengeManager extends ChallengeManager {
 
       const eventsStream: StageStreamEvents = {
         type: StageStreamType.STAGE_EVENTS,
-        clientId: client.getUserId(),
+        clientId: client.getClientId(),
         events: eventsMessage.serializeBinary(),
       };
       const streamKey = challengeStageStreamKey(challengeId, stage, attempt);
@@ -364,6 +367,7 @@ export class RemoteChallengeManager extends ChallengeManager {
           },
           body: JSON.stringify({
             userId: client.getUserId(),
+            clientId: client.getClientId(),
             recordingType,
           }),
         },
@@ -392,6 +396,7 @@ export class RemoteChallengeManager extends ChallengeManager {
     const event: ClientStatusEvent = {
       type: ClientEventType.STATUS,
       userId: client.getUserId(),
+      clientId: client.getClientId(),
       status,
     };
 

--- a/socket-server/users.ts
+++ b/socket-server/users.ts
@@ -11,6 +11,7 @@ import { Players } from './players';
 
 export type BasicUser = {
   id: number;
+  keyId: number;
   username: string;
   linkedPlayerId: number;
 };
@@ -32,11 +33,12 @@ export class Users {
    * @returns The user's basic information, or null if the key is invalid.
    */
   static async findByApiKey(apiKey: string): Promise<BasicUser | null> {
-    const [key]: [{ user_id: number; player_id: number }?] = await sql`
+    const [key]: [{ id: number; user_id: number; player_id: number }?] =
+      await sql`
       UPDATE api_keys
       SET last_used = NOW()
       WHERE key = ${apiKey}
-      RETURNING user_id, player_id;
+      RETURNING id, user_id, player_id;
     `;
 
     if (key === undefined) {
@@ -57,6 +59,7 @@ export class Users {
 
     return {
       id: key.user_id,
+      keyId: key.id,
       username: user.username,
       linkedPlayerId: key.player_id,
     };


### PR DESCRIPTION
Previously, clients in active challenges were identified by their user's ID. This limited users to only having a single account recording at a time. However, many users have multiple OSRS accounts, which should all be allowed to record.

This updates client identification in the challenge server to use the connected client's API key ID instead of its user ID. API keys are uniquely linked to OSRS accounts, so this change permits multiple OSRS accounts from the same user to be connected, record at the same time, and even in the same challenge.