### PR TITLE
Allow importing raids into the split calculator

### DIFF
--- a/web/app/tools/split-calc/import-raids.tsx
+++ b/web/app/tools/split-calc/import-raids.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { ChallengeMode, ChallengeStatus, ChallengeType } from '@blert/common';
+import { useEffect, useRef, useState } from 'react';
+
+import { ChallengeOverview } from '@/actions/challenge';
+import { getConnectedPlayers } from '@/actions/users';
+import { scaleNameAndColor } from '@/utils/challenge';
+import { timeAgo } from '@/utils/time';
+import { queryString, UrlParams } from '@/utils/url';
+
+import { TOB_MODES, TOB_ROOMS } from './types';
+
+function modeName(mode: ChallengeMode): string {
+  return TOB_MODES.find((m) => m.mode === mode)?.label ?? 'Unknown';
+}
+
+import styles from './style.module.scss';
+
+const SPLIT_EXTRA_FIELDS = TOB_ROOMS.map((r) => `splits:${r.splitType}`);
+
+type ImportRaidsProps = {
+  mode: ChallengeMode;
+  scale: number;
+  onImport: (challenge: ChallengeOverview) => void;
+};
+
+async function fetchChallenges(
+  params: UrlParams,
+): Promise<ChallengeOverview[]> {
+  const qs = queryString(params);
+  const res = await fetch(`/api/v1/challenges?${qs}`);
+  if (!res.ok) {
+    return [];
+  }
+  return res.json() as Promise<ChallengeOverview[]>;
+}
+
+export function ImportRaids({ mode, scale, onImport }: ImportRaidsProps) {
+  const [open, setOpen] = useState(false);
+  const [raids, setRaids] = useState<ChallengeOverview[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [userRaid, setUserRaid] = useState<ChallengeOverview | null>(null);
+  const [userRaidLoading, setUserRaidLoading] = useState(true);
+  const connectedPlayersRef = useRef<string[]>([]);
+  const raidsRequestIdRef = useRef(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Try to detect user's active raid on mount.
+  useEffect(() => {
+    getConnectedPlayers()
+      .then((players) => {
+        const usernames = players.map((p) => p.username);
+        connectedPlayersRef.current = usernames.map((u) => u.toLowerCase());
+
+        return Promise.all(
+          usernames.map((username) =>
+            fetchChallenges({
+              type: ChallengeType.TOB,
+              status: ChallengeStatus.IN_PROGRESS,
+              party: username,
+              limit: 1,
+              extraFields: SPLIT_EXTRA_FIELDS,
+            }),
+          ),
+        );
+      })
+      .then((results) => {
+        const raid = results.flat()[0];
+        if (raid !== undefined) {
+          setUserRaid(raid);
+        }
+      })
+      .catch(() => {
+        // Silently ignore.
+      })
+      .finally(() => {
+        setUserRaidLoading(false);
+      });
+  }, []);
+
+  // Fetch active raids when the panel opens.
+  useEffect(() => {
+    if (!open) {
+      setLoading(false);
+      return;
+    }
+
+    const requestId = raidsRequestIdRef.current + 1;
+    raidsRequestIdRef.current = requestId;
+    let cancelled = false;
+
+    setLoading(true);
+    fetchChallenges({
+      type: ChallengeType.TOB,
+      status: ChallengeStatus.IN_PROGRESS,
+      mode: mode,
+      scale: scale,
+      limit: 10,
+      extraFields: SPLIT_EXTRA_FIELDS,
+    })
+      .then((results) => {
+        if (cancelled || raidsRequestIdRef.current !== requestId) {
+          return;
+        }
+        setRaids(results);
+      })
+      .catch(() => {
+        if (cancelled || raidsRequestIdRef.current !== requestId) {
+          return;
+        }
+        setRaids([]);
+      })
+      .finally(() => {
+        if (!cancelled && raidsRequestIdRef.current === requestId) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, mode, scale]);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function handler(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  function completedRooms(challenge: ChallengeOverview): number {
+    return TOB_ROOMS.filter((r) => {
+      const split = challenge.splits?.[r.splitType];
+      return split !== undefined && split.ticks > 0;
+    }).length;
+  }
+
+  function handleImport(challenge: ChallengeOverview) {
+    onImport(challenge);
+    setOpen(false);
+  }
+
+  const browseRaids = userRaid
+    ? raids.filter((r) => r.uuid !== userRaid.uuid)
+    : raids;
+
+  const showUserRaid = userRaid !== null && !userRaidLoading;
+
+  return (
+    <div className={styles.importContainer} ref={containerRef}>
+      <button
+        className={styles.clearButton}
+        onClick={() => setOpen(!open)}
+        type="button"
+      >
+        <i className="fas fa-file-import" /> Import
+        {showUserRaid && <span className={styles.importDot} />}
+      </button>
+      {open && (
+        <div className={styles.importPanel}>
+          {showUserRaid && (
+            <>
+              <div className={styles.importSectionLabel}>Your active raid</div>
+              <button
+                className={`${styles.importItem} ${styles.importItemUser}`}
+                onClick={() => handleImport(userRaid)}
+                type="button"
+              >
+                <span className={styles.importParty}>
+                  {userRaid.party.map((p) => p.username).join(', ')}
+                </span>
+                <span className={styles.importMeta}>
+                  {completedRooms(userRaid)}/{TOB_ROOMS.length} rooms •{' '}
+                  {timeAgo(userRaid.startTime)}
+                </span>
+              </button>
+            </>
+          )}
+          <div className={styles.importSectionLabel}>
+            Active {scaleNameAndColor(scale)[0]} {modeName(mode)} raids
+          </div>
+          {loading ? (
+            <div className={styles.importEmpty}>
+              <i className="fas fa-spinner fa-spin" /> Loading&hellip;
+            </div>
+          ) : browseRaids.length === 0 ? (
+            <div className={styles.importEmpty}>No active raids found</div>
+          ) : (
+            browseRaids.map((raid) => (
+              <button
+                key={raid.uuid}
+                className={styles.importItem}
+                onClick={() => handleImport(raid)}
+                type="button"
+              >
+                <span className={styles.importParty}>
+                  {raid.party.map((p) => p.username).join(', ')}
+                </span>
+                <span className={styles.importMeta}>
+                  {completedRooms(raid)}/{TOB_ROOMS.length} rooms •{' '}
+                  {timeAgo(raid.startTime)}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/tools/split-calc/room-input.tsx
+++ b/web/app/tools/split-calc/room-input.tsx
@@ -111,7 +111,14 @@ export function RoomInput({
           className={styles.roomImage}
         />
         {state.source === 'computed' && (
-          <span className={styles.computedLabel}>COMPUTED</span>
+          <span className={`${styles.sourceLabel} ${styles.computed}`}>
+            COMPUTED
+          </span>
+        )}
+        {state.source === 'imported' && (
+          <span className={`${styles.sourceLabel} ${styles.imported}`}>
+            IMPORTED
+          </span>
         )}
       </div>
       <div className={styles.roomInput}>

--- a/web/app/tools/split-calc/style.module.scss
+++ b/web/app/tools/split-calc/style.module.scss
@@ -88,6 +88,12 @@
   }
 }
 
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .clearButton {
   font-size: 0.8rem;
   color: var(--blert-font-color-secondary);
@@ -191,7 +197,14 @@
   }
 
   &.imported {
+    --input-label-bg: color-mix(
+      in srgb,
+      var(--blert-panel-background-color) 96%,
+      var(--blert-green)
+    );
+
     border-color: rgba(var(--blert-green-base), 0.3);
+    background: rgba(var(--blert-green-base), 0.04);
   }
 
   &.infeasible {
@@ -246,12 +259,19 @@
   width: fit-content;
 }
 
-.computedLabel {
+.sourceLabel {
   font-size: 0.6rem;
   font-weight: 700;
   letter-spacing: 0.5px;
-  color: rgba(var(--blert-purple-base), 0.6);
   text-transform: uppercase;
+
+  &.computed {
+    color: rgba(var(--blert-purple-base), 0.6);
+  }
+
+  &.imported {
+    color: rgba(var(--blert-green-base), 0.6);
+  }
 }
 
 @keyframes enterBounce {
@@ -484,4 +504,112 @@
   height: 200px;
   color: var(--blert-font-color-secondary);
   font-size: 0.9rem;
+}
+
+.importContainer {
+  position: relative;
+}
+
+.importDot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--blert-green);
+  animation: livePulse 2s ease-in-out infinite;
+}
+
+@keyframes livePulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--blert-green-base), 0.7);
+    transform: scale(1);
+    background: var(--blert-green);
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(var(--blert-green-base), 0);
+    transform: scale(1.2);
+    background: rgba(var(--blert-green-base), 0.9);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--blert-green-base), 0);
+    transform: scale(1);
+    background: var(--blert-green);
+  }
+}
+
+.importPanel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 100;
+  width: 420px;
+  max-height: 480px;
+  overflow-y: auto;
+  border-radius: 8px;
+  border: 1px solid rgba(var(--blert-surface-light-base), 0.3);
+  background: var(--blert-panel-background-color);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  padding: 4px;
+}
+
+.importSectionLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--blert-font-color-secondary);
+  padding: 8px 10px 4px;
+}
+
+.importItem {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 2px 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 6px;
+  text-align: left;
+  transition: background 0.15s ease;
+
+  &:hover {
+    cursor: pointer;
+    background: rgba(var(--blert-surface-light-base), 0.2);
+  }
+
+  &.importItemUser {
+    background: rgba(var(--blert-purple-base), 0.08);
+    border: 1px solid rgba(var(--blert-purple-base), 0.2);
+
+    &:hover {
+      background: rgba(var(--blert-purple-base), 0.15);
+    }
+  }
+}
+
+.importParty {
+  font-size: 0.85rem;
+  color: var(--blert-font-color-primary);
+}
+
+.importMeta {
+  font-size: 0.75rem;
+  color: var(--blert-font-color-secondary);
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.importEmpty {
+  padding: 16px 10px;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+
+  i {
+    margin-right: 6px;
+  }
 }

--- a/web/app/utils/time.ts
+++ b/web/app/utils/time.ts
@@ -12,3 +12,27 @@ export function formatDuration(milliseconds: number): string {
   }
   return `${mins}m`;
 }
+
+/**
+ * Formats a date as a relative time string (e.g. "5m ago", "2h ago").
+ *
+ * @param date The date to format.
+ * @returns A human-readable relative time string.
+ */
+export function timeAgo(date: string | Date): string {
+  const ms = Date.now() - new Date(date).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return 'just now';
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}


### PR DESCRIPTION
Adds an import button to the split calculator which shows active raids for the selected scale and mode. For logged-in users, also shows their current raid if they are in one. Selecting a raid loads its splits into the calculator.