### PR TITLE
web: Fix server action metrics

### DIFF
--- a/web/app/api/handler.ts
+++ b/web/app/api/handler.ts
@@ -17,6 +17,11 @@ type ApiRouteOptions = {
   route: string;
 };
 
+const SLOW_REQUEST_THRESHOLD_MS = parseInt(
+  process.env.BLERT_SLOW_REQUEST_THRESHOLD_MS ?? '500',
+  10,
+);
+
 const NO_PARAMS = Promise.resolve({} as Record<string, string>);
 
 export function withApiRoute(
@@ -25,6 +30,8 @@ export function withApiRoute(
 ): (req: NextRequest, ctx?: RouteHandlerContext) => Promise<Response> {
   return async (request, context) => {
     const start = process.hrtime.bigint();
+    const route = request.nextUrl.pathname;
+    const params = Object.fromEntries(request.nextUrl.searchParams);
     const method = request.method;
 
     const ctx: HandlerContext = {
@@ -49,6 +56,15 @@ export function withApiRoute(
 
       const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
       observeHttpRequest(options.route, method, response.status, durationMs);
+
+      if (durationMs > SLOW_REQUEST_THRESHOLD_MS) {
+        logger.warn('slow_api_request', {
+          route,
+          params,
+          method,
+          durationMs,
+        });
+      }
 
       return response;
     }) as Promise<Response>;

--- a/web/app/utils/metrics.ts
+++ b/web/app/utils/metrics.ts
@@ -5,8 +5,55 @@ import {
   Registry,
 } from 'prom-client';
 
-const register = new Registry();
-collectDefaultMetrics({ register });
+const REGISTRY_KEY = Symbol.for('blert.metrics.registry');
+
+type GlobalWithRegistry = typeof globalThis & {
+  [REGISTRY_KEY]: Registry;
+};
+
+function getRegistry(): Registry {
+  const g = globalThis as GlobalWithRegistry;
+  if (!g[REGISTRY_KEY]) {
+    const registry = new Registry();
+    collectDefaultMetrics({ register: registry });
+    g[REGISTRY_KEY] = registry;
+  }
+  return g[REGISTRY_KEY];
+}
+
+const register = getRegistry();
+
+function getOrCreateCounter<T extends string>(
+  args: ConstructorParameters<typeof Counter<T>>[0],
+): Counter<T> {
+  try {
+    return new Counter<T>({ ...args, registers: [register] });
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      e.message.includes('has already been registered')
+    ) {
+      return register.getSingleMetric(args.name) as Counter<T>;
+    }
+    throw e;
+  }
+}
+
+function getOrCreateHistogram<T extends string>(
+  args: ConstructorParameters<typeof Histogram<T>>[0],
+): Histogram<T> {
+  try {
+    return new Histogram<T>({ ...args, registers: [register] });
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      e.message.includes('has already been registered')
+    ) {
+      return register.getSingleMetric(args.name) as Histogram<T>;
+    }
+    throw e;
+  }
+}
 
 function sanitizeLabel(
   value: string | null | undefined,
@@ -15,19 +62,17 @@ function sanitizeLabel(
   return value?.slice(0, 64) ?? fallback;
 }
 
-const httpRequestCounter = new Counter({
+const httpRequestCounter = getOrCreateCounter({
   name: 'web_http_requests_total',
   help: 'HTTP request results',
   labelNames: ['route', 'method', 'status'] as const,
-  registers: [register],
 });
 
-const httpRequestDuration = new Histogram({
+const httpRequestDuration = getOrCreateHistogram({
   name: 'web_http_request_duration_ms',
   help: 'HTTP request latency in milliseconds',
   labelNames: ['route', 'method', 'status'] as const,
   buckets: [5, 15, 30, 60, 120, 250, 500, 1_000, 2_000, 5_000, 10_000],
-  registers: [register],
 });
 
 export function observeHttpRequest(
@@ -45,19 +90,17 @@ export function observeHttpRequest(
   httpRequestDuration.observe(labels, durationMs);
 }
 
-const serverActionCounter = new Counter({
+const serverActionCounter = getOrCreateCounter({
   name: 'web_server_action_total',
   help: 'Server action invocations',
   labelNames: ['action', 'result'] as const,
-  registers: [register],
 });
 
-const serverActionDuration = new Histogram({
+const serverActionDuration = getOrCreateHistogram({
   name: 'web_server_action_duration_ms',
   help: 'Server action latency in milliseconds',
   labelNames: ['action', 'result'] as const,
   buckets: [5, 15, 30, 60, 120, 250, 500, 1_000, 2_000, 5_000, 10_000],
-  registers: [register],
 });
 
 export function observeServerAction(
@@ -87,22 +130,20 @@ export async function withServerAction<T>(
   }
 }
 
-const redisEventsCounter = new Counter({
+const redisEventsCounter = getOrCreateCounter({
   name: 'web_redis_events_total',
   help: 'Redis client events',
   labelNames: ['type'] as const,
-  registers: [register],
 });
 
 export function recordRedisEvent(type: 'connect' | 'error'): void {
   redisEventsCounter.inc({ type });
 }
 
-const emailSendCounter = new Counter({
+const emailSendCounter = getOrCreateCounter({
   name: 'web_email_send_total',
   help: 'Email send attempts',
   labelNames: ['type', 'result'] as const,
-  registers: [register],
 });
 
 export function recordEmailSend(


### PR DESCRIPTION
Next bundles server actions as separate entry points, giving them a different instance of the metrics module. This updates the metrics registry to use a `globalThis` singleton.