### PR TITLE
Add split distributions MV and endpoint

### DIFF
--- a/common/migrations/20260209065709-create-split-distributions-mv.ts
+++ b/common/migrations/20260209065709-create-split-distributions-mv.ts
@@ -1,0 +1,59 @@
+import { Sql } from 'postgres';
+
+import { ChallengeType } from '../challenge';
+import { SplitType } from '../split';
+
+// 1-down bloat threshold in ticks.
+const SPEEDRUN_BLOAT_THRESHOLD = 100;
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE TYPE split_tier AS ENUM ('standard', 'speedrun')
+  `;
+
+  // Use sql.unsafe() because CREATE MATERIALIZED VIEW does not support
+  // bound parameters.
+  await sql.unsafe(`
+    CREATE MATERIALIZED VIEW split_distributions AS
+    WITH challenge_quality AS (
+      SELECT c.id,
+        CASE
+          WHEN c.type = ${ChallengeType.TOB} AND c.scale >= 3 AND EXISTS (
+            SELECT 1 FROM challenge_splits bloat
+            WHERE bloat.challenge_id = c.id
+              AND bloat.type IN (${SplitType.TOB_REG_BLOAT}, ${SplitType.TOB_HM_BLOAT})
+              AND bloat.ticks < ${SPEEDRUN_BLOAT_THRESHOLD}
+              AND bloat.accurate
+          ) THEN 'speedrun'::split_tier
+          ELSE 'standard'::split_tier
+        END AS tier
+      FROM challenges c
+      WHERE c.start_time >= NOW() - INTERVAL '6 months'
+    ),
+    cutoffs AS (
+      SELECT cs.type, cs.scale, cq.tier,
+        PERCENTILE_DISC(0.9) WITHIN GROUP (ORDER BY cs.ticks) AS cutoff_ticks
+      FROM challenge_splits cs
+      JOIN challenge_quality cq ON cq.id = cs.challenge_id
+      WHERE cs.accurate
+      GROUP BY cs.type, cs.scale, cq.tier
+    )
+    SELECT cs.type, cs.scale, cq.tier, cs.ticks, COUNT(*)::int AS count
+    FROM challenge_splits cs
+    JOIN challenge_quality cq ON cq.id = cs.challenge_id
+    LEFT JOIN cutoffs co
+      ON co.type = cs.type AND co.scale = cs.scale AND co.tier = cq.tier
+    WHERE cs.accurate
+      AND (
+        cq.tier != 'standard'
+        OR cs.ticks <= co.cutoff_ticks
+      )
+    GROUP BY cs.type, cs.scale, cq.tier, cs.ticks
+    WITH DATA
+  `);
+
+  await sql`
+    CREATE UNIQUE INDEX uix_split_distributions_pkey
+      ON split_distributions (type, scale, tier, ticks)
+  `;
+}

--- a/web/app/actions/split-distributions.ts
+++ b/web/app/actions/split-distributions.ts
@@ -1,0 +1,69 @@
+'use server';
+
+import { SplitType } from '@blert/common';
+
+import { sql } from './db';
+
+type DistributionRow = {
+  type: number;
+  ticks: number;
+  count: number;
+};
+
+export type DistributionBin = {
+  ticks: number;
+  count: number;
+};
+
+export type SplitDistribution = {
+  splitType: number;
+  bins: DistributionBin[];
+  total: number;
+};
+
+export type SplitTier = 'standard' | 'speedrun';
+
+/**
+ * Fetches split distribution data from the `split_distributions` materialized
+ * view, grouped by split type.
+ *
+ * @param types The mode-specific split types to fetch.
+ * @param scale The challenge scale.
+ * @param tier Optional tier filter.
+ * @returns Distribution data for each requested type that has data.
+ */
+export async function getSplitDistributions(
+  types: SplitType[],
+  scale: number,
+  tier?: SplitTier,
+): Promise<SplitDistribution[]> {
+  const rows = await sql<DistributionRow[]>`
+    SELECT type, ticks, SUM(count)::int AS count
+    FROM split_distributions
+    WHERE type = ANY(${types})
+      AND scale = ${scale}
+      ${tier ? sql`AND tier = ${tier}` : sql``}
+    GROUP BY type, ticks
+    ORDER BY type, ticks
+  `;
+
+  const byType = new Map<number, DistributionBin[]>();
+  const totals = new Map<number, number>();
+
+  for (const row of rows) {
+    if (!byType.has(row.type)) {
+      byType.set(row.type, []);
+      totals.set(row.type, 0);
+    }
+    byType.get(row.type)!.push({ ticks: row.ticks, count: row.count });
+    totals.set(row.type, totals.get(row.type)! + row.count);
+  }
+
+  return types
+    .filter((t) => byType.has(t))
+    .map((t) => ({
+      splitType: t,
+      bins: byType.get(t)!,
+      total: totals.get(t)!,
+    }));
+}

--- a/web/app/api/v1/splits/distributions/route.ts
+++ b/web/app/api/v1/splits/distributions/route.ts
@@ -1,0 +1,51 @@
+import { SplitType } from '@blert/common';
+import { NextRequest } from 'next/server';
+
+import { InvalidQueryError } from '@/actions/errors';
+import {
+  getSplitDistributions,
+  SplitTier,
+} from '@/actions/split-distributions';
+import { expectSingle, numericListParam, numericParam } from '@/api/query';
+
+const VALID_TIERS = ['standard', 'speedrun'];
+function isSplitTier(value: string): value is SplitTier {
+  return VALID_TIERS.includes(value);
+}
+
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const params = Object.fromEntries(request.nextUrl.searchParams);
+
+    const types = numericListParam<SplitType>(params, 'types');
+    const scale = numericParam(params, 'scale');
+
+    if (types === undefined || types.length === 0 || scale === undefined) {
+      return Response.json(
+        { error: 'Missing required parameters' },
+        { status: 400 },
+      );
+    }
+
+    if (scale < 1 || scale > 5) {
+      return Response.json({ error: 'Invalid scale' }, { status: 400 });
+    }
+
+    const tier = expectSingle(params, 'tier');
+    if (tier !== undefined && !isSplitTier(tier)) {
+      return Response.json({ error: 'Invalid tier' }, { status: 400 });
+    }
+
+    const distributions = await getSplitDistributions(types, scale, tier);
+    return Response.json(distributions, { headers: CACHE_HEADERS });
+  } catch (e) {
+    if (e instanceof InvalidQueryError) {
+      return Response.json({ error: e.message }, { status: 400 });
+    }
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Creates a materliazed view which counts all distinct split tick values and an API endpoint which queries this MV to return distributions for specific split types.