### PR TITLE
Save additional ToB events as queryable events

### DIFF
--- a/challenge-server/event-processing/challenge-processor.ts
+++ b/challenge-server/event-processing/challenge-processor.ts
@@ -1419,6 +1419,45 @@ export default abstract class ChallengeProcessor {
           break;
         }
 
+        case Event.Type.TOB_XARPUS_EXHUMED: {
+          const exhumed = event.getXarpusExhumed()!;
+          const e = baseQueryableEvent(event);
+          e.tick = exhumed.getSpawnTick();
+          e[QueryableEventField.TOB_XARPUS_EXHUMED_HEAL_COUNT] =
+            exhumed.getHealTicksList().length;
+          queryableEvents.push(e);
+          break;
+        }
+
+        case Event.Type.TOB_VERZIK_BOUNCE: {
+          const bounce = event.getVerzikBounce()!;
+          const e = baseQueryableEvent(event);
+          if (bounce.hasBouncedPlayer()) {
+            const playerIndex = this.party.indexOf(bounce.getBouncedPlayer());
+            if (playerIndex !== -1) {
+              e.player_id = this.players[playerIndex].id;
+            }
+          }
+          e[QueryableEventField.TOB_VERZIK_BOUNCE_PLAYERS_IN_RANGE] =
+            bounce.getPlayersInRange();
+          e[QueryableEventField.TOB_VERZIK_BOUNCE_PLAYERS_NOT_IN_RANGE] =
+            bounce.getPlayersNotInRange();
+          queryableEvents.push(e);
+          break;
+        }
+
+        case Event.Type.TOB_VERZIK_HEAL: {
+          const heal = event.getVerzikHeal()!;
+          const e = baseQueryableEvent(event);
+          const playerIndex = this.party.indexOf(heal.getPlayer());
+          if (playerIndex !== -1) {
+            e.player_id = this.players[playerIndex].id;
+          }
+          e[QueryableEventField.TOB_VERZIK_HEAL_AMOUNT] = heal.getHealAmount();
+          queryableEvents.push(e);
+          break;
+        }
+
         case Event.Type.COLOSSEUM_SOL_GRAPPLE: {
           const grapple = event.getColosseumSolGrapple()!;
           const e = baseQueryableEvent(event);

--- a/challenge-server/event-processing/theatre.ts
+++ b/challenge-server/event-processing/theatre.ts
@@ -619,30 +619,26 @@ export default class TheatreProcessor extends ChallengeProcessor {
       case Event.Type.TOB_VERZIK_BOUNCE: {
         const bounce = event.getVerzikBounce()!;
 
-        if (bounce.getNpcAttackTick() === -1) {
-          // If the tick is -1, no one got bounced, and the event just reports
-          // the number of players who were in bounce range.
-          return false;
+        if (bounce.getNpcAttackTick() !== -1) {
+          const attack = allEvents
+            .eventsForTick(bounce.getNpcAttackTick())
+            .find(
+              (e) =>
+                e.getType() === Event.Type.NPC_ATTACK &&
+                e.getNpcAttack()!.getAttack() ===
+                  NpcAttack.TOB_VERZIK_P2_BOUNCE,
+            );
+
+          if (attack !== undefined) {
+            attack.getNpcAttack()!.setTarget(bounce.getBouncedPlayer());
+          } else {
+            logger.warn('challenge_event_missing_npc_attack', {
+              eventType: event.getType(),
+              tick: bounce.getNpcAttackTick(),
+            });
+          }
         }
-
-        const attack = allEvents
-          .eventsForTick(bounce.getNpcAttackTick())
-          .find(
-            (e) =>
-              e.getType() === Event.Type.NPC_ATTACK &&
-              e.getNpcAttack()!.getAttack() === NpcAttack.TOB_VERZIK_P2_BOUNCE,
-          );
-
-        if (attack === undefined) {
-          logger.warn('challenge_event_missing_npc_attack', {
-            eventType: event.getType(),
-            tick: bounce.getNpcAttackTick(),
-          });
-          return false;
-        }
-
-        attack.getNpcAttack()!.setTarget(bounce.getBouncedPlayer());
-        return false; // Don't write this event.
+        break;
       }
 
       case Event.Type.TOB_VERZIK_ATTACK_STYLE: {

--- a/common/data-repository/data-repository.ts
+++ b/common/data-repository/data-repository.ts
@@ -63,6 +63,7 @@ import {
   SoteMazePathEvent,
   Spell,
   SpellTarget,
+  VerzikBounceEvent,
   VerzikDawnEvent,
   VerzikHealEvent,
   VerzikPhaseEvent,
@@ -1278,10 +1279,23 @@ function eventFromProto(evt: EventProto, eventData: ChallengeEvents): Event {
     }
 
     case EventType.TOB_VERZIK_ATTACK_STYLE:
-    case EventType.TOB_VERZIK_BOUNCE:
     case EventType.COLOSSEUM_HANDICAP_CHOICE:
       // These events are not serialized to the file.
       break;
+
+    case EventType.TOB_VERZIK_BOUNCE: {
+      const verzikBounce = evt.getVerzikBounce()!;
+      const e = event as VerzikBounceEvent;
+      e.verzikBounce = {
+        npcAttackTick: verzikBounce.getNpcAttackTick(),
+        playersInRange: verzikBounce.getPlayersInRange(),
+        playersNotInRange: verzikBounce.getPlayersNotInRange(),
+      };
+      if (verzikBounce.hasBouncedPlayer()) {
+        e.verzikBounce.bouncedPlayer = verzikBounce.getBouncedPlayer();
+      }
+      break;
+    }
 
     case EventType.COLOSSEUM_TOTEM_HEAL: {
       const e = event as ColosseumTotemHealEvent;

--- a/common/db/queryable-event.ts
+++ b/common/db/queryable-event.ts
@@ -46,6 +46,13 @@ export const QueryableEventField = {
   TOB_NYLO_WAVE_NUMBER: 'custom_short_1',
   TOB_NYLO_WAVE_NYLO_COUNT: 'custom_short_2',
 
+  TOB_XARPUS_EXHUMED_HEAL_COUNT: 'custom_short_1',
+
+  TOB_VERZIK_BOUNCE_PLAYERS_IN_RANGE: 'custom_short_1',
+  TOB_VERZIK_BOUNCE_PLAYERS_NOT_IN_RANGE: 'custom_short_2',
+
+  TOB_VERZIK_HEAL_AMOUNT: 'custom_short_1',
+
   SOL_GRAPPLE_TARGET: 'custom_short_1',
   SOL_GRAPPLE_OUTCOME: 'custom_short_2',
 } as const;

--- a/common/event.ts
+++ b/common/event.ts
@@ -218,6 +218,16 @@ export interface VerzikDawnEvent extends BaseEvent {
   };
 }
 
+export interface VerzikBounceEvent extends BaseEvent {
+  type: EventType.TOB_VERZIK_BOUNCE;
+  verzikBounce: {
+    npcAttackTick: number;
+    playersInRange: number;
+    playersNotInRange: number;
+    bouncedPlayer?: string;
+  };
+}
+
 export interface VerzikYellowsEvent extends BaseEvent {
   type: EventType.TOB_VERZIK_YELLOWS;
   verzikYellows: Coords[];
@@ -367,6 +377,7 @@ export type Event =
   | XarpusPhaseEvent
   | VerzikPhaseEvent
   | VerzikAttackStyleEvent
+  | VerzikBounceEvent
   | VerzikDawnEvent
   | VerzikYellowsEvent
   | VerzikHealEvent

--- a/common/index.ts
+++ b/common/index.ts
@@ -61,6 +61,7 @@ export type {
   SoteMazePathEvent,
   Spell,
   VerzikAttackStyleEvent,
+  VerzikBounceEvent,
   VerzikDawnEvent,
   VerzikHealEvent,
   VerzikPhaseEvent,

--- a/common/migrations/20260226035321-add-composite-index-to-queryable-events.ts
+++ b/common/migrations/20260226035321-add-composite-index-to-queryable-events.ts
@@ -1,0 +1,12 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_queryable_events_challenge_type_stage_subtype
+    ON queryable_events (challenge_id, event_type, stage, subtype)
+  `;
+
+  await sql`DROP INDEX IF EXISTS idx_queryable_events_challenge_id`;
+  await sql`DROP INDEX IF EXISTS idx_queryable_events_event_type_subtype`;
+  await sql`DROP INDEX IF EXISTS idx_queryable_events_stage_mode`;
+}


### PR DESCRIPTION
Adds Xarpus splats and Verzik bounces/heals as queryable events. Requires saving Verzik bounce events, so also adds deserialization.

Additionally, replaces the queryable events indexes with a single compound one to reflect actual query patterns, where events are first scoped by challenge type/scale to be meaningful and then analyzed by type, stage, etc.