### PR TITLE
common: Separate Bloat up time from walk time

### DIFF
--- a/challenge-server/event-processing/challenge-processor.ts
+++ b/challenge-server/event-processing/challenge-processor.ts
@@ -1404,7 +1404,8 @@ export default abstract class ChallengeProcessor {
           const down = event.getBloatDown()!;
           const e = baseQueryableEvent(event);
           e[QueryableEventField.TOB_BLOAT_DOWN_NUMBER] = down.getDownNumber();
-          e[QueryableEventField.TOB_BLOAT_DOWN_WALK_TIME] = down.getWalkTime();
+          e[QueryableEventField.TOB_BLOAT_DOWN_WALK_TIME] =
+            down.getUpTicks() - 1;
           queryableEvents.push(e);
           break;
         }

--- a/common/__tests__/json-converter.test.ts
+++ b/common/__tests__/json-converter.test.ts
@@ -372,6 +372,31 @@ describe('jsonToServerMessage', () => {
             yCoord: 0,
             bloatDown: {
               downNumber: 1,
+              upTicks: 32,
+            },
+          },
+        ],
+      };
+
+      const proto = jsonToServerMessage(json);
+      const down = proto.getChallengeEventsList()[0].getBloatDown();
+
+      expect(down?.getDownNumber()).toBe(1);
+      expect(down?.getUpTicks()).toBe(32);
+    });
+
+    it('converts bloat down event with legacy walkTime field', () => {
+      const json: ServerMessageJson = {
+        type: ServerMessage.Type.EVENT_STREAM,
+        challengeEvents: [
+          {
+            type: Event.Type.TOB_BLOAT_DOWN,
+            stage: 11,
+            tick: 33,
+            xCoord: 0,
+            yCoord: 0,
+            bloatDown: {
+              downNumber: 1,
               walkTime: 32,
             },
           },
@@ -382,7 +407,7 @@ describe('jsonToServerMessage', () => {
       const down = proto.getChallengeEventsList()[0].getBloatDown();
 
       expect(down?.getDownNumber()).toBe(1);
-      expect(down?.getWalkTime()).toBe(32);
+      expect(down?.getUpTicks()).toBe(32);
     });
 
     it('converts nylo wave spawn event', () => {

--- a/common/__tests__/proto-converter.test.ts
+++ b/common/__tests__/proto-converter.test.ts
@@ -355,13 +355,14 @@ describe('protoToJsonEvent', () => {
       const evt = makeEvent(EventType.TOB_BLOAT_DOWN, { stage: 11 });
       const down = new EventProto.BloatDown();
       down.setDownNumber(1);
-      down.setWalkTime(32);
+      down.setUpTicks(40);
       evt.setBloatDown(down);
 
       const result = protoToJsonEvent(evt) as BloatDownEvent;
 
       expect(result.bloatDown.downNumber).toBe(1);
-      expect(result.bloatDown.walkTime).toBe(32);
+      expect(result.bloatDown.upTicks).toBe(40);
+      expect(result.bloatDown.walkTime).toBe(39);
     });
 
     it('converts nylo wave spawn', () => {
@@ -594,12 +595,12 @@ describe('protoToJsonEvent', () => {
     it('converts sol lasers', () => {
       const evt = makeEvent(EventType.COLOSSEUM_SOL_LASERS);
       const lasers = new EventProto.ColosseumSolLasers();
-      lasers.setPhase(2);
+      lasers.setPhase(1);
       evt.setColosseumSolLasers(lasers);
 
       const result = protoToJsonEvent(evt) as ColosseumSolLasersEvent;
 
-      expect(result.colosseumSolLasers.phase).toBe(2);
+      expect(result.colosseumSolLasers.phase).toBe(1);
     });
   });
 });

--- a/common/event.ts
+++ b/common/event.ts
@@ -494,6 +494,7 @@ export type Coords = {
 
 export type BloatDown = {
   downNumber: number;
+  upTicks: number;
   walkTime: number;
 };
 

--- a/common/migrations/20260407013140-fix-bloat-walk-time.ts
+++ b/common/migrations/20260407013140-fix-bloat-walk-time.ts
@@ -1,0 +1,9 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    UPDATE queryable_events
+    SET custom_short_2 = custom_short_2 - 1
+    WHERE event_type = 110
+  `;
+}

--- a/common/protocol/json-converter.ts
+++ b/common/protocol/json-converter.ts
@@ -337,7 +337,11 @@ function eventJsonToProto(json: EventJson): Event {
   if (json.bloatDown !== undefined) {
     const down = new Event.BloatDown();
     down.setDownNumber(json.bloatDown.downNumber);
-    down.setWalkTime(json.bloatDown.walkTime);
+    down.setUpTicks(
+      'upTicks' in json.bloatDown
+        ? json.bloatDown.upTicks
+        : json.bloatDown.walkTime,
+    );
     event.setBloatDown(down);
   }
 

--- a/common/protocol/json-schemas.ts
+++ b/common/protocol/json-schemas.ts
@@ -259,10 +259,16 @@ export const attackStyleSchema = z.object({
 });
 
 // Event.BloatDown
-export const bloatDownSchema = z.object({
-  downNumber: z.number().int(),
-  walkTime: z.number().int(),
-});
+export const bloatDownSchema = z
+  .object({
+    downNumber: z.number().int(),
+  })
+  .and(
+    z.union([
+      z.object({ upTicks: z.number().int() }),
+      z.object({ walkTime: z.number().int() }),
+    ]),
+  );
 
 // Event.NyloWave
 export const nyloWaveSchema = z.object({

--- a/common/protocol/proto-converter.ts
+++ b/common/protocol/proto-converter.ts
@@ -221,9 +221,11 @@ export function protoToJsonEvent(evt: EventProto): Event {
     case EventType.TOB_BLOAT_DOWN: {
       const bloatDown = evt.getBloatDown()!;
       const e = event as BloatDownEvent;
+      const upTicks = bloatDown.getUpTicks();
       e.bloatDown = {
         downNumber: bloatDown.getDownNumber(),
-        walkTime: bloatDown.getWalkTime(),
+        upTicks,
+        walkTime: upTicks - 1,
       };
       break;
     }

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/bloat/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/bloat/page.tsx
@@ -332,8 +332,8 @@ export default function BloatPage() {
                 <span className="sr-only">Walk time</span>
               </td>
               <td className={styles.walkTime}>
-                {ticksToFormattedSeconds(down.walkTime - 1)}
-                <span className={styles.walkTicks}>({down.walkTime - 1})</span>
+                {ticksToFormattedSeconds(down.walkTime)}
+                <span className={styles.walkTicks}>({down.walkTime})</span>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Bloat events sent a walkTime value with the number of ticks between Bloat getting up and back down again. It turns out that since on the last of those ticks Bloat doesn't actually walk, the community definition of walk time is actually one fewer. Blert was already compenstating for this by applying a -1 correction on the frontend, but other places such as saved queryable events used the raw up time value when they really wanted walk time.

This makes the distinction explicit by renaming the field sent by plugins to `upTicks` (keeping `walkTime` for backwards compatibility) and deriving `walkTime = upTicks - 1` when deseralizing events in APIs as well as where it is used in the database.