### PR TITLE
Standardize RSN normalization

### DIFF
--- a/challenge-server/players.ts
+++ b/challenge-server/players.ts
@@ -4,6 +4,7 @@ import {
   camelToSnakeObject,
   CamelToSnakeCase,
   camelToSnake,
+  normalizeRsn,
 } from '@blert/common';
 
 import sql from './db';
@@ -28,14 +29,15 @@ export class Players {
    * @returns The IDs of the players, in the same order as the input usernames.
    */
   public static async lookupIds(usernames: string[]): Promise<number[]> {
-    const rows = await sql<{ id: number; username: string }[]>`
-      SELECT id, username
+    const normalized = usernames.map(normalizeRsn);
+    const rows = await sql<{ id: number; normalized_username: string }[]>`
+      SELECT id, normalized_username
       FROM players
-      WHERE lower(username) = ANY(${usernames.map((u) => u.toLowerCase())})
+      WHERE normalized_username = ANY(${normalized})
     `;
     const result: number[] = [];
-    for (const username of usernames) {
-      const row = rows.find((r) => r.username === username);
+    for (const norm of normalized) {
+      const row = rows.find((r) => r.normalized_username === norm);
       if (row !== undefined) {
         result.push(row.id);
       }
@@ -75,6 +77,7 @@ export class Players {
     }
 
     fields.username = username;
+    fields.normalized_username = normalizeRsn(username);
 
     const [player]: [{ id: number }?] = await sql`
       INSERT INTO players ${sql(fields)} RETURNING id;
@@ -87,7 +90,7 @@ export class Players {
     const [player]: [{ id: number }?] = await sql`
       UPDATE players
       SET total_recordings = total_recordings + 1
-      WHERE lower(username) = ${username.toLowerCase()}
+      WHERE normalized_username = ${normalizeRsn(username)}
       RETURNING id;
     `;
 

--- a/common/__tests__/player.test.ts
+++ b/common/__tests__/player.test.ts
@@ -1,0 +1,46 @@
+import { normalizeRsn } from '../player';
+
+describe('normalizeRsn', () => {
+  it('should lowercase the name', () => {
+    expect(normalizeRsn('Zezima')).toBe('zezima');
+    expect(normalizeRsn('ZEZIMA')).toBe('zezima');
+  });
+
+  it('should replace spaces with underscores', () => {
+    expect(normalizeRsn('Gucci Clogs')).toBe('gucci_clogs');
+  });
+
+  it('should replace hyphens with underscores', () => {
+    expect(normalizeRsn('Gucci-Clogs')).toBe('gucci_clogs');
+  });
+
+  it('should preserve existing underscores', () => {
+    expect(normalizeRsn('Gucci_Clogs')).toBe('gucci_clogs');
+  });
+
+  it('should treat all separator variants as equivalent', () => {
+    const expected = 'gucci_clogs';
+    expect(normalizeRsn('Gucci Clogs')).toBe(expected);
+    expect(normalizeRsn('Gucci-Clogs')).toBe(expected);
+    expect(normalizeRsn('Gucci_Clogs')).toBe(expected);
+    expect(normalizeRsn('gucci clogs')).toBe(expected);
+    expect(normalizeRsn('gucci-clogs')).toBe(expected);
+    expect(normalizeRsn('gucci_clogs')).toBe(expected);
+  });
+
+  it('should handle names with multiple separators', () => {
+    expect(normalizeRsn('A B-C')).toBe('a_b_c');
+  });
+
+  it('should handle names with no separators', () => {
+    expect(normalizeRsn('Zezima')).toBe('zezima');
+  });
+
+  it('should handle single character names', () => {
+    expect(normalizeRsn('A')).toBe('a');
+  });
+
+  it('should handle names with numbers', () => {
+    expect(normalizeRsn('Player 123')).toBe('player_123');
+  });
+});

--- a/common/db/redis.ts
+++ b/common/db/redis.ts
@@ -1,13 +1,10 @@
 import { createHash } from 'crypto';
 
 import { ChallengeType, Stage, StageStatus } from '../challenge';
-
-function normalizeUsername(username: string): string {
-  return username.toLowerCase().replaceAll(' ', '_');
-}
+import { normalizeRsn } from '../player';
 
 function challengePartyKey(type: ChallengeType, partyMembers: string[]) {
-  const party = partyMembers.toSorted().map(normalizeUsername).join('-');
+  const party = partyMembers.toSorted().map(normalizeRsn).join('-');
   return `${type}-${party}`;
 }
 
@@ -36,7 +33,7 @@ export function clientChallengesKey(id: number) {
  */
 export function partyHash(party: string[]) {
   return createHash('sha256')
-    .update(party.toSorted().map(normalizeUsername).join('-'))
+    .update(party.toSorted().map(normalizeRsn).join('-'))
     .digest('hex');
 }
 
@@ -287,5 +284,5 @@ export function stageStreamFromRecord(
  * @returns Key for the player's information.
  */
 export function activePlayerKey(username: string) {
-  return `player:${normalizeUsername(username)}`;
+  return `player:${normalizeRsn(username)}`;
 }

--- a/common/index.ts
+++ b/common/index.ts
@@ -9,6 +9,7 @@ export {
   type PlayerExperience,
   HiscoresRateLimitError,
   hiscoreLookup,
+  normalizeRsn,
 } from './player';
 export {
   SplitType,

--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -12,5 +12,7 @@ module.exports = {
     '!**/__tests__/**',
     '!**/migrations/**',
     '!**/npcs/**',
+    '!**/db/**',
+    '!index.ts',
   ],
 };

--- a/common/migrations/20260408063117-normalize-player-usernames.ts
+++ b/common/migrations/20260408063117-normalize-player-usernames.ts
@@ -1,0 +1,51 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  // Widen username to allow headroom beyond the 12-char OSRS limit
+  // (e.g. the * zombie prefix).
+  await sql`
+    ALTER TABLE players
+    ALTER COLUMN username TYPE VARCHAR(16)
+  `;
+
+  // Add the new column and backfill.
+  await sql`
+    ALTER TABLE players
+    ADD COLUMN normalized_username VARCHAR(16)
+  `;
+  await sql`
+    UPDATE players
+    SET normalized_username = translate(lower(username), ' -', '__')
+  `;
+
+  const collisions = await sql<
+    { normalized_username: string; count: string }[]
+  >`
+    SELECT normalized_username, COUNT(*) as count
+    FROM players
+    GROUP BY normalized_username
+    HAVING COUNT(*) > 1
+  `;
+
+  if (collisions.length > 0) {
+    const details = collisions
+      .map((c) => `  ${c.normalized_username} (${c.count} rows)`)
+      .join('\n');
+    throw new Error(
+      `Cannot create unique index: ${collisions.length} normalized username collision(s) found.\n` +
+        `Resolve these manually before re-running the migration:\n${details}`,
+    );
+  }
+
+  await sql`
+    ALTER TABLE players
+    ALTER COLUMN normalized_username SET NOT NULL
+  `;
+
+  await sql`DROP INDEX uix_players_username`;
+
+  await sql`
+    CREATE UNIQUE INDEX uix_players_username
+    ON players (normalized_username)
+  `;
+}

--- a/common/player.ts
+++ b/common/player.ts
@@ -1,7 +1,19 @@
 import { Skill } from './challenge';
 
+/**
+ * Normalizes an OSRS username for identity comparison. In OSRS, spaces,
+ * hyphens, and underscores are interchangeable and names are case-insensitive.
+ *
+ * @param name The RSN to normalize.
+ * @returns The normalized form of the name.
+ */
+export function normalizeRsn(name: string): string {
+  return name.toLowerCase().replaceAll(/[- ]/g, '_');
+}
+
 export type Player = {
   username: string;
+  normalizedUsername: string;
   totalRecordings: number;
   overallExperience: number;
   attackExperience: number;

--- a/socket-server/message-handler.ts
+++ b/socket-server/message-handler.ts
@@ -2,6 +2,7 @@ import {
   ChallengeType,
   ClientStatus,
   isPostgresUniqueViolation,
+  normalizeRsn,
   RecordingType,
   Stage,
 } from '@blert/common';
@@ -646,7 +647,7 @@ export default class MessageHandler {
   ): Promise<boolean> {
     const storedAccountHash = await Players.getAccountHash(playerId);
     const displayNameMatches =
-      clientRsn.toLowerCase() === storedUsername.toLowerCase();
+      normalizeRsn(clientRsn) === normalizeRsn(storedUsername);
 
     if (storedAccountHash !== null) {
       // Account hash is stored; use it for validation.

--- a/socket-server/players.ts
+++ b/socket-server/players.ts
@@ -5,6 +5,7 @@ import {
   CamelToSnakeCase,
   camelToSnake,
   NameChangeStatus,
+  normalizeRsn,
 } from '@blert/common';
 import { RedisClientType } from 'redis';
 
@@ -138,12 +139,12 @@ export class Players {
       }
     });
 
-    const normalizedUsername = username.toLowerCase();
+    const normalized = normalizeRsn(username);
     if (Object.keys(updates).length === 0) {
       await sql`
         UPDATE players
         SET last_updated = NOW()
-        WHERE lower(username) = ${normalizedUsername}
+        WHERE normalized_username = ${normalized}
       `;
       return;
     }
@@ -151,7 +152,7 @@ export class Players {
     await sql`
       UPDATE players
       SET ${sql(updates)}, last_updated = NOW()
-      WHERE lower(username) = ${normalizedUsername}
+      WHERE normalized_username = ${normalized}
     `;
   }
 }
@@ -173,30 +174,29 @@ export class PlayerManager {
   }
 
   public setPlayerActive(username: string, challengeId: string): void {
-    this.activePlayers.set(username.toLowerCase(), { challengeId });
+    const normalized = normalizeRsn(username);
+    this.activePlayers.set(normalized, { challengeId });
     this.statusUpdateListeners
-      .get(username.toLowerCase())
+      .get(normalized)
       ?.forEach((cb) => cb(challengeId));
   }
 
   public setPlayerInactive(username: string, challengeId: string): void {
-    username = username.toLowerCase();
-    const activePlayer = this.activePlayers.get(username);
+    const normalized = normalizeRsn(username);
+    const activePlayer = this.activePlayers.get(normalized);
     if (activePlayer === undefined) {
       return;
     }
     if (activePlayer.challengeId !== challengeId) {
       logger.warn('player_challenge_mismatch', {
-        username,
+        username: normalized,
         expectedChallengeUuid: challengeId,
         actualChallengeUuid: activePlayer.challengeId,
       });
       return;
     }
-    this.activePlayers.delete(username);
-    this.statusUpdateListeners
-      .get(username.toLowerCase())
-      ?.forEach((cb) => cb(null));
+    this.activePlayers.delete(normalized);
+    this.statusUpdateListeners.get(normalized)?.forEach((cb) => cb(null));
   }
 
   public async getCurrentChallengeId(username: string): Promise<string | null> {
@@ -204,31 +204,31 @@ export class PlayerManager {
       const challengeId = await this.redisClient.get(activePlayerKey(username));
       return challengeId ?? null;
     }
-    return this.activePlayers.get(username.toLowerCase())?.challengeId ?? null;
+    return this.activePlayers.get(normalizeRsn(username))?.challengeId ?? null;
   }
 
   public subscribeToPlayer(
     username: string,
     callback: PlayerStatusCallback,
   ): void {
-    username = username.toLowerCase();
-    if (!this.statusUpdateListeners.has(username)) {
-      this.statusUpdateListeners.set(username, []);
+    const normalized = normalizeRsn(username);
+    if (!this.statusUpdateListeners.has(normalized)) {
+      this.statusUpdateListeners.set(normalized, []);
     }
 
-    this.statusUpdateListeners.get(username)!.push(callback);
+    this.statusUpdateListeners.get(normalized)!.push(callback);
   }
 
   public unsubscribeFromPlayer(
     username: string,
     callback: PlayerStatusCallback,
   ): void {
-    username = username.toLowerCase();
-    if (!this.statusUpdateListeners.has(username)) {
+    const normalized = normalizeRsn(username);
+    if (!this.statusUpdateListeners.has(normalized)) {
       return;
     }
 
-    const listeners = this.statusUpdateListeners.get(username)!;
+    const listeners = this.statusUpdateListeners.get(normalized)!;
     const index = listeners.indexOf(callback);
     if (index !== -1) {
       listeners.splice(index, 1);

--- a/web/__tests__/actions/admin.test.ts
+++ b/web/__tests__/actions/admin.test.ts
@@ -1,3 +1,5 @@
+import { normalizeRsn } from '@blert/common';
+
 import {
   getLinkedRsns,
   grantApiAccess,
@@ -341,8 +343,10 @@ describe('admin actions', () => {
     beforeEach(async () => {
       // Create test players.
       const players = await sql<{ id: number }[]>`
-        INSERT INTO players (username)
-        VALUES ('PlayerOne'), ('PlayerTwo')
+        INSERT INTO players (username, normalized_username)
+        VALUES
+          ('PlayerOne', ${normalizeRsn('PlayerOne')}),
+          ('PlayerTwo', ${normalizeRsn('PlayerTwo')})
         RETURNING id
       `;
       playerId1 = players[0].id;

--- a/web/__tests__/actions/bloat-hands.test.ts
+++ b/web/__tests__/actions/bloat-hands.test.ts
@@ -1,4 +1,9 @@
-import { ChallengeMode, ChallengeStatus, ChallengeType } from '@blert/common';
+import {
+  ChallengeMode,
+  ChallengeStatus,
+  ChallengeType,
+  normalizeRsn,
+} from '@blert/common';
 
 import { sql } from '@/actions/db';
 import { aggregateBloatHands } from '@/actions/bloat-hands';
@@ -10,6 +15,7 @@ describe('aggregateBloatHands', () => {
     const players = [
       {
         username: 'Player1',
+        normalized_username: normalizeRsn('Player1'),
         total_recordings: 5,
         overall_experience: 200_000_000,
         attack_experience: 13_000_000,

--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -3,6 +3,7 @@ import {
   ChallengeStatus,
   ChallengeType,
   SessionStatus,
+  normalizeRsn,
   partyHash,
 } from '@blert/common';
 
@@ -18,12 +19,12 @@ describe('aggregateSessions', () => {
 
   beforeEach(async () => {
     const players = [
-      { username: 'PlayerA' },
-      { username: 'PlayerB' },
-      { username: 'PlayerC' },
+      { username: 'PlayerA', normalized_username: normalizeRsn('PlayerA') },
+      { username: 'PlayerB', normalized_username: normalizeRsn('PlayerB') },
+      { username: 'PlayerC', normalized_username: normalizeRsn('PlayerC') },
     ];
     const playerResults = await sql`
-      INSERT INTO players ${sql(players, ['username'])} RETURNING id
+      INSERT INTO players ${sql(players, ['username', 'normalized_username'])} RETURNING id
     `;
     playerIds = playerResults.map((p) => p.id);
 

--- a/web/__tests__/actions/name-change-processor.test.ts
+++ b/web/__tests__/actions/name-change-processor.test.ts
@@ -5,6 +5,7 @@ import {
   NameChangeUpdateType,
   PlayerExperience,
   Skill,
+  normalizeRsn,
 } from '@blert/common';
 
 import { sql } from '@/actions/db';
@@ -98,6 +99,7 @@ describe('processNameChange', () => {
     const players = [
       {
         username: 'Old Name',
+        normalized_username: normalizeRsn('Old Name'),
         total_recordings: 2,
         overall_experience: 150_000_000,
         attack_experience: 6_500_000,
@@ -110,6 +112,7 @@ describe('processNameChange', () => {
       },
       {
         username: 'New Name',
+        normalized_username: normalizeRsn('New Name'),
         total_recordings: 2,
         overall_experience: 200_000_000,
         attack_experience: 6_900_000,
@@ -122,6 +125,7 @@ describe('processNameChange', () => {
       },
       {
         username: 'SomeRandom',
+        normalized_username: normalizeRsn('SomeRandom'),
         total_recordings: 4,
         overall_experience: 300_000_000,
         attack_experience: 7_000_000,
@@ -961,6 +965,43 @@ describe('processNameChange', () => {
     expect(updatedRequest.migratedDocuments).toBe(0);
   });
 
+  it('updates only the display name for separator-only changes', async () => {
+    global.fetch = jest.fn();
+
+    const id = await createNameChangeRequest(
+      'Old Name',
+      oldPlayerId,
+      'Old_Name',
+    );
+    const result = await processNameChange(id);
+
+    expect(result).toEqual({
+      type: NameChangeUpdateType.RENAMED,
+      playerId: oldPlayerId,
+      oldName: 'Old Name',
+      newName: 'Old_Name',
+    });
+
+    // Display name should be updated but normalized form is unchanged.
+    const [updatedPlayer] = await sql<
+      [{ username: string; normalized_username: string }?]
+    >`
+      SELECT username, normalized_username FROM players WHERE id = ${oldPlayerId}
+    `;
+    expect(updatedPlayer).not.toBeUndefined();
+    expect(updatedPlayer!.username).toBe('Old_Name');
+    expect(updatedPlayer!.normalized_username).toBe(normalizeRsn('Old Name'));
+
+    // No data should have been migrated.
+    const updatedRequest = await loadNameChangeRequest(id);
+    expect(updatedRequest.status).toBe(NameChangeStatus.ACCEPTED);
+    expect(updatedRequest.processedAt).not.toBeNull();
+    expect(updatedRequest.migratedDocuments).toBe(0);
+
+    // Hiscores should not have been called.
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it('throws PlayerInActiveChallengeError if player is in active challenge', async () => {
     // Mock Redis to indicate the old player is in an active challenge.
     const mockMulti = {
@@ -1095,6 +1136,7 @@ describe('NameChangeProcessor.processBatch', () => {
     const [{ id }] = await sql`
       INSERT INTO players (
         username,
+        normalized_username,
         total_recordings,
         overall_experience,
         attack_experience,
@@ -1106,6 +1148,7 @@ describe('NameChangeProcessor.processBatch', () => {
         magic_experience
       ) VALUES (
         'BatchPlayer',
+        ${normalizeRsn('BatchPlayer')},
         0,
         100000000,
         5000000,
@@ -1259,9 +1302,10 @@ describe('NameChangeProcessor.processBatch', () => {
 
     // Insert 3 PENDING name changes.
     for (let i = 0; i < 3; i++) {
+      const name = 'Bp' + i;
       const [{ id: pid }] = await sql<[{ id: number }]>`
-        INSERT INTO players (username, total_recordings, overall_experience)
-        VALUES (${'Bp' + i}, 0, 100000000)
+        INSERT INTO players (username, normalized_username, total_recordings, overall_experience)
+        VALUES (${name}, ${normalizeRsn(name)}, 0, 100000000)
         RETURNING id
       `;
       await sql`

--- a/web/__tests__/api/admin/linked-rsns.test.ts
+++ b/web/__tests__/api/admin/linked-rsns.test.ts
@@ -1,3 +1,5 @@
+import { normalizeRsn } from '@blert/common';
+
 import { POST } from '@/api/admin/linked-rsns/route';
 import { sql } from '@/actions/db';
 import { NextRequest } from 'next/server';
@@ -46,8 +48,10 @@ describe('POST /api/admin/linked-rsns', () => {
     testUserId2 = users[1].id;
 
     const players = await sql<{ id: number }[]>`
-      INSERT INTO players (username)
-      VALUES ('PlayerOne'), ('PlayerTwo')
+      INSERT INTO players (username, normalized_username)
+      VALUES
+        ('PlayerOne', ${normalizeRsn('PlayerOne')}),
+        ('PlayerTwo', ${normalizeRsn('PlayerTwo')})
       RETURNING id
     `;
     playerId1 = players[0].id;

--- a/web/app/actions/activity.ts
+++ b/web/app/actions/activity.ts
@@ -3,6 +3,7 @@ import {
   ActivityFeedItem as RedisActivityFeedItem,
   ActivityFeedItemType,
   ActivityFeedData,
+  normalizeRsn,
 } from '@blert/common';
 
 import { ChallengeOverview, findChallenges } from './challenge';
@@ -120,7 +121,7 @@ export async function playerActivityByHour(username: string, startTime: Date) {
     FROM challenges c
     JOIN challenge_players cp ON c.id = cp.challenge_id
     JOIN players p ON cp.player_id = p.id
-    WHERE LOWER(p.username) = ${username.toLowerCase()}
+    WHERE p.normalized_username = ${normalizeRsn(username)}
       AND c.start_time >= ${startTime}
   `;
 

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -31,6 +31,7 @@ import {
   generalizeSplit,
   isPostgresInvalidTextRepresentation,
   isPostgresUndefinedColumn,
+  normalizeRsn,
   snakeToCamel,
   snakeToCamelObject,
 } from '@blert/common';
@@ -539,7 +540,9 @@ function applyFilters(
           tableName: 'players',
         },
       );
-      conditions.push(sql`lower(players.username) = ${username.toLowerCase()}`);
+      conditions.push(
+        sql`players.normalized_username = ${normalizeRsn(username)}`,
+      );
     } else {
       const matchAll = query.partyMatch !== 'any';
       if (matchAll) {
@@ -548,7 +551,7 @@ function applyFilters(
           FROM challenges
           JOIN challenge_players ON challenges.id = challenge_players.challenge_id
           JOIN players ON challenge_players.player_id = players.id
-          WHERE lower(players.username) = ANY(${query.party.map((u) => u.toLowerCase())})
+          WHERE players.normalized_username = ANY(${query.party.map(normalizeRsn)})
           GROUP BY challenges.id
           HAVING COUNT(*) = ${query.party.length}
         ) challenges`;
@@ -558,7 +561,7 @@ function applyFilters(
           FROM challenges
           JOIN challenge_players ON challenges.id = challenge_players.challenge_id
           JOIN players ON challenge_players.player_id = players.id
-          WHERE lower(players.username) = ANY(${query.party.map((u) => u.toLowerCase())})
+          WHERE players.normalized_username = ANY(${query.party.map(normalizeRsn)})
         ) challenges`;
       }
     }
@@ -1444,7 +1447,7 @@ function sessionFilters(query: SessionQuery): {
             FROM challenge_players cp
             JOIN players p ON p.id = cp.player_id
             JOIN challenges c ON c.id = cp.challenge_id
-            WHERE LOWER(p.username) = ${query.party[0].toLowerCase()}
+            WHERE p.normalized_username = ${normalizeRsn(query.party[0])}
           )
         `,
       );
@@ -1456,7 +1459,7 @@ function sessionFilters(query: SessionQuery): {
             FROM challenge_players cp
             JOIN players p ON p.id = cp.player_id
             JOIN challenges c ON c.id = cp.challenge_id
-            WHERE LOWER(p.username) = ANY(${query.party.map((u) => u.toLowerCase())})
+            WHERE p.normalized_username = ANY(${query.party.map(normalizeRsn)})
             GROUP BY c.id
             HAVING COUNT(*) = ${query.party.length}
           )
@@ -2304,7 +2307,7 @@ export async function loadPlayerWithStats(
       player_stats.*
     FROM players
     JOIN player_stats ON players.id = player_stats.player_id
-    WHERE lower(players.username) = ${username.toLowerCase()}
+    WHERE players.normalized_username = ${normalizeRsn(username)}
     ORDER BY player_stats.date DESC
     LIMIT 1
   `;
@@ -2403,7 +2406,7 @@ export async function loadPbsForPlayer(
     WITH player_id_cte AS (
       SELECT id
       FROM players
-      WHERE lower(username) = ${username.toLowerCase()}
+      WHERE normalized_username = ${normalizeRsn(username)}
       LIMIT 1
     ),
     player_pbs AS (
@@ -2758,7 +2761,7 @@ export async function getPlayerStatsHistory(
   filter: PlayerStatsFilter = {},
 ): Promise<Partial<PlayerStats>[]> {
   const conditions: postgres.Fragment[] = [
-    sql`lower(players.username) = ${username.toLowerCase()}`,
+    sql`players.normalized_username = ${normalizeRsn(username)}`,
   ];
   const fields: postgres.Fragment[] = [];
 
@@ -2936,7 +2939,7 @@ export async function topPartnersForPlayer(
   } = options;
 
   const playerId = await sql<{ id: number }[]>`
-    SELECT id FROM players WHERE LOWER(username) = ${username.toLowerCase()}
+    SELECT id FROM players WHERE normalized_username = ${normalizeRsn(username)}
   `.then((rows) => rows[0]?.id);
 
   if (!playerId) {

--- a/web/app/actions/change-name.ts
+++ b/web/app/actions/change-name.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { NameChange, NameChangeStatus } from '@blert/common';
+import { NameChange, NameChangeStatus, normalizeRsn } from '@blert/common';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
@@ -8,7 +8,7 @@ import { sql } from './db';
 import processor from './name-change-processor';
 import { getSignedInUserId } from './users';
 
-const RSN_REGEX = /^[a-zA-Z0-9 _-]{1,12}$/;
+const RSN_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9 _-]{0,11}$/;
 
 export async function submitNameChangeForm(
   _state: string | null,
@@ -29,11 +29,21 @@ export async function submitNameChangeForm(
   const [player] = await sql<[{ id: number; username: string }?]>`
     SELECT id, username
     FROM players
-    WHERE lower(username) = ${oldName.toLowerCase()}
+    WHERE normalized_username = ${normalizeRsn(oldName)}
   `;
 
   if (!player) {
     return `No Blert player found with the name ${oldName}`;
+  }
+
+  const [existingPending] = await sql`
+    SELECT 1 FROM name_changes
+    WHERE player_id = ${player.id}
+      AND status IN (${NameChangeStatus.PENDING}, ${NameChangeStatus.DEFERRED})
+    LIMIT 1
+  `;
+  if (existingPending) {
+    return 'This player already has a pending name change';
   }
 
   const nameChange: {
@@ -111,7 +121,7 @@ export async function getNameChangesForPlayer(
       nc.processed_at
     FROM name_changes nc
     JOIN players p ON nc.player_id = p.id
-    WHERE lower(p.username) = ${username.toLowerCase()}
+    WHERE p.normalized_username = ${normalizeRsn(username)}
       AND nc.status = ${NameChangeStatus.ACCEPTED}
       AND nc.hidden = FALSE
     ORDER BY nc.processed_at DESC

--- a/web/app/actions/feed.ts
+++ b/web/app/actions/feed.ts
@@ -7,6 +7,7 @@ import {
   RELEVANT_PB_SPLITS,
   SessionStatus,
   SplitType,
+  normalizeRsn,
   splitName,
 } from '@blert/common';
 import type { SessionRow } from '@blert/common/dist/db/challenge';
@@ -96,7 +97,7 @@ export async function followPlayer(
   const [player] = await sql<{ id: number; username: string }[]>`
     SELECT id, username
     FROM players
-    WHERE lower(username) = ${username.toLowerCase()}
+    WHERE normalized_username = ${normalizeRsn(username)}
   `;
 
   if (!player) {
@@ -259,7 +260,7 @@ export async function isFollowingByUsername(
     SELECT uf.user_id
     FROM user_follows uf
     JOIN players p ON uf.player_id = p.id
-    WHERE uf.user_id = ${userId} AND lower(p.username) = ${username.toLowerCase()}
+    WHERE uf.user_id = ${userId} AND p.normalized_username = ${normalizeRsn(username)}
     LIMIT 1
   `;
 

--- a/web/app/actions/name-change-processor.ts
+++ b/web/app/actions/name-change-processor.ts
@@ -10,6 +10,7 @@ import {
   PlayerStats,
   Skill,
   hiscoreLookup,
+  normalizeRsn,
 } from '@blert/common';
 
 import logger from '@/utils/log';
@@ -334,6 +335,30 @@ export async function processNameChange(
 
   logger.info('processing_name_change', { changeId, oldName, newName });
 
+  // If the names normalize to the same value, this is just a display name
+  // update. Skip validation and simply update the stored display name.
+  if (normalizeRsn(oldName) === normalizeRsn(newName)) {
+    logger.info('name_change_display_only', { changeId, oldName, newName });
+
+    await Promise.all([
+      db`UPDATE players SET username = ${newName} WHERE id = ${playerId}`,
+      db`
+        UPDATE name_changes
+        SET
+          status = ${NameChangeStatus.ACCEPTED},
+          processed_at = ${new Date()}
+        WHERE id = ${changeId}
+      `,
+    ]);
+
+    return {
+      type: NameChangeUpdateType.RENAMED,
+      playerId,
+      oldName,
+      newName,
+    };
+  }
+
   // Check if the player is in an active challenge. If so, defer the name
   // change until they are no longer in a challenge.
   if (await isPlayerInActiveChallenge(oldName, newName)) {
@@ -367,6 +392,7 @@ export async function processNameChange(
 
   const playerUpdates: Record<string, any> = {
     username: newName,
+    normalized_username: normalizeRsn(newName),
   };
 
   if (oldExperience !== null) {
@@ -426,7 +452,7 @@ export async function processNameChange(
   const [newPlayer]: [{ id: number }?] = await db`
     SELECT id
     FROM players
-    WHERE lower(username) = ${newName.toLowerCase()}
+    WHERE normalized_username = ${normalizeRsn(newName)}
   `;
 
   if (newPlayer) {
@@ -503,10 +529,12 @@ export async function processNameChange(
       // current values reflect the experience of the player who has taken over
       // the username.
       logger.info('name_change_zombie_player', { changeId, newName });
+      const zombieName = `*${newName}`;
       await db`
         UPDATE players
         SET
-          username = ${`*${newName}`},
+          username = ${zombieName},
+          normalized_username = ${normalizeRsn(zombieName)},
           total_recordings = total_recordings - ${challengesUpdated},
           overall_experience = 0,
           attack_experience = 0,

--- a/web/app/actions/split-distributions.ts
+++ b/web/app/actions/split-distributions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { ChallengeType, SplitType } from '@blert/common';
+import { ChallengeType, SplitType, normalizeRsn } from '@blert/common';
 
 import { sql } from './db';
 
@@ -99,13 +99,13 @@ export async function getFilteredSplitDistributions(
   after?: Date,
   before?: Date,
 ): Promise<SplitDistribution[]> {
-  const lowercaseParty = party.map((u) => u.toLowerCase());
+  const normalizedParty = party.map(normalizeRsn);
 
   const matchingChallenges = sql`
     SELECT cp.challenge_id AS id
     FROM challenge_players cp
     JOIN players p ON p.id = cp.player_id
-    WHERE lower(p.username) = ANY(${lowercaseParty})
+    WHERE p.normalized_username = ANY(${normalizedParty})
     GROUP BY cp.challenge_id
     HAVING COUNT(DISTINCT cp.player_id) = ${party.length}
   `;

--- a/web/app/actions/users.ts
+++ b/web/app/actions/users.ts
@@ -7,6 +7,7 @@ import {
   User,
   hiscoreLookup,
   isPostgresUniqueViolation,
+  normalizeRsn,
 } from '@blert/common';
 import { headers } from 'next/headers';
 
@@ -175,7 +176,7 @@ export async function createApiKey(rsn: string): Promise<ApiKeyWithUsername> {
     let [player] = await sql<{ id: number; username: string }[]>`
       SELECT id, username
       FROM players
-      WHERE lower(username) = ${rsn.toLowerCase()}
+      WHERE normalized_username = ${normalizeRsn(rsn)}
     `;
 
     if (!player) {
@@ -194,6 +195,7 @@ export async function createApiKey(rsn: string): Promise<ApiKeyWithUsername> {
       const [{ id }] = await sql<{ id: number }[]>`
         INSERT INTO players (
           username,
+          normalized_username,
           overall_experience,
           attack_experience,
           defence_experience,
@@ -205,6 +207,7 @@ export async function createApiKey(rsn: string): Promise<ApiKeyWithUsername> {
           last_updated
         ) VALUES (
           ${rsn},
+          ${normalizeRsn(rsn)},
           ${experience[Skill.OVERALL]},
           ${experience[Skill.ATTACK]},
           ${experience[Skill.DEFENCE]},


### PR DESCRIPTION
In OSRS, display names are case insensitive and spaces, underscores, and hyphens are treated the same. Different parts of the system handled this separately and inconsistently. This creates a standard `normalizeRsn` function and adds a normalized column to the players table, using it for all username reads and writes throughout the system.

Fixes #230.