### PR TITLE
Increase user API key limit and improve form

### DIFF
--- a/web/app/settings/api-keys/api-key-form.tsx
+++ b/web/app/settings/api-keys/api-key-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState } from 'react';
+import { useActionState, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
 import {
@@ -13,8 +13,13 @@ import Input from '@/components/input';
 
 import styles from '../style.module.scss';
 
-function FormFields() {
+function FormFields({ existingPlayers }: { existingPlayers: Set<string> }) {
   const { pending } = useFormStatus();
+
+  const [rsn, setRsn] = useState('');
+
+  const existingKey = existingPlayers.has(rsn.toLowerCase().trim());
+  const canSubmit = rsn.length > 0 && !existingKey;
 
   return (
     <>
@@ -27,8 +32,12 @@ function FormFields() {
         maxLength={12}
         required
         faIcon="fa-solid fa-user"
+        value={rsn}
+        onChange={(e) => setRsn(e.target.value)}
+        invalid={existingKey}
+        errorMessage="You already have an API key for this player"
       />
-      <Button loading={pending} type="submit" fluid>
+      <Button disabled={!canSubmit} loading={pending} type="submit" fluid>
         Generate API key
       </Button>
     </>
@@ -37,8 +46,10 @@ function FormFields() {
 
 export default function ApiKeyForm({
   onApiKeyGenerated,
+  existingPlayers,
 }: {
   onApiKeyGenerated: (apiKey: ApiKeyWithUsername) => void;
+  existingPlayers: Set<string>;
 }) {
   const [state, formAction] = useActionState(
     async (formState: ApiKeyFormState, formData: FormData) =>
@@ -53,7 +64,7 @@ export default function ApiKeyForm({
 
   return (
     <form action={formAction}>
-      <FormFields />
+      <FormFields existingPlayers={existingPlayers} />
       {state.error && <p className={styles.error}>{state.error}</p>}
     </form>
   );

--- a/web/app/settings/api-keys/api-keys-section.tsx
+++ b/web/app/settings/api-keys/api-keys-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ApiKeyWithUsername } from '@/actions/users';
 
@@ -17,6 +17,10 @@ export default function ApiKeysSection({
   initialApiKeys,
 }: ApiKeysSectionProps) {
   const [apiKeys, setApiKeys] = useState(initialApiKeys);
+  const existingPlayers = useMemo(
+    () => new Set(apiKeys.map((key) => key.rsn.toLowerCase())),
+    [apiKeys],
+  );
 
   const handleDelete = (deletedKey: ApiKeyWithUsername) => {
     setApiKeys(apiKeys.filter((key) => key.id !== deletedKey.id));
@@ -55,6 +59,7 @@ export default function ApiKeysSection({
         <h3>Generate new API key</h3>
         <ApiKeyForm
           onApiKeyGenerated={(key) => setApiKeys((prev) => [...prev, key])}
+          existingPlayers={existingPlayers}
         />
       </div>
     </section>


### PR DESCRIPTION
Updates the API key form to show an error state if the user already has a key associated with the entered RSN, and rejects duplicate RSNs on the backend.