### PR TITLE
web: Add Bloat first walk to session analysis

### DIFF
--- a/common/challenge.ts
+++ b/common/challenge.ts
@@ -104,6 +104,13 @@ export type TobRooms = {
   verzik: Nullable<TobRoom & { redsSpawnCount: number }>;
 };
 
+export type BloatDown = {
+  downNumber: number;
+  downTick: number;
+  walkTicks: number;
+  accurate: boolean;
+};
+
 export type TobChallengeStats = {
   maidenDeaths: number;
   maidenFullLeaks: number | null;
@@ -111,6 +118,7 @@ export type TobChallengeStats = {
   bloatDeaths: number;
   bloatDownCount: number | null;
   bloatFirstDownHpPercent: number | null;
+  downs?: BloatDown[];
   nylocasDeaths: number;
   nylocasPreCapStalls: number | null;
   nylocasPostCapStalls: number | null;

--- a/common/index.ts
+++ b/common/index.ts
@@ -90,6 +90,7 @@ export {
 } from './event';
 
 export type {
+  BloatDown,
   Challenge,
   ChallengePlayer,
   ColosseumChallenge,

--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   aggregateSessions,
   findChallenges,
+  loadSessionWithStats,
   SessionQuery,
 } from '@/actions/challenge';
 import { sql } from '@/actions/db';
@@ -19,7 +20,7 @@ afterAll(async () => {
   await sql.end();
 });
 
-describe('aggregateSessions', () => {
+describe('sessions', () => {
   let playerIds: number[];
   let sessionIds: number[];
   let partyHash1: string;
@@ -274,123 +275,243 @@ describe('aggregateSessions', () => {
     await sql`DELETE FROM players`;
   });
 
-  describe('basic aggregations', () => {
-    it('should aggregate count and duration for all non-hidden sessions', async () => {
-      const query: SessionQuery = {};
-      const result = await aggregateSessions(query, {
-        '*': 'count',
-        duration: ['sum', 'avg', 'min', 'max'],
-        challenges: ['sum', 'avg'],
+  describe('aggregateSessions', () => {
+    describe('basic aggregations', () => {
+      it('should aggregate count and duration for all non-hidden sessions', async () => {
+        const query: SessionQuery = {};
+        const result = await aggregateSessions(query, {
+          '*': 'count',
+          duration: ['sum', 'avg', 'min', 'max'],
+          challenges: ['sum', 'avg'],
+        });
+
+        expect(result).not.toBeNull();
+        expect(result!['*'].count).toBe(4);
+        // Durations: 3600, 2700, 1800, 900.
+        expect(result!.duration.sum).toBe(3600 + 2700 + 1800 + 900);
+        expect(result!.duration.avg).toBeCloseTo(
+          (3600 + 2700 + 1800 + 900) / 4,
+        );
+        expect(result!.duration.min).toBe(900);
+        expect(result!.duration.max).toBe(3600);
+        // Challenges (non-abandoned): 2, 2, 1, 1 -> sum=6, avg=1.5
+        expect(result!.challenges.sum).toBe(6);
+        expect(result!.challenges.avg).toBe(1.5);
+      });
+    });
+
+    describe('filtering', () => {
+      it('should filter by session status', async () => {
+        const query: SessionQuery = { status: ['==', SessionStatus.COMPLETED] };
+        const result = await aggregateSessions(query, { '*': 'count' });
+        expect(result!['*'].count).toBe(3);
       });
 
-      expect(result).not.toBeNull();
-      expect(result!['*'].count).toBe(4);
-      // Durations: 3600, 2700, 1800, 900.
-      expect(result!.duration.sum).toBe(3600 + 2700 + 1800 + 900);
-      expect(result!.duration.avg).toBeCloseTo((3600 + 2700 + 1800 + 900) / 4);
-      expect(result!.duration.min).toBe(900);
-      expect(result!.duration.max).toBe(3600);
-      // Challenges (non-abandoned): 2, 2, 1, 1 -> sum=6, avg=1.5
-      expect(result!.challenges.sum).toBe(6);
-      expect(result!.challenges.avg).toBe(1.5);
+      it('should filter by challenge type', async () => {
+        const query: SessionQuery = { type: ['==', ChallengeType.COLOSSEUM] };
+        const result = await aggregateSessions(query, { '*': 'count' });
+        expect(result!['*'].count).toBe(1);
+      });
+    });
+
+    describe('grouping', () => {
+      it('should group by challenge mode', async () => {
+        const query: SessionQuery = {};
+        const result = await aggregateSessions(
+          query,
+          { '*': 'count' },
+          {},
+          'mode',
+        );
+
+        expect(result).not.toBeNull();
+        const regular = ChallengeMode.TOB_REGULAR.toString();
+        const hard = ChallengeMode.TOB_HARD.toString();
+        const colo = ChallengeMode.NO_MODE.toString();
+        expect(result![regular]['*'].count).toBe(2);
+        expect(result![hard]['*'].count).toBe(1);
+        expect(result![colo]['*'].count).toBe(1);
+      });
+
+      it('should group by party and return usernames', async () => {
+        const query: SessionQuery = {};
+        const result = await aggregateSessions(
+          query,
+          { '*': 'count' },
+          {},
+          'party',
+        );
+
+        expect(result).not.toBeNull();
+        const party1Usernames = 'PlayerA,PlayerB';
+        const party2Usernames = 'PlayerA,PlayerB,PlayerC';
+        const party3Usernames = 'PlayerA';
+
+        expect(Object.keys(result!)).toHaveLength(3);
+        expect(result![party1Usernames]['*'].count).toBe(2);
+        expect(result![party2Usernames]['*'].count).toBe(1);
+        expect(result![party3Usernames]['*'].count).toBe(1);
+      });
+
+      it('should group by multiple fields', async () => {
+        const query: SessionQuery = {};
+        const result = await aggregateSessions(query, { '*': 'count' }, {}, [
+          'type',
+          'scale',
+        ] as const);
+
+        expect(result).not.toBeNull();
+        const tob = ChallengeType.TOB.toString();
+        const colo = ChallengeType.COLOSSEUM.toString();
+
+        expect(result![tob]['2']['*'].count).toBe(2);
+        expect(result![tob]['3']['*'].count).toBe(1);
+        expect(result![colo]['1']['*'].count).toBe(1);
+      });
+    });
+
+    describe('sorting and limiting', () => {
+      it('should sort by an aggregated field', async () => {
+        const query: SessionQuery = {};
+        const result = await aggregateSessions(
+          query,
+          { duration: 'max' },
+          { sort: '-duration:max', limit: 2 },
+          'scale',
+        );
+
+        expect(Object.keys(result!)).toHaveLength(2);
+        expect(result!['2'].duration.max).toBe(3600);
+        expect(result!['1'].duration.max).toBe(1800);
+      });
+
+      it('should limit the number of results', async () => {
+        const query: SessionQuery = {};
+        const result = await aggregateSessions(
+          query,
+          { '*': 'count' },
+          { limit: 2 },
+          'scale',
+        );
+
+        expect(Object.keys(result!)).toHaveLength(2);
+      });
     });
   });
 
-  describe('filtering', () => {
-    it('should filter by session status', async () => {
-      const query: SessionQuery = { status: ['==', SessionStatus.COMPLETED] };
-      const result = await aggregateSessions(query, { '*': 'count' });
-      expect(result!['*'].count).toBe(3);
+  describe('loadSessionWithStats', () => {
+    const SESSION_UUID = '11111111-1111-1111-1111-111111111111';
+    const CHALLENGE_WITH_DOWNS_UUID = '11111111-1111-1111-1111-111111111111';
+    const CHALLENGE_WITHOUT_DOWNS_UUID = '22222222-2222-2222-2222-222222222222';
+
+    let withDownsId: number;
+    let withoutDownsId: number;
+
+    beforeEach(async () => {
+      const rows = await sql<{ id: number; uuid: string }[]>`
+        SELECT id, uuid FROM challenges
+        WHERE uuid IN (
+          ${CHALLENGE_WITH_DOWNS_UUID},
+          ${CHALLENGE_WITHOUT_DOWNS_UUID}
+        )
+      `;
+      const byUuid = new Map(rows.map((r) => [r.uuid, r.id]));
+      withDownsId = byUuid.get(CHALLENGE_WITH_DOWNS_UUID)!;
+      withoutDownsId = byUuid.get(CHALLENGE_WITHOUT_DOWNS_UUID)!;
+
+      await sql`
+        INSERT INTO tob_challenge_stats ${sql([
+          { challenge_id: withDownsId, bloat_down_count: 3 },
+          { challenge_id: withoutDownsId, bloat_down_count: 0 },
+        ])}
+      `;
+
+      await sql`
+        INSERT INTO bloat_downs ${sql([
+          {
+            challenge_id: withDownsId,
+            down_number: 1,
+            down_tick: 40,
+            walk_ticks: 40,
+            accurate: true,
+          },
+          {
+            challenge_id: withDownsId,
+            down_number: 2,
+            down_tick: 80,
+            walk_ticks: 35,
+            accurate: true,
+          },
+          {
+            challenge_id: withDownsId,
+            down_number: 3,
+            down_tick: 120,
+            walk_ticks: 38,
+            accurate: false,
+          },
+        ])}
+      `;
     });
 
-    it('should filter by challenge type', async () => {
-      const query: SessionQuery = { type: ['==', ChallengeType.COLOSSEUM] };
-      const result = await aggregateSessions(query, { '*': 'count' });
-      expect(result!['*'].count).toBe(1);
-    });
-  });
+    it('attaches bloat downs to the matching challenge', async () => {
+      const session = await loadSessionWithStats(SESSION_UUID);
+      expect(session).not.toBeNull();
+      expect(session!.challenges).toHaveLength(2);
 
-  describe('grouping', () => {
-    it('should group by challenge mode', async () => {
-      const query: SessionQuery = {};
-      const result = await aggregateSessions(
-        query,
-        { '*': 'count' },
-        {},
-        'mode',
+      const withDowns = session!.challenges.find(
+        (c) => c.uuid === CHALLENGE_WITH_DOWNS_UUID,
+      );
+      expect(withDowns).toBeDefined();
+      expect(withDowns!.tobStats).toBeDefined();
+      expect(withDowns!.tobStats!.bloatDownCount).toBe(3);
+      expect(withDowns!.tobStats!.downs).toEqual([
+        { downNumber: 1, downTick: 40, walkTicks: 40, accurate: true },
+        { downNumber: 2, downTick: 80, walkTicks: 35, accurate: true },
+        { downNumber: 3, downTick: 120, walkTicks: 38, accurate: false },
+      ]);
+    });
+
+    it('returns an empty downs array for challenges without bloat_downs rows', async () => {
+      const session = await loadSessionWithStats(SESSION_UUID);
+      const withoutDowns = session!.challenges.find(
+        (c) => c.uuid === CHALLENGE_WITHOUT_DOWNS_UUID,
       );
 
-      expect(result).not.toBeNull();
-      const regular = ChallengeMode.TOB_REGULAR.toString();
-      const hard = ChallengeMode.TOB_HARD.toString();
-      const colo = ChallengeMode.NO_MODE.toString();
-      expect(result![regular]['*'].count).toBe(2);
-      expect(result![hard]['*'].count).toBe(1);
-      expect(result![colo]['*'].count).toBe(1);
+      expect(withoutDowns).toBeDefined();
+      expect(withoutDowns!.tobStats).toBeDefined();
+      expect(withoutDowns!.tobStats!.bloatDownCount).toBe(0);
+      expect(withoutDowns!.tobStats!.downs).toEqual([]);
     });
 
-    it('should group by party and return usernames', async () => {
-      const query: SessionQuery = {};
-      const result = await aggregateSessions(
-        query,
-        { '*': 'count' },
-        {},
-        'party',
-      );
+    it('orders downs by down_number ascending regardless of insertion order', async () => {
+      // Add two more rows for the other challenge in reversed order.
+      await sql`
+        INSERT INTO bloat_downs ${sql([
+          {
+            challenge_id: withoutDownsId,
+            down_number: 2,
+            down_tick: 90,
+            walk_ticks: 45,
+            accurate: true,
+          },
+          {
+            challenge_id: withoutDownsId,
+            down_number: 1,
+            down_tick: 45,
+            walk_ticks: 45,
+            accurate: true,
+          },
+        ])}
+      `;
 
-      expect(result).not.toBeNull();
-      const party1Usernames = 'PlayerA,PlayerB';
-      const party2Usernames = 'PlayerA,PlayerB,PlayerC';
-      const party3Usernames = 'PlayerA';
+      const session = await loadSessionWithStats(SESSION_UUID);
+      const challenge = session!.challenges.find(
+        (c) => c.uuid === CHALLENGE_WITHOUT_DOWNS_UUID,
+      )!;
 
-      expect(Object.keys(result!)).toHaveLength(3);
-      expect(result![party1Usernames]['*'].count).toBe(2);
-      expect(result![party2Usernames]['*'].count).toBe(1);
-      expect(result![party3Usernames]['*'].count).toBe(1);
-    });
-
-    it('should group by multiple fields', async () => {
-      const query: SessionQuery = {};
-      const result = await aggregateSessions(query, { '*': 'count' }, {}, [
-        'type',
-        'scale',
-      ] as const);
-
-      expect(result).not.toBeNull();
-      const tob = ChallengeType.TOB.toString();
-      const colo = ChallengeType.COLOSSEUM.toString();
-
-      expect(result![tob]['2']['*'].count).toBe(2);
-      expect(result![tob]['3']['*'].count).toBe(1);
-      expect(result![colo]['1']['*'].count).toBe(1);
-    });
-  });
-
-  describe('sorting and limiting', () => {
-    it('should sort by an aggregated field', async () => {
-      const query: SessionQuery = {};
-      const result = await aggregateSessions(
-        query,
-        { duration: 'max' },
-        { sort: '-duration:max', limit: 2 },
-        'scale',
-      );
-
-      expect(Object.keys(result!)).toHaveLength(2);
-      expect(result!['2'].duration.max).toBe(3600);
-      expect(result!['1'].duration.max).toBe(1800);
-    });
-
-    it('should limit the number of results', async () => {
-      const query: SessionQuery = {};
-      const result = await aggregateSessions(
-        query,
-        { '*': 'count' },
-        { limit: 2 },
-        'scale',
-      );
-
-      expect(Object.keys(result!)).toHaveLength(2);
+      expect(challenge.tobStats!.downs!.map((d) => d.downNumber)).toEqual([
+        1, 2,
+      ]);
     });
   });
 });

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import {
+  BloatDown,
   CamelToSnakeCase,
   Challenge,
   ChallengeMode,
@@ -201,25 +202,6 @@ export async function loadChallenge(
   return challenge;
 }
 
-function statsTableAndField(type: ChallengeType): {
-  table: string;
-  field: keyof Pick<
-    SessionChallenge,
-    'tobStats' | 'mokhaiotlStats' | 'infernoStats'
-  >;
-} | null {
-  switch (type) {
-    case ChallengeType.TOB:
-      return { table: 'tob_challenge_stats', field: 'tobStats' };
-    case ChallengeType.MOKHAIOTL:
-      return { table: 'mokhaiotl_challenge_stats', field: 'mokhaiotlStats' };
-    case ChallengeType.INFERNO:
-      return { table: 'inferno_challenge_stats', field: 'infernoStats' };
-    default:
-      return null;
-  }
-}
-
 type StatsObject =
   | TobChallengeStats
   | MokhaiotlChallengeStats
@@ -229,6 +211,135 @@ function statsObject<T extends StatsObject>(rawRow: Record<string, any>): T {
   delete rawRow.id;
   delete rawRow.challenge_id;
   return snakeToCamelObject(rawRow) as T;
+}
+
+type StatsTarget = {
+  tobStats?: TobChallengeStats;
+  mokhaiotlStats?: MokhaiotlChallengeStats;
+  infernoStats?: InfernoChallengeStats;
+};
+
+type StatsLoadEntry<T extends StatsTarget> = {
+  id: number;
+  type: ChallengeType;
+  target: T;
+};
+
+/**
+ * Loads per-challenge stats rows for a heterogeneous set of challenges and
+ * attaches them to each entry's `target`.
+ */
+async function attachChallengeStats<T extends StatsTarget>(
+  entries: StatsLoadEntry<T>[],
+): Promise<void> {
+  const targetsById = new Map<number, T>();
+  const idsByType = new Map<ChallengeType, number[]>();
+  for (const entry of entries) {
+    const id = Number(entry.id);
+    targetsById.set(id, entry.target);
+    const list = idsByType.get(entry.type) ?? [];
+    list.push(id);
+    idsByType.set(entry.type, list);
+  }
+
+  const promises: Promise<void>[] = [];
+
+  const tobIds = idsByType.get(ChallengeType.TOB);
+  if (tobIds !== undefined && tobIds.length > 0) {
+    promises.push(
+      (async () => {
+        const [statsRows, downsRows] = await Promise.all([
+          sql<(StatsObject & { challenge_id: number })[]>`
+            SELECT * FROM tob_challenge_stats
+            WHERE challenge_id = ANY(${tobIds})
+          `,
+          sql<
+            {
+              challenge_id: number;
+              down_number: number;
+              down_tick: number;
+              walk_ticks: number;
+              accurate: boolean;
+            }[]
+          >`
+            SELECT challenge_id, down_number, down_tick, walk_ticks, accurate
+            FROM bloat_downs
+            WHERE challenge_id = ANY(${tobIds})
+            ORDER BY challenge_id, down_number
+          `,
+        ]);
+
+        const downsByChallenge = new Map<number, BloatDown[]>();
+        for (const row of downsRows) {
+          const cid = Number(row.challenge_id);
+          let list = downsByChallenge.get(cid);
+          if (list === undefined) {
+            list = [];
+            downsByChallenge.set(cid, list);
+          }
+          list.push({
+            downNumber: row.down_number,
+            downTick: row.down_tick,
+            walkTicks: row.walk_ticks,
+            accurate: row.accurate,
+          });
+        }
+
+        for (const row of statsRows) {
+          const challengeId = Number(
+            (row as { challenge_id: number }).challenge_id,
+          );
+          const target = targetsById.get(challengeId);
+          if (target === undefined) {
+            continue;
+          }
+          const tobStats = statsObject<TobChallengeStats>(row);
+          tobStats.downs = downsByChallenge.get(challengeId) ?? [];
+          target.tobStats = tobStats;
+        }
+      })(),
+    );
+  }
+
+  const mokhaiotlIds = idsByType.get(ChallengeType.MOKHAIOTL);
+  if (mokhaiotlIds !== undefined && mokhaiotlIds.length > 0) {
+    promises.push(
+      sql<(StatsObject & { challenge_id: number })[]>`
+        SELECT * FROM mokhaiotl_challenge_stats
+        WHERE challenge_id = ANY(${mokhaiotlIds})
+      `.then((rows) => {
+        for (const row of rows) {
+          const challengeId = (row as { challenge_id: number }).challenge_id;
+          const target = targetsById.get(challengeId);
+          if (target === undefined) {
+            continue;
+          }
+          target.mokhaiotlStats = statsObject<MokhaiotlChallengeStats>(row);
+        }
+      }),
+    );
+  }
+
+  const infernoIds = idsByType.get(ChallengeType.INFERNO);
+  if (infernoIds !== undefined && infernoIds.length > 0) {
+    promises.push(
+      sql<(StatsObject & { challenge_id: number })[]>`
+        SELECT * FROM inferno_challenge_stats
+        WHERE challenge_id = ANY(${infernoIds})
+      `.then((rows) => {
+        for (const row of rows) {
+          const challengeId = (row as { challenge_id: number }).challenge_id;
+          const target = targetsById.get(challengeId);
+          if (target === undefined) {
+            continue;
+          }
+          target.infernoStats = statsObject<InfernoChallengeStats>(row);
+        }
+      }),
+    );
+  }
+
+  await Promise.all(promises);
 }
 
 export type SplitValue = {
@@ -902,66 +1013,15 @@ export async function findChallenges(
   }
 
   if (options.extraFields?.stats) {
-    const types = new Map<ChallengeType, number[]>();
-    for (const c of rawChallenges) {
-      const list = types.get(c.type) ?? [];
-      types.set(c.type, [...list, c.id]);
-    }
-
-    if (types.has(ChallengeType.TOB)) {
-      loadPromises.push(
-        sql<({ challenge_id?: number; id?: number } & TobChallengeStats)[]>`
-          SELECT *
-          FROM tob_challenge_stats
-          WHERE challenge_id = ANY(${types.get(ChallengeType.TOB)!})
-        `.then((stats) => {
-          stats.forEach((s) => {
-            const challengeId = s.challenge_id!;
-            delete s.id;
-            delete s.challenge_id;
-            extra[challengeId].tobStats = snakeToCamelObject(
-              s,
-            ) as TobChallengeStats;
-          });
-        }),
-      );
-    }
-
-    if (types.has(ChallengeType.MOKHAIOTL)) {
-      loadPromises.push(
-        sql<
-          ({ challenge_id?: number; id?: number } & MokhaiotlChallengeStats)[]
-        >`
-          SELECT *
-          FROM mokhaiotl_challenge_stats
-          WHERE challenge_id = ANY(${types.get(ChallengeType.MOKHAIOTL)!})
-        `.then((stats) => {
-          stats.forEach((s) => {
-            const challengeId = s.challenge_id!;
-            delete s.id;
-            delete s.challenge_id;
-            extra[challengeId].mokhaiotlStats = snakeToCamelObject(s);
-          });
-        }),
-      );
-    }
-
-    if (types.has(ChallengeType.INFERNO)) {
-      loadPromises.push(
-        sql<({ challenge_id?: number; id?: number } & InfernoChallengeStats)[]>`
-          SELECT *
-          FROM inferno_challenge_stats
-          WHERE challenge_id = ANY(${types.get(ChallengeType.INFERNO)!})
-        `.then((stats) => {
-          stats.forEach((s) => {
-            const challengeId = s.challenge_id!;
-            delete s.id;
-            delete s.challenge_id;
-            extra[challengeId].infernoStats = snakeToCamelObject(s);
-          });
-        }),
-      );
-    }
+    loadPromises.push(
+      attachChallengeStats(
+        rawChallenges.map((c) => ({
+          id: c.id,
+          type: c.type,
+          target: extra[c.id],
+        })),
+      ),
+    );
   }
 
   loadPromises.push(
@@ -1750,24 +1810,20 @@ export async function loadSessionWithStats(
     ORDER BY pbh.created_at ASC
   `;
 
-  let challengeStatsQuery: Promise<(StatsObject & { challenge_id: number })[]>;
-  const statsMeta = statsTableAndField(rawChallenges[0].type);
-  if (statsMeta !== null) {
-    challengeStatsQuery = sql<(StatsObject & { challenge_id: number })[]>`
-      SELECT * FROM ${sql(statsMeta.table)}
-      WHERE challenge_id = ANY(${challengeIds})
-    `;
-  } else {
-    challengeStatsQuery = Promise.resolve([]);
-  }
+  const challengeStatsAttach = attachChallengeStats(
+    rawChallenges.map((c) => ({
+      id: c.id,
+      type: c.type,
+      target: extraChallengeData[c.id],
+    })),
+  );
 
-  const [challengePlayers, challengeSplits, personalBests, challengeStats] =
-    await Promise.all([
-      challengePlayersQuery,
-      challengeSplitsQuery,
-      personalBestsQuery,
-      challengeStatsQuery,
-    ]);
+  const [challengePlayers, challengeSplits, personalBests] = await Promise.all([
+    challengePlayersQuery,
+    challengeSplitsQuery,
+    personalBestsQuery,
+    challengeStatsAttach,
+  ]);
 
   for (const player of challengePlayers) {
     extraChallengeData[player.challenge_id].party.push({
@@ -1803,12 +1859,6 @@ export async function loadSessionWithStats(
 
     // PB rows are sorted by creation date, so the latest row is the fastest.
     pbsByPlayer.get(pb.username)?.set(pb.type, pb.ticks);
-  }
-
-  for (const stat of challengeStats) {
-    const challengeId = stat.challenge_id;
-    // @ts-expect-error `stat` is guaranteed to have the correct type.
-    extraChallengeData[challengeId][statsMeta!.field] = statsObject(stat);
   }
 
   const challenges: SessionChallenge[] = rawChallenges.map((c) => ({

--- a/web/app/components/menu/style.module.scss
+++ b/web/app/components/menu/style.module.scss
@@ -24,7 +24,6 @@
     text-align: left;
     font-size: 1rem;
     min-width: 120px;
-    max-width: 320px;
     flex-grow: 1;
     display: flex;
     align-items: center;
@@ -35,6 +34,8 @@
 
     &:not(.wrap) {
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     &:disabled,

--- a/web/app/components/tick-input/tick-input.tsx
+++ b/web/app/components/tick-input/tick-input.tsx
@@ -77,11 +77,14 @@ export default function TickInput(props: TickInputProps) {
   const lockedMode = props.inputMode;
   const [displayTicks, setDisplayTicks] = useState(lockedMode === 'ticks');
   const ref = useRef<HTMLInputElement>(null);
-  const [value, setValue] = useState(() =>
-    props.initialTicks !== undefined
-      ? ticksToFormattedSeconds(props.initialTicks)
-      : '',
-  );
+  const [value, setValue] = useState(() => {
+    if (props.initialTicks === undefined) {
+      return '';
+    }
+    return lockedMode === 'ticks'
+      ? props.initialTicks.toString()
+      : ticksToFormattedSeconds(props.initialTicks);
+  });
   const [comparator, setComparator] = useState<Comparator>(
     props.initialComparator ?? Comparator.EQUAL,
   );

--- a/web/app/search/challenges/filters.tsx
+++ b/web/app/search/challenges/filters.tsx
@@ -1123,19 +1123,33 @@ function CustomFilters({
   const display = useContext(DisplayContext);
 
   const [menuOpen, setMenuOpen] = useState(false);
-  const [customInputs, setCustomInputs] = useState<Record<string, SplitValues>>(
-    () => {
+  const customInputsFromFilters = React.useCallback(
+    (filters: SearchFilters) => {
       const inputs: Record<string, SplitValues> = {};
       for (const [id, filterDef] of Object.entries(FILTER_DEFS)) {
-        const value = getFilterValue(context.filters, filterDef);
+        const value = getFilterValue(filters, filterDef);
         if (value !== null) {
           inputs[id] = { ticks: value[1], comparator: value[0] };
         }
       }
       return inputs;
     },
+    [],
+  );
+  const [customInputs, setCustomInputs] = useState<Record<string, SplitValues>>(
+    () => customInputsFromFilters(context.filters),
   );
   const [modified, setModified] = useState(false);
+
+  // Sync from context.filters on external changes (e.g. browser back/forward),
+  // but don't clobber the user's in-progress edits.
+  React.useEffect(() => {
+    if (modified) {
+      return;
+    }
+    setCustomInputs(customInputsFromFilters(context.filters));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [context.filters, customInputsFromFilters]);
 
   const addInput = (id: string | number) => {
     const key = String(id);
@@ -1256,19 +1270,21 @@ function CustomFilters({
           return (
             <div key={id} className={styles.customInput}>
               {filterDef.inputKind === 'number' ? (
-                <ComparableInput
-                  id={`filters-custom-${id}`}
-                  label={filterDef.label}
-                  labelBg="var(--blert-surface-dark)"
-                  type="number"
-                  comparator={input.comparator}
-                  onComparatorChange={(c) => onChange(input.ticks, c)}
-                  value={input.ticks?.toString() ?? ''}
-                  onChange={(e) => {
-                    const v = parseInt(e.target.value);
-                    onChange(isNaN(v) ? null : v, input.comparator);
-                  }}
-                />
+                <div className={styles.comparable}>
+                  <ComparableInput
+                    id={`filters-custom-${id}`}
+                    label={filterDef.label}
+                    labelBg="var(--blert-surface-dark)"
+                    type="number"
+                    comparator={input.comparator}
+                    onComparatorChange={(c) => onChange(input.ticks, c)}
+                    value={input.ticks?.toString() ?? ''}
+                    onChange={(e) => {
+                      const v = parseInt(e.target.value);
+                      onChange(isNaN(v) ? null : v, input.comparator);
+                    }}
+                  />
+                </div>
               ) : (
                 <TickInput
                   comparator

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -507,6 +507,10 @@
         justify-content: space-between;
         padding: 4px 12px;
 
+        .comparable {
+          margin-top: -10px;
+        }
+
         button.remove {
           cursor: pointer;
           margin: -12px 0 0 12px;

--- a/web/app/search/challenges/table.tsx
+++ b/web/app/search/challenges/table.tsx
@@ -1504,7 +1504,7 @@ function ColumnsModal({
                 return (
                   <div key={group.label} className={styles.columnGroup}>
                     <div className={styles.groupHeading}>{group.label}</div>
-                    {available.map((col) => columnListEntry(col))}
+                    {available.map(columnListEntry)}
                   </div>
                 );
               });

--- a/web/app/sessions/components/challenge-analysis.tsx
+++ b/web/app/sessions/components/challenge-analysis.tsx
@@ -50,6 +50,16 @@ type StatOption = {
   unit?: string;
   filter?: StatFilter;
   formatter?: (value: number) => string;
+  /**
+   * Custom value extractor for stats that aren't a flat field on the
+   * per-challenge stats object. When provided, the aggregator uses this
+   * instead of looking up `challenge[<typeStats>][key]`. Return `null` to
+   * skip the challenge.
+   */
+  getValue?: (
+    challenge: SessionChallenge,
+    requireAccurate: boolean,
+  ) => number | null;
 };
 
 type AggregatedData = {
@@ -125,6 +135,26 @@ function getAvailableStats(
       },
       {
         type: StatType.CHALLENGE_SPECIFIC,
+        key: 'bloatFirstDownWalkTime',
+        label: 'Bloat First Down Walk Time',
+        unit: 'count',
+        formatter: (value) => `${Math.round(value)}t`,
+        filter: stageFilter(Stage.TOB_BLOAT),
+        getValue: (challenge, requireAccurate) => {
+          const first = challenge.tobStats?.downs?.find(
+            (d) => d.downNumber === 1,
+          );
+          if (first === undefined) {
+            return null;
+          }
+          if (requireAccurate && !first.accurate) {
+            return null;
+          }
+          return first.walkTicks;
+        },
+      },
+      {
+        type: StatType.CHALLENGE_SPECIFIC,
         key: 'nylocasDeaths',
         label: 'Nylocas Deaths',
         unit: 'count',
@@ -163,7 +193,7 @@ function getAvailableStats(
         key: 'nylocasMeleeSplits',
         label: 'Nylocas Melee Splits',
         unit: 'count',
-        filter: stageFilter(Stage.TOB_SOTETSEG),
+        filter: stageFilter(Stage.TOB_NYLOCAS),
       },
       {
         type: StatType.CHALLENGE_SPECIFIC,
@@ -250,6 +280,9 @@ function getAvailableStats(
 
   return stats.filter((stat) => {
     return challenges.some((challenge) => {
+      if (stat.getValue !== undefined) {
+        return stat.getValue(challenge, false) !== null;
+      }
       if (stat.type === StatType.SPLIT) {
         const generalizedSplit = parseInt(stat.key) as SplitType;
         return Object.keys(challenge.splits || {}).some((splitKey) => {
@@ -295,7 +328,9 @@ function aggregateStatData(
       return;
     }
 
-    if (selectedStat.type === StatType.SPLIT) {
+    if (selectedStat.getValue !== undefined) {
+      value = selectedStat.getValue(challenge, requireAccurateSplits);
+    } else if (selectedStat.type === StatType.SPLIT) {
       const generalizedSplit = parseInt(selectedStat.key) as SplitType;
       const splitEntries = Object.entries(challenge.splits || {});
       for (const [splitKey, splitValue] of splitEntries) {
@@ -512,19 +547,27 @@ function DistributionChart({
               x2="0"
               y2="1"
             >
-              <stop offset="0%" stopColor="#8b5cf6" stopOpacity={0.9} />
-              <stop offset="100%" stopColor="#62429b" stopOpacity={0.8} />
+              <stop
+                offset="0%"
+                stopColor="rgb(88, 101, 242)"
+                stopOpacity={0.95}
+              />
+              <stop
+                offset="100%"
+                stopColor="rgb(68, 79, 191)"
+                stopOpacity={0.8}
+              />
             </linearGradient>
           </defs>
           <CartesianGrid
             strokeDasharray="3 3"
-            stroke="rgba(255, 255, 255, 0.1)"
+            stroke="rgba(94, 98, 136, 0.3)"
           />
           <XAxis
             dataKey="value"
             tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
-            axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
-            tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
+            axisLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
+            tickLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
             angle={selectedStat.type === StatType.SPLIT ? -45 : undefined}
             textAnchor="end"
             height={60}
@@ -532,8 +575,8 @@ function DistributionChart({
           />
           <YAxis
             tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
-            axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
-            tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
+            axisLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
+            tickLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
             label={{
               value: 'Frequency',
               angle: -90,
@@ -547,12 +590,12 @@ function DistributionChart({
           <Tooltip
             contentStyle={{
               backgroundColor: 'var(--blert-panel-background-color)',
-              border: '1px solid var(--blert-surface-light)',
+              border: '1px solid rgba(88, 101, 242, 0.15)',
               borderRadius: '6px',
               color: 'var(--blert-font-color-primary)',
               boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
             }}
-            cursor={{ fill: 'rgba(139, 92, 246, 0.1)' }}
+            cursor={{ fill: 'rgba(88, 101, 242, 0.1)' }}
             formatter={(
               value: number,
               _name: string,
@@ -615,12 +658,12 @@ function ChartDisplay({
     <Tooltip
       contentStyle={{
         backgroundColor: 'var(--blert-panel-background-color)',
-        border: '1px solid var(--blert-surface-light)',
+        border: '1px solid rgba(88, 101, 242, 0.15)',
         borderRadius: '6px',
         color: 'var(--blert-font-color-primary)',
         boxShadow: '0 4px 12px rgba(0, 0, 0, 0.3)',
       }}
-      cursor={{ fill: 'rgba(139, 92, 246, 0.1)' }}
+      cursor={{ fill: 'rgba(88, 101, 242, 0.1)' }}
       formatter={(value: number, _name: string, _props: any) => [
         <span key={value} style={{ color: 'var(--blert-font-color-primary)' }}>
           {selectedStat.formatter ? selectedStat.formatter(value) : value}
@@ -655,25 +698,33 @@ function ChartDisplay({
                 x2="0"
                 y2="1"
               >
-                <stop offset="0%" stopColor="#8b5cf6" stopOpacity={0.9} />
-                <stop offset="100%" stopColor="#62429b" stopOpacity={0.8} />
+                <stop
+                  offset="0%"
+                  stopColor="rgb(88, 101, 242)"
+                  stopOpacity={0.95}
+                />
+                <stop
+                  offset="100%"
+                  stopColor="rgb(68, 79, 191)"
+                  stopOpacity={0.8}
+                />
               </linearGradient>
             </defs>
             <CartesianGrid
               strokeDasharray="3 3"
-              stroke="rgba(255, 255, 255, 0.1)"
+              stroke="rgba(94, 98, 136, 0.3)"
             />
             <XAxis
               dataKey="challengeIndex"
               tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
-              axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
-              tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
+              axisLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
+              tickLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
               tickFormatter={(value: number) => `#${value}`}
             />
             <YAxis
               tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
-              axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
-              tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
+              axisLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
+              tickLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
               tickFormatter={selectedStat.formatter}
             />
             {tooltip}
@@ -690,33 +741,33 @@ function ChartDisplay({
           >
             <CartesianGrid
               strokeDasharray="3 3"
-              stroke="rgba(255, 255, 255, 0.1)"
+              stroke="rgba(94, 98, 136, 0.3)"
             />
             <XAxis
               dataKey="challengeIndex"
               tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
-              axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
-              tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
+              axisLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
+              tickLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
               tickFormatter={(value: number) => `#${value}`}
             />
             <YAxis
               tick={{ fill: 'var(--blert-font-color-primary)', fontSize: 12 }}
-              axisLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
-              tickLine={{ stroke: 'rgba(255, 255, 255, 0.2)' }}
+              axisLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
+              tickLine={{ stroke: 'rgba(94, 98, 136, 0.5)' }}
               tickFormatter={selectedStat.formatter}
             />
             {tooltip}
             <Line
               type="monotone"
               dataKey="value"
-              stroke="#8b5cf6"
+              stroke="rgb(88, 101, 242)"
               strokeWidth={3}
-              dot={{ fill: '#8b5cf6', strokeWidth: 2, r: 4 }}
+              dot={{ fill: 'rgb(88, 101, 242)', strokeWidth: 2, r: 4 }}
               activeDot={{
                 r: 6,
-                stroke: '#8b5cf6',
+                stroke: 'rgb(88, 101, 242)',
                 strokeWidth: 2,
-                fill: '#a855f7',
+                fill: 'rgb(118, 131, 255)',
               }}
             />
           </LineChart>
@@ -739,7 +790,6 @@ export default function ChallengeAnalysis() {
     if (!session) {
       return [];
     }
-
     return getAvailableStats(session.challengeType, session.challenges);
   }, [session]);
 


### PR DESCRIPTION
Updates the analysis section on the session page to support Bloat's first down walk time as an analyzable statistic.