### PR TITLE
Store bloat downs in database

### DIFF
--- a/challenge-server/event-processing/challenge-processor.ts
+++ b/challenge-server/event-processing/challenge-processor.ts
@@ -480,9 +480,9 @@ export default abstract class ChallengeProcessor {
       this.challengeStatus = ChallengeStatus.WIPED;
     }
 
-    await this.onStageFinished(stage, events);
-
     const accurate = !this.partyChangedMidChallenge && events.isAccurate();
+
+    await this.onStageFinished(stage, events, accurate);
 
     await Promise.all([
       this.addStageDeaths(),
@@ -1579,10 +1579,12 @@ export default abstract class ChallengeProcessor {
    * Invoked after all events have been processed for a stage.
    * @param stage The stage of the events.
    * @param events The events that were processed.
+   * @param accurate Whether the stage data is considered accurate.
    */
   protected abstract onStageFinished(
     stage: Stage,
     events: MergedEvents,
+    accurate: boolean,
   ): Promise<void>;
 
   /**

--- a/challenge-server/event-processing/colosseum.ts
+++ b/challenge-server/event-processing/colosseum.ts
@@ -103,6 +103,7 @@ export default class ColosseumProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
+    _accurate: boolean,
   ): Promise<void> {
     const state = this.getStageState();
 

--- a/challenge-server/event-processing/inferno.ts
+++ b/challenge-server/event-processing/inferno.ts
@@ -180,6 +180,7 @@ export default class InfernoProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
+    _accurate: boolean,
   ): Promise<void> {
     if (this.waveStartTick !== null) {
       // Override total challenge ticks based on reported start time.

--- a/challenge-server/event-processing/mokhaiotl.ts
+++ b/challenge-server/event-processing/mokhaiotl.ts
@@ -111,6 +111,7 @@ export default class MokhaiotlProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
+    _accurate: boolean,
   ): Promise<void> {
     if (stage !== Stage.MOKHAIOTL_DELVE_8PLUS) {
       if (stage === Stage.MOKHAIOTL_DELVE_8) {

--- a/challenge-server/event-processing/theatre.ts
+++ b/challenge-server/event-processing/theatre.ts
@@ -39,6 +39,12 @@ type SoteMazeState = {
   chosenPlayer: string | null;
 };
 
+type BloatDownData = {
+  downNumber: number;
+  tick: number;
+  walkTime: number;
+};
+
 type BloatHandData = {
   waveNumber: number;
   tileId: number;
@@ -102,7 +108,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
   private rooms: TobRooms;
 
   private stageStats: Partial<TobChallengeStats>;
-  private bloatDownTicks: number[];
+  private bloatDowns: BloatDownData[];
   private bloatHands: BloatHandData[];
   private bloatWaveNumber: number;
   private stalledNyloWaves: number[];
@@ -141,7 +147,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
     );
 
     this.stageStats = {};
-    this.bloatDownTicks = [];
+    this.bloatDowns = [];
     this.bloatHands = [];
     this.bloatWaveNumber = 1;
     this.stalledNyloWaves = [];
@@ -226,6 +232,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
+    accurate: boolean,
   ): Promise<void> {
     const stageTicks = events.getLastTick();
     let stageSplit: SplitType;
@@ -252,19 +259,23 @@ export default class TheatreProcessor extends ChallengeProcessor {
         this.stageStats.maidenDeaths = this.rooms.maiden.deaths.length;
         break;
 
-      case Stage.TOB_BLOAT:
+      case Stage.TOB_BLOAT: {
         stageSplit = SplitType.TOB_BLOAT;
         this.rooms.bloat = {
           ...roomData,
           stage: Stage.TOB_BLOAT,
-          downTicks: this.bloatDownTicks,
+          downTicks: this.bloatDowns.map((d) => d.tick),
         };
         this.stageStats.bloatDeaths = this.rooms.bloat.deaths.length;
+        this.stageStats.bloatDownCount = this.bloatDowns.length;
 
-        if (events.isAccurate()) {
-          await this.saveBloatHands();
+        const bloatSaves: Promise<void>[] = [this.saveBloatDowns(accurate)];
+        if (accurate) {
+          bloatSaves.push(this.saveBloatHands());
         }
+        await Promise.all(bloatSaves);
         break;
+      }
 
       case Stage.TOB_NYLOCAS: {
         stageSplit = SplitType.TOB_NYLO_ROOM;
@@ -434,9 +445,14 @@ export default class TheatreProcessor extends ChallengeProcessor {
       }
 
       case Event.Type.TOB_BLOAT_DOWN: {
-        this.bloatDownTicks.push(event.getTick());
+        const bloatDown = event.getBloatDown()!;
+        this.bloatDowns.push({
+          downNumber: bloatDown.getDownNumber(),
+          tick: event.getTick(),
+          walkTime: bloatDown.getUpTicks() - 1,
+        });
 
-        if (event.getBloatDown()!.getDownNumber() === 1) {
+        if (bloatDown.getDownNumber() === 1) {
           const bloat = allEvents
             .eventsForTick(event.getTick())
             .find(
@@ -1033,6 +1049,23 @@ export default class TheatreProcessor extends ChallengeProcessor {
       SET ${sql(camelToSnakeObject(updates))}
       WHERE challenge_id = ${this.getDatabaseId()};
     `;
+  }
+
+  private async saveBloatDowns(accurate: boolean): Promise<void> {
+    if (this.bloatDowns.length === 0) {
+      return;
+    }
+
+    const challengeId = this.getDatabaseId();
+    const rows = this.bloatDowns.map((down) => ({
+      challenge_id: challengeId,
+      down_number: down.downNumber,
+      down_tick: down.tick,
+      walk_ticks: down.walkTime,
+      accurate,
+    }));
+
+    await sql`INSERT INTO bloat_downs ${sql(rows)}`;
   }
 
   private async saveBloatHands(): Promise<void> {

--- a/common/challenge.ts
+++ b/common/challenge.ts
@@ -109,6 +109,7 @@ export type TobChallengeStats = {
   maidenFullLeaks: number | null;
   maidenScuffedSpawns: boolean;
   bloatDeaths: number;
+  bloatDownCount: number | null;
   bloatFirstDownHpPercent: number | null;
   nylocasDeaths: number;
   nylocasPreCapStalls: number | null;

--- a/common/migrations/20260408070141-create-bloat-downs-table.ts
+++ b/common/migrations/20260408070141-create-bloat-downs-table.ts
@@ -1,0 +1,30 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE TABLE bloat_downs (
+      challenge_id BIGINT NOT NULL REFERENCES challenges (id) ON DELETE CASCADE,
+      down_number SMALLINT NOT NULL,
+      down_tick INT NOT NULL,
+      walk_ticks SMALLINT NOT NULL,
+      accurate BOOLEAN NOT NULL DEFAULT false,
+      PRIMARY KEY (challenge_id, down_number)
+    )
+  `;
+
+  await sql`
+    CREATE INDEX idx_bloat_downs_walk_ticks
+      ON bloat_downs (down_number, walk_ticks, challenge_id)
+  `;
+
+  await sql`
+    CREATE INDEX idx_bloat_downs_walk_ticks_accurate
+      ON bloat_downs (down_number, walk_ticks, challenge_id)
+      WHERE accurate
+  `;
+
+  await sql`
+    ALTER TABLE tob_challenge_stats
+      ADD COLUMN bloat_down_count SMALLINT
+  `;
+}

--- a/common/migrations/20260408070353-create-bloat-downs-mv.ts
+++ b/common/migrations/20260408070353-create-bloat-downs-mv.ts
@@ -1,0 +1,38 @@
+import { Sql } from 'postgres';
+
+import { ChallengeStatus, EventType } from '../index';
+
+export async function migrate(sql: Sql) {
+  await sql.unsafe(`
+    CREATE MATERIALIZED VIEW mv_bloat_downs_daily AS
+    SELECT
+      c.mode,
+      c.scale,
+      DATE(c.start_time) AS day,
+      qe.custom_short_1 AS down_number,
+      qe.custom_short_2 AS walk_ticks,
+      COUNT(*)::int AS count
+    FROM queryable_events qe
+    JOIN challenges c ON c.id = qe.challenge_id
+    WHERE qe.event_type = ${EventType.TOB_BLOAT_DOWN}
+      AND c.status != ${ChallengeStatus.ABANDONED}
+    GROUP BY c.mode, c.scale, DATE(c.start_time), qe.custom_short_1, qe.custom_short_2
+    WITH DATA
+  `);
+
+  await sql`
+    CREATE INDEX idx_mv_bloat_downs_daily_mode_day
+      ON mv_bloat_downs_daily (mode, day)
+  `;
+
+  await sql`
+    CREATE INDEX idx_mv_bloat_downs_daily_down_number
+      ON mv_bloat_downs_daily (mode, down_number, day)
+  `;
+
+  await sql`
+    CREATE UNIQUE INDEX uix_mv_bloat_downs_daily
+      ON mv_bloat_downs_daily (mode, day, scale, down_number, walk_ticks)
+      NULLS NOT DISTINCT
+  `;
+}

--- a/common/migrations/backfill-bloat-downs.ts
+++ b/common/migrations/backfill-bloat-downs.ts
@@ -1,0 +1,137 @@
+import postgres from 'postgres';
+import { parseArgs } from 'util';
+
+import { dataRepositoryFromEnv } from './script-helpers';
+import { ChallengeType, TobRooms } from '../challenge';
+import { SplitType } from '../split';
+
+const BLOAT_SPLIT_TYPES = [
+  SplitType.TOB_ENTRY_BLOAT,
+  SplitType.TOB_REG_BLOAT,
+  SplitType.TOB_HM_BLOAT,
+];
+
+// The number of ticks between consecutive down ticks that are not walk time:
+// 32t down + 1t standing up animation + 1t stationary before next down.
+const INTER_DOWN_OVERHEAD = 34;
+
+type TobChallengeWithAccuracy = {
+  id: number;
+  uuid: string;
+  accurate: boolean;
+};
+
+export async function scriptMain(sql: postgres.Sql, args: string[]) {
+  const { values } = parseArgs({
+    options: {
+      'dry-run': { type: 'boolean', default: false },
+      'batch-size': { type: 'string', default: '100' },
+      'start-id': { type: 'string' },
+      'end-id': { type: 'string' },
+    },
+    args,
+  });
+
+  const dryRun = values['dry-run'];
+  const batchSize = parseInt(values['batch-size']);
+  const startId = values['start-id'] ? parseInt(values['start-id']) : undefined;
+  const endId = values['end-id'] ? parseInt(values['end-id']) : undefined;
+
+  const dataRepository = dataRepositoryFromEnv();
+
+  let lastId = startId !== undefined ? startId - 1 : 0;
+  let challengesProcessed = 0;
+
+  const startTime = process.hrtime.bigint();
+
+  const totalChallenges = await sql`
+    SELECT COUNT(*)
+    FROM challenges c
+    JOIN challenge_splits cs
+      ON cs.challenge_id = c.id
+      AND cs.type = ANY(${BLOAT_SPLIT_TYPES})
+    WHERE c.type = ${ChallengeType.TOB}
+      AND c.id > ${lastId}
+      ${endId !== undefined ? sql`AND c.id <= ${endId}` : sql``}
+  `.then(([row]) => Number(row.count));
+
+  while (true) {
+    const challenges = await sql<readonly TobChallengeWithAccuracy[]>`
+      SELECT c.id, c.uuid, cs.accurate
+      FROM challenges c
+      JOIN challenge_splits cs
+        ON cs.challenge_id = c.id
+        AND cs.type = ANY(${BLOAT_SPLIT_TYPES})
+      WHERE c.type = ${ChallengeType.TOB}
+        AND c.id > ${lastId}
+        ${endId !== undefined ? sql`AND c.id <= ${endId}` : sql``}
+      ORDER BY c.id ASC
+      LIMIT ${batchSize}
+    `;
+
+    if (challenges.length === 0) {
+      break;
+    }
+
+    const promises = challenges.map(async (challenge) => {
+      let rooms: TobRooms;
+      try {
+        rooms = await dataRepository.loadTobChallengeData(challenge.uuid);
+      } catch (error) {
+        console.error(`Error loading challenge ${challenge.id}:`, error);
+        return;
+      }
+
+      if (rooms.bloat === null) {
+        return;
+      }
+
+      const downTicks = rooms.bloat.downTicks;
+
+      const rows = downTicks.map((tick, i) => ({
+        challenge_id: challenge.id,
+        down_number: i + 1,
+        down_tick: tick,
+        walk_ticks:
+          i === 0 ? tick : tick - downTicks[i - 1] - INTER_DOWN_OVERHEAD,
+        accurate: challenge.accurate,
+      }));
+
+      if (dryRun) {
+        console.log(
+          `Challenge ${challenge.id}: ${rows.length} downs, accurate=${challenge.accurate}`,
+          rows.map(
+            (r) => `d${r.down_number}@${r.down_tick} walk=${r.walk_ticks}`,
+          ),
+        );
+      } else {
+        if (rows.length > 0) {
+          await sql`
+            INSERT INTO bloat_downs ${sql(rows)}
+            ON CONFLICT (challenge_id, down_number) DO NOTHING
+          `;
+        }
+
+        await sql`
+          UPDATE tob_challenge_stats
+          SET bloat_down_count = ${downTicks.length}
+          WHERE challenge_id = ${challenge.id}
+        `;
+      }
+    });
+
+    await Promise.all(promises);
+
+    challengesProcessed += challenges.length;
+    lastId = challenges[challenges.length - 1].id;
+
+    const elapsed = Number(process.hrtime.bigint() - startTime) / 1e9;
+    const minutes = Math.floor(elapsed / 60);
+    const seconds = (elapsed % 60).toFixed(2);
+    console.log(
+      `Processed ${challengesProcessed} of ${totalChallenges} challenges in ${minutes}:${seconds.padStart(5, '0')}`,
+    );
+  }
+
+  console.log(`Completed. ${challengesProcessed} challenges processed.`);
+}

--- a/common/migrations/runner.ts
+++ b/common/migrations/runner.ts
@@ -82,16 +82,16 @@ async function runScript(dir: string, script: string, sql: Sql) {
     throw new Error(`Script "${srcPath}" not found`);
   }
 
-  try {
-    const { scriptMain } = (await import(fullPath)) as {
-      scriptMain: (sql: Sql, args: string[]) => Promise<void>;
-    };
-    await scriptMain(sql, process.argv.slice(4));
-  } catch {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require(fullPath) as {
+    scriptMain?: (sql: Sql, args: string[]) => Promise<void>;
+  };
+  if (typeof mod.scriptMain !== 'function') {
     throw new Error(
       `Script "${srcPath}" does not export a scriptMain function`,
     );
   }
+  await mod.scriptMain(sql, process.argv.slice(4));
 }
 
 export async function runMigrationsCli(options: MigrationRunnerOptions) {

--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -2,13 +2,22 @@ import {
   ChallengeMode,
   ChallengeStatus,
   ChallengeType,
+  Stage,
   SessionStatus,
   normalizeRsn,
   partyHash,
 } from '@blert/common';
 
-import { aggregateSessions, SessionQuery } from '@/actions/challenge';
+import {
+  aggregateSessions,
+  findChallenges,
+  SessionQuery,
+} from '@/actions/challenge';
 import { sql } from '@/actions/db';
+
+afterAll(async () => {
+  await sql.end();
+});
 
 describe('aggregateSessions', () => {
   let playerIds: number[];
@@ -265,10 +274,6 @@ describe('aggregateSessions', () => {
     await sql`DELETE FROM players`;
   });
 
-  afterAll(async () => {
-    await sql.end();
-  });
-
   describe('basic aggregations', () => {
     it('should aggregate count and duration for all non-hidden sessions', async () => {
       const query: SessionQuery = {};
@@ -386,6 +391,147 @@ describe('aggregateSessions', () => {
       );
 
       expect(Object.keys(result!)).toHaveLength(2);
+    });
+  });
+});
+
+describe('findChallenges', () => {
+  describe('bloat down filters', () => {
+    let playerId: number;
+    let sessionId: number;
+    let zeroDownChallengeId: number;
+    let oneDownChallengeId: number;
+
+    beforeEach(async () => {
+      [{ id: playerId }] = await sql<{ id: number }[]>`
+        INSERT INTO players ${sql([
+          {
+            username: 'PlayerA',
+            normalized_username: normalizeRsn('PlayerA'),
+          },
+        ])} RETURNING id
+      `;
+
+      [{ id: sessionId }] = await sql<{ id: number }[]>`
+        INSERT INTO challenge_sessions ${sql([
+          {
+            uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            challenge_type: ChallengeType.TOB,
+            challenge_mode: ChallengeMode.TOB_REGULAR,
+            scale: 2,
+            party_hash: partyHash(['PlayerA']),
+            start_time: new Date('2024-01-01T10:00:00Z'),
+            end_time: new Date('2024-01-01T10:30:00Z'),
+            status: SessionStatus.COMPLETED,
+          },
+        ])} RETURNING id
+      `;
+
+      const challenges = await sql<{ id: number }[]>`
+        INSERT INTO challenges ${sql([
+          {
+            session_id: sessionId,
+            uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+            type: ChallengeType.TOB,
+            mode: ChallengeMode.TOB_REGULAR,
+            stage: Stage.TOB_BLOAT,
+            status: ChallengeStatus.WIPED,
+            start_time: new Date('2024-01-01T10:00:00Z'),
+            finish_time: new Date('2024-01-01T10:10:00Z'),
+            scale: 2,
+            challenge_ticks: 600,
+            overall_ticks: 650,
+            total_deaths: 2,
+          },
+          {
+            session_id: sessionId,
+            uuid: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+            type: ChallengeType.TOB,
+            mode: ChallengeMode.TOB_REGULAR,
+            stage: Stage.TOB_VERZIK,
+            status: ChallengeStatus.COMPLETED,
+            start_time: new Date('2024-01-01T11:00:00Z'),
+            finish_time: new Date('2024-01-01T11:20:00Z'),
+            scale: 2,
+            challenge_ticks: 1200,
+            overall_ticks: 1250,
+            total_deaths: 0,
+          },
+        ])} RETURNING id
+      `;
+      [zeroDownChallengeId, oneDownChallengeId] = challenges.map((c) => c.id);
+
+      await sql`
+        INSERT INTO challenge_players ${sql([
+          {
+            challenge_id: zeroDownChallengeId,
+            player_id: playerId,
+            username: 'PlayerA',
+            orb: 0,
+            primary_gear: 0,
+          },
+          {
+            challenge_id: oneDownChallengeId,
+            player_id: playerId,
+            username: 'PlayerA',
+            orb: 0,
+            primary_gear: 0,
+          },
+        ])}
+      `;
+
+      await sql`
+        INSERT INTO tob_challenge_stats ${sql([
+          {
+            challenge_id: zeroDownChallengeId,
+            bloat_down_count: 0,
+          },
+          {
+            challenge_id: oneDownChallengeId,
+            bloat_down_count: 1,
+          },
+        ])}
+      `;
+
+      await sql`
+        INSERT INTO bloat_downs ${sql([
+          {
+            challenge_id: oneDownChallengeId,
+            down_number: 1,
+            down_tick: 41,
+            walk_ticks: 41,
+            accurate: true,
+          },
+        ])}
+      `;
+    });
+
+    afterEach(async () => {
+      await sql`DELETE FROM challenge_players`;
+      await sql`DELETE FROM challenges`;
+      await sql`DELETE FROM challenge_sessions`;
+      await sql`DELETE FROM players`;
+    });
+
+    it('matches zero-down raids for tob.bloatDownCount=eq0', async () => {
+      const [challenges] = await findChallenges(10, {
+        tob: { bloatDownCount: ['==', 0] },
+      });
+
+      expect(challenges).toHaveLength(1);
+      expect(challenges[0].uuid).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+    });
+
+    it('combines persisted down count and bloat down filters', async () => {
+      const [challenges] = await findChallenges(10, {
+        tob: {
+          bloatDowns: new Map([[1, ['==', 41]]]),
+          bloatDownCount: ['==', 1],
+        },
+      });
+
+      expect(challenges).toHaveLength(1);
+      expect(challenges[0].uuid).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc');
     });
   });
 });

--- a/web/__tests__/actions/theatre.test.ts
+++ b/web/__tests__/actions/theatre.test.ts
@@ -2,11 +2,18 @@ import {
   ChallengeMode,
   ChallengeStatus,
   ChallengeType,
+  EventType,
   normalizeRsn,
+  QueryableEventRow,
+  Stage,
 } from '@blert/common';
 
 import { sql } from '@/actions/db';
-import { aggregateBloatHands } from '@/actions/bloat-hands';
+import { aggregateBloatDowns, aggregateBloatHands } from '@/actions/theatre';
+
+afterAll(async () => {
+  await sql.end();
+});
 
 describe('aggregateBloatHands', () => {
   let challengeIds: number[];
@@ -155,10 +162,6 @@ describe('aggregateBloatHands', () => {
     await sql`REFRESH MATERIALIZED VIEW mv_bloat_hands_daily`;
   });
 
-  afterAll(async () => {
-    await sql.end();
-  });
-
   it('aggregates total hands per tile across all non-abandoned challenges', async () => {
     const result = await aggregateBloatHands({});
 
@@ -229,5 +232,203 @@ describe('aggregateBloatHands', () => {
     expect(result.totalChallenges).toBe(0);
     expect(result.totalHands).toBe(0);
     expect(result.byTile).toEqual({});
+  });
+});
+
+describe('aggregateBloatDowns', () => {
+  let challengeIds: number[];
+
+  function bloatDownEvent(
+    challengeId: number,
+    mode: ChallengeMode,
+    tick: number,
+    downNumber: number,
+    walkTicks: number,
+  ): QueryableEventRow {
+    return {
+      challenge_id: challengeId,
+      event_type: EventType.TOB_BLOAT_DOWN,
+      stage: Stage.TOB_BLOAT,
+      mode,
+      tick,
+      x_coord: 0,
+      y_coord: 0,
+      subtype: null,
+      player_id: null,
+      npc_id: null,
+      custom_int_1: null,
+      custom_int_2: null,
+      custom_short_1: downNumber,
+      custom_short_2: walkTicks,
+    };
+  }
+
+  beforeEach(async () => {
+    const players = [
+      {
+        username: 'Player1',
+        normalized_username: normalizeRsn('Player1'),
+        total_recordings: 5,
+        overall_experience: 200_000_000,
+        attack_experience: 13_000_000,
+        defence_experience: 13_000_000,
+        strength_experience: 13_000_000,
+        hitpoints_experience: 13_000_000,
+        ranged_experience: 13_000_000,
+        prayer_experience: 13_000_000,
+        magic_experience: 13_000_000,
+      },
+    ];
+
+    await sql`INSERT INTO players ${sql(players)}`;
+
+    const challenges = [
+      {
+        uuid: '11111111-1111-1111-1111-111111111111',
+        start_time: new Date('2024-01-01'),
+        type: ChallengeType.TOB,
+        mode: ChallengeMode.TOB_REGULAR,
+        status: ChallengeStatus.COMPLETED,
+        scale: 4,
+        challenge_ticks: 1000,
+        overall_ticks: 1200,
+        total_deaths: 0,
+      },
+      {
+        uuid: '22222222-2222-2222-2222-222222222222',
+        start_time: new Date('2024-01-02'),
+        type: ChallengeType.TOB,
+        mode: ChallengeMode.TOB_REGULAR,
+        status: ChallengeStatus.COMPLETED,
+        scale: 4,
+        challenge_ticks: 1100,
+        overall_ticks: 1300,
+        total_deaths: 0,
+      },
+      {
+        uuid: '33333333-3333-3333-3333-333333333333',
+        start_time: new Date('2024-01-03'),
+        type: ChallengeType.TOB,
+        mode: ChallengeMode.TOB_HARD,
+        status: ChallengeStatus.COMPLETED,
+        scale: 4,
+        challenge_ticks: 1200,
+        overall_ticks: 1400,
+        total_deaths: 0,
+      },
+      {
+        uuid: '44444444-4444-4444-4444-444444444444',
+        start_time: new Date('2024-01-04'),
+        type: ChallengeType.TOB,
+        mode: ChallengeMode.TOB_REGULAR,
+        status: ChallengeStatus.ABANDONED,
+        scale: 4,
+        challenge_ticks: 800,
+        overall_ticks: 800,
+        total_deaths: 0,
+      },
+    ];
+
+    const challengeResults =
+      await sql`INSERT INTO challenges ${sql(challenges)} RETURNING id`;
+    challengeIds = challengeResults.map((r) => r.id);
+
+    const mode = ChallengeMode.TOB_REGULAR;
+    const hmMode = ChallengeMode.TOB_HARD;
+
+    const events = [
+      // Challenge 1: 3-down bloat, walk times 41, 40, 39
+      bloatDownEvent(challengeIds[0], mode, 41, 1, 41),
+      bloatDownEvent(challengeIds[0], mode, 115, 2, 40),
+      bloatDownEvent(challengeIds[0], mode, 189, 3, 39),
+      // Challenge 2: 2-down bloat, walk times 41, 42
+      bloatDownEvent(challengeIds[1], mode, 41, 1, 41),
+      bloatDownEvent(challengeIds[1], mode, 117, 2, 42),
+      // Challenge 3 (hard mode): 3-down bloat, walk times 39, 38, 40
+      bloatDownEvent(challengeIds[2], hmMode, 39, 1, 39),
+      bloatDownEvent(challengeIds[2], hmMode, 111, 2, 38),
+      bloatDownEvent(challengeIds[2], hmMode, 185, 3, 40),
+      // Challenge 4 (abandoned): should be excluded
+      bloatDownEvent(challengeIds[3], mode, 41, 1, 41),
+    ];
+
+    await sql`INSERT INTO queryable_events ${sql(events)}`;
+    await sql`REFRESH MATERIALIZED VIEW mv_bloat_downs_daily`;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM queryable_events`;
+    await sql`DELETE FROM challenges`;
+    await sql`DELETE FROM players`;
+    await sql`REFRESH MATERIALIZED VIEW mv_bloat_downs_daily`;
+  });
+
+  it('aggregates walk time distribution across all non-abandoned challenges', async () => {
+    const result = await aggregateBloatDowns({});
+
+    // 8 total downs (3 + 2 + 3), abandoned challenge excluded
+    expect(result.totalDowns).toBe(8);
+    expect(result.byWalkTicks['38']).toBe(1);
+    expect(result.byWalkTicks['39']).toBe(2);
+    expect(result.byWalkTicks['40']).toBe(2);
+    expect(result.byWalkTicks['41']).toBe(2);
+    expect(result.byWalkTicks['42']).toBe(1);
+  });
+
+  it('filters by mode', async () => {
+    const result = await aggregateBloatDowns({
+      mode: [ChallengeMode.TOB_REGULAR],
+    });
+    expect(result.totalDowns).toBe(5);
+    expect(result.byWalkTicks['41']).toBe(2);
+    expect(result.byWalkTicks['38']).toBeUndefined();
+  });
+
+  it('filters by down number', async () => {
+    const result = await aggregateBloatDowns({
+      downNumber: ['==', 1],
+    });
+    expect(result.totalDowns).toBe(3);
+    expect(result.byWalkTicks['41']).toBe(2);
+    expect(result.byWalkTicks['39']).toBe(1);
+  });
+
+  it('filters by down number with comparator', async () => {
+    const result = await aggregateBloatDowns({
+      downNumber: ['>', 1],
+    });
+    expect(result.totalDowns).toBe(5);
+    expect(result.byWalkTicks).not.toHaveProperty('41');
+  });
+
+  it('filters by scale', async () => {
+    const result = await aggregateBloatDowns({ scale: [5] });
+    expect(result.totalDowns).toBe(0);
+    expect(result.byWalkTicks).toEqual({});
+  });
+
+  it('filters by date range', async () => {
+    const result = await aggregateBloatDowns({
+      startTime: ['>=', new Date('2024-01-02')],
+    });
+    expect(result.totalDowns).toBe(5);
+  });
+
+  it('combines mode and down number filters', async () => {
+    const result = await aggregateBloatDowns({
+      mode: [ChallengeMode.TOB_HARD],
+      downNumber: ['==', 1],
+    });
+
+    expect(result.totalDowns).toBe(1);
+    expect(result.byWalkTicks['39']).toBe(1);
+  });
+
+  it('returns empty when no challenges match', async () => {
+    const result = await aggregateBloatDowns({
+      mode: [ChallengeMode.TOB_ENTRY],
+    });
+    expect(result.totalDowns).toBe(0);
+    expect(result.byWalkTicks).toEqual({});
   });
 });

--- a/web/__tests__/api/challenge-query.test.ts
+++ b/web/__tests__/api/challenge-query.test.ts
@@ -1,0 +1,225 @@
+import { ChallengeMode, ChallengeType, SplitType, Stage } from '@blert/common';
+
+import { parseChallengeQueryParams } from '@/api/v1/challenges/query';
+
+function parse(params: Record<string, string>) {
+  return parseChallengeQueryParams(new URLSearchParams(params));
+}
+
+describe('parseChallengeQuery', () => {
+  it('should return an empty query for no params', () => {
+    const query = parse({});
+    expect(query).not.toBeNull();
+    expect(query!.splits!.size).toBe(0);
+    expect(query!.customConditions).toEqual([]);
+  });
+
+  describe('party', () => {
+    it('should parse a single player', () => {
+      const query = parse({ party: 'WWWWWWWWWWQQ' });
+      expect(query!.party).toEqual(['WWWWWWWWWWQQ']);
+    });
+
+    it('should parse multiple players', () => {
+      const query = parse({ party: 'Caps lock13,Yieldofin' });
+      expect(query!.party).toEqual(['Caps lock13', 'Yieldofin']);
+    });
+  });
+
+  describe('mode', () => {
+    it('should parse a single mode', () => {
+      const query = parse({ mode: String(ChallengeMode.TOB_REGULAR) });
+      expect(query!.mode).toEqual([ChallengeMode.TOB_REGULAR]);
+    });
+
+    it('should parse multiple modes', () => {
+      const query = parse({
+        mode: `${ChallengeMode.TOB_REGULAR},${ChallengeMode.TOB_HARD}`,
+      });
+      expect(query!.mode).toEqual([
+        ChallengeMode.TOB_REGULAR,
+        ChallengeMode.TOB_HARD,
+      ]);
+    });
+
+    it('should filter out non-numeric modes', () => {
+      const query = parse({ mode: `${ChallengeMode.TOB_REGULAR},abc` });
+      expect(query!.mode).toEqual([ChallengeMode.TOB_REGULAR]);
+    });
+  });
+
+  describe('sort', () => {
+    it('should parse a descending sort', () => {
+      const query = parse({ sort: '-startTime' });
+      expect(query!.sort).toEqual(['-startTime#nl']);
+    });
+
+    it('should parse an ascending sort', () => {
+      const query = parse({ sort: '+challengeTicks' });
+      expect(query!.sort).toEqual(['+challengeTicks#nl']);
+    });
+
+    it('should parse two sort fields', () => {
+      const query = parse({ sort: '-startTime,+id' });
+      expect(query!.sort).toHaveLength(2);
+    });
+
+    it('should reject more than two sort fields', () => {
+      expect(parse({ sort: '-a,+b,-c' })).toBeNull();
+    });
+
+    it('should reject sort without direction prefix', () => {
+      expect(parse({ sort: 'startTime' })).toBeNull();
+    });
+
+    it('should reverse sort direction with before param', () => {
+      const query = parse({ sort: '-startTime', before: '100' });
+      expect(query!.sort).toEqual(['+startTime#nf']);
+    });
+  });
+
+  describe('pagination', () => {
+    it('should reject both before and after', () => {
+      expect(
+        parse({ sort: '-startTime', before: '100', after: '200' }),
+      ).toBeNull();
+    });
+  });
+
+  describe('comparator params', () => {
+    it('should parse type', () => {
+      const query = parse({ type: String(ChallengeType.TOB) });
+      expect(query!.type).toEqual(['==', ChallengeType.TOB]);
+    });
+
+    it('should parse scale', () => {
+      const query = parse({ scale: 'ge4' });
+      expect(query!.scale).toEqual(['>=', 4]);
+    });
+
+    it('should parse status as a list', () => {
+      const query = parse({ status: '1,2' });
+      expect(query!.status).toEqual(['in', [1, 2]]);
+    });
+
+    it('should parse challengeTicks', () => {
+      const query = parse({ challengeTicks: 'lt1000' });
+      expect(query!.challengeTicks).toEqual(['<', 1000]);
+    });
+
+    it('should parse stage', () => {
+      const query = parse({ stage: String(Stage.TOB_BLOAT) });
+      expect(query!.stage).toEqual(['==', Stage.TOB_BLOAT]);
+    });
+
+    it('should parse startTime as a date comparator', () => {
+      const timestamp = Date.now();
+      const query = parse({ startTime: `ge${timestamp}` });
+      expect(query).not.toBeNull();
+      expect(query!.startTime![0]).toBe('>=');
+    });
+
+    it('should reject invalid comparator values', () => {
+      expect(parse({ type: 'invalid' })).toBeNull();
+    });
+  });
+
+  describe('split params', () => {
+    it('should parse split comparators', () => {
+      const query = parse({ 'split:28': 'le600' });
+      expect(query).not.toBeNull();
+      expect(query!.splits!.get(SplitType.TOB_REG_BLOAT)).toEqual(['<=', 600]);
+    });
+
+    it('should parse multiple splits', () => {
+      const query = parse({ 'split:28': 'le600', 'split:7': 'lt300' });
+      expect(query!.splits!.size).toBe(2);
+      expect(query!.splits!.get(28)).toEqual(['<=', 600]);
+      expect(query!.splits!.get(7)).toEqual(['<', 300]);
+    });
+
+    it('should reject non-numeric split type', () => {
+      expect(parse({ 'split:abc': 'le600' })).toBeNull();
+    });
+
+    it('should reject invalid comparator value', () => {
+      expect(parse({ 'split:28': 'invalid' })).toBeNull();
+    });
+  });
+
+  describe('tob.bloatDown params', () => {
+    it('should parse a single down walk time filter', () => {
+      const query = parse({ 'tob.bloatDown:1': 'le39' });
+      expect(query).not.toBeNull();
+      expect(query!.tob!.bloatDowns!.get(1)).toEqual(['<=', 39]);
+    });
+
+    it('should parse multiple down walk time filters', () => {
+      const query = parse({
+        'tob.bloatDown:1': 'eq41',
+        'tob.bloatDown:2': 'le42',
+      });
+      expect(query).not.toBeNull();
+      expect(query!.tob!.bloatDowns!.get(1)).toEqual(['==', 41]);
+      expect(query!.tob!.bloatDowns!.get(2)).toEqual(['<=', 42]);
+    });
+
+    it('should reject down number < 1', () => {
+      expect(parse({ 'tob.bloatDown:0': 'le39' })).toBeNull();
+      expect(parse({ 'tob.bloatDown:-10': 'le39' })).toBeNull();
+    });
+
+    it('should reject non-numeric down number', () => {
+      expect(parse({ 'tob.bloatDown:abc': 'le39' })).toBeNull();
+    });
+
+    it('should reject invalid comparator value', () => {
+      expect(parse({ 'tob.bloatDown:1': 'invalid' })).toBeNull();
+    });
+  });
+
+  describe('tob.bloatDownCount param', () => {
+    it('should parse a down count comparator', () => {
+      const query = parse({ 'tob.bloatDownCount': 'eq3' });
+      expect(query).not.toBeNull();
+      expect(query!.tob!.bloatDownCount).toEqual(['==', 3]);
+    });
+
+    it('should parse a range down count', () => {
+      const query = parse({ 'tob.bloatDownCount': '2..5' });
+      expect(query).not.toBeNull();
+      expect(query!.tob!.bloatDownCount).toEqual(['range', [2, 5]]);
+    });
+  });
+
+  describe('unknown namespaced params', () => {
+    it('should ignore unknown namespaces', () => {
+      const query = parse({ 'unknown:1': 'eq5' });
+      expect(query).not.toBeNull();
+      expect(query!.splits!.size).toBe(0);
+      expect(query!.tob).toBeUndefined();
+    });
+  });
+
+  describe('combined params', () => {
+    it('should parse a complex query', () => {
+      const query = parse({
+        party: 'WWWWWWWWWWQQ',
+        mode: String(ChallengeMode.TOB_REGULAR),
+        type: String(ChallengeType.TOB),
+        'split:28': 'le600',
+        'tob.bloatDown:1': 'eq41',
+        'tob.bloatDownCount': 'eq3',
+        sort: '-startTime',
+      });
+      expect(query).not.toBeNull();
+      expect(query!.party).toEqual(['WWWWWWWWWWQQ']);
+      expect(query!.mode).toEqual([ChallengeMode.TOB_REGULAR]);
+      expect(query!.type).toEqual(['==', ChallengeType.TOB]);
+      expect(query!.splits!.get(28)).toEqual(['<=', 600]);
+      expect(query!.tob!.bloatDowns!.get(1)).toEqual(['==', 41]);
+      expect(query!.tob!.bloatDownCount).toEqual(['==', 3]);
+      expect(query!.sort).toEqual(['-startTime#nl']);
+    });
+  });
+});

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -300,6 +300,11 @@ export type SortableFields =
 
 type SingleOrArray<T> = T | T[];
 
+export type TobQuery = {
+  bloatDowns?: Map<number, Comparator<number>>;
+  bloatDownCount?: Comparator<number>;
+};
+
 export type ChallengeQuery = {
   uuid?: string[];
   session?: number[] | string[];
@@ -311,6 +316,7 @@ export type ChallengeQuery = {
   /** Whether all players must be present ('all') or any player ('any'). Default: 'all' */
   partyMatch?: 'all' | 'any';
   splits?: Map<SplitType, Comparator<number>>;
+  tob?: TobQuery;
   sort?: SingleOrArray<SortQuery<SortableFields>>;
   startTime?: Comparator<Date>;
   challengeTicks?: Comparator<number>;
@@ -594,6 +600,53 @@ function applyFilters(
       on: sql`${sqlChallenges}.id = filtered_splits.challenge_id`,
       tableName: 'challenges_with_splits',
     });
+  }
+
+  if (query.tob !== undefined) {
+    const { bloatDowns, bloatDownCount } = query.tob;
+    const bloatDownConditions: postgres.Fragment[] = [];
+
+    if (bloatDowns !== undefined && bloatDowns.size > 0) {
+      for (const [downNumber, comparator] of bloatDowns) {
+        const condition = comparatorToSql(
+          sql('bloat_downs'),
+          'walk_ticks',
+          comparator,
+        );
+        bloatDownConditions.push(
+          sql`(bloat_downs.down_number = ${downNumber} AND ${condition})`,
+        );
+      }
+    }
+
+    if (bloatDownConditions.length > 0) {
+      joins.push({
+        table: sql`(
+          SELECT challenge_id
+          FROM bloat_downs
+          WHERE accurate
+          GROUP BY challenge_id
+          HAVING COUNT(*) FILTER (${where(bloatDownConditions, 'or')}) = ${bloatDownConditions.length}
+        ) filtered_bloat_downs`,
+        on: sql`${sqlChallenges}.id = filtered_bloat_downs.challenge_id`,
+        tableName: 'filtered_bloat_downs',
+      });
+    }
+
+    if (bloatDownCount !== undefined) {
+      joins.push({
+        table: sql`tob_challenge_stats`,
+        on: sql`${sqlChallenges}.id = tob_challenge_stats.challenge_id`,
+        tableName: 'tob_challenge_stats',
+      });
+      conditions.push(
+        comparatorToSql(
+          sql('tob_challenge_stats'),
+          'bloat_down_count',
+          bloatDownCount,
+        ),
+      );
+    }
   }
 
   if (query.sort !== undefined) {
@@ -1142,6 +1195,13 @@ export async function aggregateChallenges<
 
     if (!Array.isArray(aggs)) {
       aggs = [aggs];
+    }
+
+    const invalidAggregations = aggs.filter((agg) => !isAggregation(agg));
+    if (invalidAggregations.length > 0) {
+      throw new InvalidQueryError(
+        `Invalid aggregations: ${invalidAggregations.join(', ')}`,
+      );
     }
 
     const [tableField, table] = shorthandToFullField(camelToSnake(field));
@@ -2018,6 +2078,13 @@ export async function aggregateSessions<
 
     if (!Array.isArray(aggs)) {
       aggs = [aggs];
+    }
+
+    const invalidAggregations = aggs.filter((agg) => !isAggregation(agg));
+    if (invalidAggregations.length > 0) {
+      throw new InvalidQueryError(
+        `Invalid aggregations: ${invalidAggregations.join(', ')}`,
+      );
     }
 
     const fieldExpression = sessionFieldToExpression(field);

--- a/web/app/actions/query.ts
+++ b/web/app/actions/query.ts
@@ -92,18 +92,40 @@ export function comparatorToSql(
   table: postgres.Helper<string>,
   column: string,
   comparator: Comparator<ComparableValue>,
+): postgres.Fragment;
+
+export function comparatorToSql(
+  expression: postgres.Fragment,
+  comparator: Comparator<ComparableValue>,
+): postgres.Fragment;
+
+export function comparatorToSql(
+  ...args:
+    | [postgres.Helper<string>, string, Comparator<ComparableValue>]
+    | [postgres.Fragment, Comparator<ComparableValue>]
 ): postgres.Fragment {
+  let lhs: postgres.Fragment;
+  let comparator: Comparator<ComparableValue>;
+
+  if (args.length === 3) {
+    const [table, column] = args;
+    lhs = sql`${table}.${sql(column)}`;
+    comparator = args[2];
+  } else {
+    [lhs, comparator] = args;
+  }
+
   if (comparator[0] === 'in') {
-    return sql`${table}.${sql(column)} = ANY(${comparator[1]})`;
+    return sql`${lhs} = ANY(${comparator[1]})`;
   }
 
   if (comparator[0] === 'range') {
     const [start, end] = comparator[1];
-    return sql`${table}.${sql(column)} >= ${start} AND ${table}.${sql(column)} < ${end}`;
+    return sql`${lhs} >= ${start} AND ${lhs} < ${end}`;
   }
 
   const op = operator(comparator[0]);
-  return sql`${table}.${sql(column)} ${op} ${comparator[1]}`;
+  return sql`${lhs} ${op} ${comparator[1]}`;
 }
 
 export type BaseOperand = number | string | null;

--- a/web/app/actions/theatre.ts
+++ b/web/app/actions/theatre.ts
@@ -74,3 +74,59 @@ export async function aggregateBloatHands(
     ),
   };
 }
+
+export type BloatDownsQuery = {
+  mode?: ChallengeMode[];
+  scale?: number[];
+  startTime?: Comparator<Date>;
+  downNumber?: Comparator<number>;
+};
+
+export type BloatDownsResponse = {
+  totalDowns: number;
+  byWalkTicks: Record<string, number>;
+};
+
+/**
+ * Aggregates bloat down walk time distributions filtered by mode, scale, date
+ * range, and down number.
+ */
+export async function aggregateBloatDowns(
+  query: BloatDownsQuery,
+): Promise<BloatDownsResponse> {
+  const mv = sql('mv_bloat_downs_daily');
+  const conditions: postgres.Fragment[] = [];
+
+  if (query.mode !== undefined) {
+    conditions.push(sql`${mv}.mode = ANY(${query.mode})`);
+  }
+
+  if (query.scale !== undefined) {
+    conditions.push(sql`${mv}.scale = ANY(${query.scale})`);
+  }
+
+  if (query.startTime !== undefined) {
+    conditions.push(comparatorToSql(mv, 'day', query.startTime));
+  }
+
+  if (query.downNumber !== undefined) {
+    conditions.push(comparatorToSql(mv, 'down_number', query.downNumber));
+  }
+
+  const rows = await sql<{ walk_ticks: number; count: number }[]>`
+    SELECT
+      walk_ticks,
+      SUM(count)::int AS count
+    FROM ${mv}
+    ${where(conditions)}
+    GROUP BY walk_ticks
+    ORDER BY walk_ticks
+  `;
+
+  return {
+    totalDowns: rows.reduce((sum, row) => sum + row.count, 0),
+    byWalkTicks: Object.fromEntries(
+      rows.map((row) => [row.walk_ticks.toString(), row.count]),
+    ),
+  };
+}

--- a/web/app/api/v1/challenges/query.ts
+++ b/web/app/api/v1/challenges/query.ts
@@ -1,7 +1,7 @@
 import { ChallengeMode, SplitType } from '@blert/common';
 
 import { ChallengeQuery, SortQuery, SortableFields } from '@/actions/challenge';
-import { Condition, Operator, parseQuery } from '@/actions/query';
+import { Comparator, Condition, Operator, parseQuery } from '@/actions/query';
 import {
   dateComparatorParam,
   expectSingle,
@@ -9,6 +9,29 @@ import {
   numericComparatorValue,
 } from '@/api/query';
 import { NextSearchParams } from '@/utils/url';
+
+type NamespacedParamHandler = {
+  validateKey?: (id: number) => boolean;
+  apply: (
+    query: ChallengeQuery,
+    id: number,
+    comparator: Comparator<number>,
+  ) => void;
+};
+
+const namespacedParams: Record<string, NamespacedParamHandler> = {
+  split: {
+    apply: (query, id, comparator) => {
+      (query.splits ??= new Map()).set(id as SplitType, comparator);
+    },
+  },
+  'tob.bloatDown': {
+    validateKey: (id) => id >= 1,
+    apply: (query, id, comparator) => {
+      ((query.tob ??= {}).bloatDowns ??= new Map()).set(id, comparator);
+    },
+  },
+};
 
 export function parseChallengeQueryParams(
   searchParams: URLSearchParams,
@@ -86,26 +109,33 @@ export function parseChallengeQuery(
   }
 
   for (const [key, value] of Object.entries(searchParams)) {
-    if (key.startsWith('split:')) {
-      if (value === undefined || Array.isArray(value)) {
-        return null;
-      }
+    const colonIndex = key.indexOf(':');
+    if (colonIndex === -1) {
+      continue;
+    }
 
-      const parts = key.split(':');
-      if (parts.length !== 2) {
-        return null;
-      }
+    const handler = namespacedParams[key.slice(0, colonIndex)];
+    if (handler === undefined) {
+      continue;
+    }
 
-      const split = parseInt(parts[1]) as SplitType;
-      if (Number.isNaN(split)) {
-        return null;
-      }
+    if (value === undefined || Array.isArray(value)) {
+      return null;
+    }
 
-      try {
-        query.splits!.set(split, numericComparatorValue(value));
-      } catch {
-        return null;
-      }
+    const id = parseInt(key.slice(colonIndex + 1));
+    if (Number.isNaN(id)) {
+      return null;
+    }
+
+    if (handler.validateKey !== undefined && !handler.validateKey(id)) {
+      return null;
+    }
+
+    try {
+      handler.apply(query, id, numericComparatorValue(value));
+    } catch {
+      return null;
     }
   }
 
@@ -119,6 +149,14 @@ export function parseChallengeQuery(
       'challengeTicks',
     );
     query.stage = numericComparatorParam(searchParams, 'stage');
+
+    const bloatDownCount = numericComparatorParam(
+      searchParams,
+      'tob.bloatDownCount',
+    );
+    if (bloatDownCount !== undefined) {
+      (query.tob ??= {}).bloatDownCount = bloatDownCount;
+    }
   } catch {
     return null;
   }

--- a/web/app/api/v1/trends/bloat-downs/route.ts
+++ b/web/app/api/v1/trends/bloat-downs/route.ts
@@ -1,16 +1,20 @@
 import { ChallengeMode } from '@blert/common';
 import { NextRequest } from 'next/server';
 
-import { aggregateBloatHands, BloatHandsQuery } from '@/actions/theatre';
+import { aggregateBloatDowns, BloatDownsQuery } from '@/actions/theatre';
 import { withApiRoute } from '@/api/handler';
-import { dateComparatorParam, expectSingle } from '@/api/query';
+import {
+  dateComparatorParam,
+  expectSingle,
+  numericComparatorParam,
+} from '@/api/query';
 
 export const GET = withApiRoute(
-  { route: '/api/v1/trends/bloat-hands' },
+  { route: '/api/v1/trends/bloat-downs' },
   async (request: NextRequest) => {
     const searchParams = Object.fromEntries(request.nextUrl.searchParams);
 
-    const query: BloatHandsQuery = {};
+    const query: BloatDownsQuery = {};
 
     const mode = expectSingle(searchParams, 'mode');
     if (mode !== undefined) {
@@ -20,22 +24,22 @@ export const GET = withApiRoute(
         .filter((m) => !isNaN(m)) as ChallengeMode[];
     }
 
-    const order = expectSingle(searchParams, 'intraChunkOrder');
-    if (order !== undefined) {
-      const parsed = parseInt(order);
-      if (isNaN(parsed)) {
-        return new Response(null, { status: 400 });
-      }
-      query.intraChunkOrder = parsed;
+    const scale = expectSingle(searchParams, 'scale');
+    if (scale !== undefined) {
+      query.scale = scale
+        .split(',')
+        .map((s) => parseInt(s))
+        .filter((s) => !isNaN(s));
     }
 
     try {
       query.startTime = dateComparatorParam(searchParams, 'startTime');
+      query.downNumber = numericComparatorParam(searchParams, 'downNumber');
     } catch {
       return new Response(null, { status: 400 });
     }
 
-    const result = await aggregateBloatHands(query);
+    const result = await aggregateBloatDowns(query);
     return Response.json(result);
   },
 );

--- a/web/app/trends/bloat-hands/bloat-hands.tsx
+++ b/web/app/trends/bloat-hands/bloat-hands.tsx
@@ -3,7 +3,7 @@
 import { ChallengeMode } from '@blert/common';
 import { useState, useEffect, useCallback } from 'react';
 
-import { BloatHandsResponse } from '@/actions/bloat-hands';
+import { BloatHandsResponse } from '@/actions/theatre';
 
 import BloatHandsControls, { BloatHandsFilters, DisplayMode } from './controls';
 import BloatHandsStats from './stats';

--- a/web/app/trends/bloat-hands/stats.tsx
+++ b/web/app/trends/bloat-hands/stats.tsx
@@ -1,6 +1,6 @@
 import { ChallengeMode } from '@blert/common';
 
-import { BloatHandsResponse } from '@/actions/bloat-hands';
+import { BloatHandsResponse } from '@/actions/theatre';
 import { getOrdinal } from '@/utils/path-util';
 
 import { BloatHandsFilters, DisplayMode } from './controls';

--- a/web/app/trends/bloat-hands/visualizer.tsx
+++ b/web/app/trends/bloat-hands/visualizer.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { BloatHandsResponse } from '@/actions/bloat-hands';
+import { BloatHandsResponse } from '@/actions/theatre';
 import Tooltip from '@/components/tooltip';
 
 import { DisplayMode } from './controls';


### PR DESCRIPTION
Bloat downs were previously only stored in data files and queryable events (which only includes accurate ones). However, it's common for users to want to find raids where they had a specific walk time or number of downs.

This creates a new bloat_downs table which stores all downs for a ToB raid with accuracy (as they are time-based), with a backfill script to populate historic downs from static Bloat room data. For querying, adds filters to the challenge search/aggregation APIs for down count and per-down walk times.

Additionally, this creates a materialized view over the existing queryable events Bloat down data which collects downs by date, number, and walk time, with an API route to query aggregate down stats.