### PR TITLE
Skip checks for automatic name changes

### DIFF
--- a/socket-server/message-handler.ts
+++ b/socket-server/message-handler.ts
@@ -643,7 +643,12 @@ export default class MessageHandler {
           existingPlayerId: playerId,
           newPlayerId: playerId,
         });
-        await Players.queueNameChange(storedUsername, clientRsn, playerId);
+        await Players.queueNameChange(
+          storedUsername,
+          clientRsn,
+          playerId,
+          true,
+        );
       }
       return isValid;
     }
@@ -686,6 +691,7 @@ export default class MessageHandler {
               existingPlayer.username,
               clientRsn,
               existingPlayer.id,
+              true,
             );
           }
         } else {

--- a/socket-server/players.ts
+++ b/socket-server/players.ts
@@ -86,6 +86,7 @@ export class Players {
     oldName: string,
     newName: string,
     playerId: number,
+    skipChecks: boolean = false,
   ): Promise<void> {
     // Messages from each client are queued and processed sequentially, and it's
     // not possible to log into the same OSRS account multiple times. Therefore,
@@ -109,14 +110,16 @@ export class Players {
         new_name,
         player_id,
         status,
-        submitted_at
+        submitted_at,
+        skip_checks
       )
       VALUES (
         ${oldName},
         ${newName},
         ${playerId},
         ${NameChangeStatus.PENDING},
-        NOW()
+        NOW(),
+        ${skipChecks}
       )
     `;
   }


### PR DESCRIPTION
When a name change is auto-queued due to account hash, it's not necessary to perform further identity checks since the hash is authoratative. Sets skip_checks in these cases to avoid processing flakes from things like delayed hiscores updates.