### PR TITLE
web: Allow unlisted gear setups

### DIFF
--- a/common/migrations/20260410214400-add-unlisted-gear-setup-state.ts
+++ b/common/migrations/20260410214400-add-unlisted-gear-setup-state.ts
@@ -1,0 +1,5 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`ALTER TYPE gear_setup_state ADD VALUE IF NOT EXISTS 'unlisted'`;
+}

--- a/web/app/actions/setup.ts
+++ b/web/app/actions/setup.ts
@@ -20,7 +20,7 @@ import { where } from './query';
 import redis from './redis';
 import { getSignedInUser, getSignedInUserId } from './users';
 
-export type SetupState = 'draft' | 'published' | 'archived';
+export type SetupState = 'draft' | 'published' | 'archived' | 'unlisted';
 
 export type SetupRevision = {
   version: number;
@@ -114,6 +114,7 @@ export async function newGearSetup(
   author: User,
   template?: GearSetup,
   clone: boolean = false,
+  overrideName?: string,
 ): Promise<SetupMetadata> {
   let name = 'Untitled setup';
   let challengeType = ChallengeType.TOB;
@@ -124,7 +125,7 @@ export async function newGearSetup(
     if (template === undefined) {
       throw new Error('Template is required for cloning');
     }
-    name = `Copy of ${template.title}`;
+    name = overrideName ?? `Copy of ${template.title}`;
     challengeType = template.challenge;
     scale = template.players.length;
     hasDraft = true;
@@ -134,7 +135,7 @@ export async function newGearSetup(
       title: name,
     };
   } else if (template !== undefined) {
-    name = template.title;
+    name = overrideName ?? template.title;
     challengeType = template.challenge;
     scale = template.players.length;
     hasDraft = true;
@@ -241,16 +242,21 @@ export async function newGearSetup(
 /**
  * Clones a gear setup for the logged in user.
  * @param setup The setup to clone.
+ * @param name Optional title override for the clone. Defaults to
+ *   `Copy of <original title>` if not provided.
  * @returns The new setup metadata.
  */
-export async function cloneGearSetup(setup: GearSetup): Promise<SetupMetadata> {
+export async function cloneGearSetup(
+  setup: GearSetup,
+  name?: string,
+): Promise<SetupMetadata> {
   return withServerAction('cloneGearSetup', async () => {
     const user = await getSignedInUser();
     if (user === null) {
       throw new Error('Not authorized');
     }
 
-    return newGearSetup(user, setup, true);
+    return newGearSetup(user, setup, true, name);
   });
 }
 
@@ -463,6 +469,7 @@ export async function publishSetupRevision(
   publicId: string,
   setup: GearSetup,
   message: string | null,
+  targetState: 'published' | 'unlisted' = 'published',
 ): Promise<SetupMetadata> {
   return withServerAction('publishSetupRevision', async () => {
     const userId = await getSignedInUserId();
@@ -523,7 +530,7 @@ export async function publishSetupRevision(
           challenge_type = ${setup.challenge},
           scale = ${setup.players.length},
           latest_revision_id = ${revision.id},
-          state = 'published',
+          state = ${targetState},
           has_draft = FALSE,
           updated_at = NOW()
         WHERE id = ${current.id}
@@ -538,6 +545,41 @@ export async function publishSetupRevision(
     );
 
     return getSetupByPublicId(publicId) as Promise<SetupMetadata>;
+  });
+}
+
+/**
+ * Updates the visibility of an already-published setup between 'published'
+ * and 'unlisted' without creating a new revision.
+ * @param publicId The public ID of the setup.
+ * @param state The new visibility state.
+ * @returns The updated setup metadata, or null if not authorized or the
+ *   setup is not in a state that can be toggled.
+ */
+export async function updateSetupVisibility(
+  publicId: string,
+  state: 'published' | 'unlisted',
+): Promise<SetupMetadata | null> {
+  return withServerAction('updateSetupVisibility', async () => {
+    const userId = await getSignedInUserId();
+    if (userId === null) {
+      return null;
+    }
+
+    const [updated] = await sql<[{ id: number }?]>`
+      UPDATE gear_setups
+      SET state = ${state}, updated_at = NOW()
+      WHERE public_id = ${publicId}
+        AND author_id = ${userId}
+        AND state IN ('published', 'unlisted')
+      RETURNING id
+    `;
+
+    if (!updated) {
+      return null;
+    }
+
+    return getSetupByPublicId(publicId);
   });
 }
 

--- a/web/app/api/setups/route.ts
+++ b/web/app/api/setups/route.ts
@@ -12,7 +12,12 @@ import { withApiRoute } from '@/api/handler';
 import { clamp } from '@/utils/math';
 
 function isSetupState(state: string): state is SetupState {
-  return state === 'draft' || state === 'published' || state === 'archived';
+  return (
+    state === 'draft' ||
+    state === 'published' ||
+    state === 'archived' ||
+    state === 'unlisted'
+  );
 }
 
 export const GET = withApiRoute(

--- a/web/app/components/modal/modal.tsx
+++ b/web/app/components/modal/modal.tsx
@@ -19,7 +19,12 @@ export function Modal(props: ModalProps) {
 
   const modalPortal = useRef<HTMLDivElement | null>(null);
   const modalRef = useRef<HTMLDivElement | null>(null);
+  const onCloseRef = useRef(onClose);
   const [shouldRender, setShouldRender] = useState(open);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     const root = document.getElementById('portal-root');
@@ -46,13 +51,13 @@ export function Modal(props: ModalProps) {
         event.target instanceof HTMLTextAreaElement ||
         event.target instanceof HTMLSelectElement;
       if (event.key === 'Escape' && !isInput) {
-        onClose();
+        onCloseRef.current();
       }
     };
 
     const onClick = (event: MouseEvent) => {
       if (!modalRef.current?.contains(event.target as Node)) {
-        onClose();
+        onCloseRef.current();
       }
     };
 
@@ -94,7 +99,7 @@ export function Modal(props: ModalProps) {
     }
 
     return () => hidePortal();
-  }, [open, onClose]);
+  }, [open]);
 
   if (modalPortal.current === null || !shouldRender) {
     return null;

--- a/web/app/components/radio-input/style.module.scss
+++ b/web/app/components/radio-input/style.module.scss
@@ -64,7 +64,7 @@
       color: var(--blert-font-color-secondary);
 
       label {
-        border: 1px solid rgba(var(--blert-divider-color), 0.5);
+        border: 1px solid var(--blert-divider-color);
         border-radius: 8px;
         background: rgba(var(--blert-panel-background-color-base), 0.3);
         transition: all 0.2s ease;

--- a/web/app/setups/[id]/actions.tsx
+++ b/web/app/setups/[id]/actions.tsx
@@ -2,15 +2,18 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 
 import { SetupMetadata, cloneGearSetup } from '@/actions/setup';
+import ConfirmationModal from '@/components/confirmation-modal';
+import Input from '@/components/input';
 import Menu from '@/components/menu';
 import { useToast } from '@/components/toast';
 
 import DeleteModal from '../delete-modal';
 import { GearSetup } from '../setup';
 import { ExportFormat, exportSetup } from '../translate';
+import { SetupViewingContext } from '../viewing-context';
 
 import styles from './style.module.scss';
 
@@ -18,34 +21,71 @@ export default function SetupActions({
   showClone = false,
   showDelete = false,
   showEdit = false,
+  currentRevision,
+  isLatestRevision,
   gearSetup,
   setup,
 }: {
   showClone?: boolean;
   showEdit?: boolean;
   showDelete?: boolean;
+  currentRevision: number;
+  isLatestRevision: boolean;
   gearSetup: GearSetup;
   setup: SetupMetadata;
 }) {
   const router = useRouter();
   const showToast = useToast();
+  const { highlightedPlayerIndex } = useContext(SetupViewingContext);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [cloneModalOpen, setCloneModalOpen] = useState(false);
+  const [cloneTitle, setCloneTitle] = useState('');
+  const [cloning, setCloning] = useState(false);
+
+  const copyShareLink = useCallback(async () => {
+    try {
+      const url = new URL(`/setups/${setup.publicId}`, window.location.origin);
+      if (!isLatestRevision) {
+        url.searchParams.set('revision', String(currentRevision));
+      }
+      if (highlightedPlayerIndex !== null) {
+        url.searchParams.set('player', String(highlightedPlayerIndex + 1));
+      }
+      await navigator.clipboard.writeText(url.toString());
+      showToast('Link copied to clipboard', 'success');
+    } catch {
+      showToast('Failed to copy link', 'error');
+    }
+  }, [
+    currentRevision,
+    highlightedPlayerIndex,
+    isLatestRevision,
+    setup.publicId,
+    showToast,
+  ]);
 
   const forkSetup = useCallback(async () => {
+    setCloning(true);
     let publicId: string | null = null;
     try {
-      const newSetup = await cloneGearSetup(gearSetup);
+      const trimmed = cloneTitle.trim();
+      const newSetup = await cloneGearSetup(
+        gearSetup,
+        trimmed.length > 0 ? trimmed : undefined,
+      );
       publicId = newSetup.publicId;
     } catch {
       showToast('Failed to clone setup', 'error');
+    } finally {
+      setCloning(false);
     }
 
     if (publicId !== null) {
       router.push(`/setups/${publicId}/edit`);
     }
-  }, [router, gearSetup, showToast]);
+  }, [cloneTitle, gearSetup, router, showToast]);
 
   const handleExport = useCallback(
     (format: ExportFormat, playerIndex: number) => {
@@ -75,48 +115,99 @@ export default function SetupActions({
     },
   ];
 
+  const hasPrimaryRow = showEdit || showDelete;
+
   return (
     <div className={styles.actions}>
-      {showEdit && (
-        <Link
-          href={`/setups/${setup.publicId}/edit`}
-          className={styles.editButton}
-        >
-          <i className="fas fa-pencil-alt" />
-          <span>Edit</span>
-        </Link>
+      {hasPrimaryRow && (
+        <div className={`${styles.actionRow} ${styles.primaryRow}`}>
+          {showEdit && (
+            <Link
+              href={`/setups/${setup.publicId}/edit`}
+              className={styles.editButton}
+            >
+              <i className="fas fa-pencil-alt" />
+              <span>Edit</span>
+            </Link>
+          )}
+          {showDelete && (
+            <button
+              className={`${styles.actionButton} ${styles.deleteButton}`}
+              onClick={() => setShowDeleteModal(true)}
+            >
+              <i className="fas fa-trash" />
+              <span>Delete</span>
+            </button>
+          )}
+        </div>
       )}
-      {showDelete && (
-        <button
-          className={`${styles.actionButton} ${styles.deleteButton}`}
-          onClick={() => setShowDeleteModal(true)}
-        >
-          <i className="fas fa-trash" />
-          <span>Delete</span>
-        </button>
-      )}
-      {showClone && (
+      <div className={styles.actionRow}>
+        {showClone && (
+          <button
+            className={styles.actionButton}
+            onClick={() => {
+              setCloneTitle('');
+              setCloneModalOpen(true);
+            }}
+          >
+            <i className="fas fa-clone" />
+            <span>Clone</span>
+          </button>
+        )}
         <button
           className={styles.actionButton}
-          onClick={() => void forkSetup()}
+          onClick={() => void copyShareLink()}
         >
-          <i className="fas fa-clone" />
-          <span>Clone</span>
+          <i className="fas fa-link" />
+          <span>Share</span>
         </button>
-      )}
-      <button
-        id="setup-export-button"
-        className={styles.actionButton}
-        onClick={() => setShowExportMenu(true)}
-      >
-        <i className="fas fa-download" />
-        <span>Export…</span>
-      </button>
+        <button
+          id="setup-export-button"
+          className={styles.actionButton}
+          onClick={() => setShowExportMenu(true)}
+        >
+          <i className="fas fa-download" />
+          <span>Export…</span>
+        </button>
+      </div>
       <DeleteModal
         open={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}
         onDelete={() => router.replace('/setups/my')}
         setupId={setup.publicId}
+      />
+      <ConfirmationModal
+        open={cloneModalOpen}
+        onClose={() => setCloneModalOpen(false)}
+        onConfirm={() => void forkSetup()}
+        title="Clone setup"
+        message={
+          <div className={styles.cloneModalBody}>
+            <p>
+              You&apos;ll be taken to the editor to customize your copy. Give it
+              a name or leave blank to use the default.
+            </p>
+            <Input
+              id="clone-setup-title"
+              label="Setup title"
+              labelBg="var(--blert-surface-dark)"
+              value={cloneTitle}
+              onChange={(e) => setCloneTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !cloning) {
+                  e.preventDefault();
+                  void forkSetup();
+                }
+              }}
+              placeholder={`Copy of ${gearSetup.title}`}
+              maxLength={128}
+              fluid
+              autoFocus
+            />
+          </div>
+        }
+        confirmText="Clone"
+        loading={cloning}
       />
       <Menu
         open={showExportMenu}

--- a/web/app/setups/[id]/edit/setup-creator.tsx
+++ b/web/app/setups/[id]/edit/setup-creator.tsx
@@ -190,7 +190,7 @@ export default function GearSetupsCreator({ setup }: GearSetupsCreatorProps) {
   const isLocal = context.isLocal;
 
   const handlePublish = useCallback(
-    async (publishMessage: string) => {
+    async (publishMessage: string, targetState: 'published' | 'unlisted') => {
       try {
         if (isLocal) {
           // This should not be called by the publish modal.
@@ -202,6 +202,7 @@ export default function GearSetupsCreator({ setup }: GearSetupsCreatorProps) {
           setup.publicId,
           gearSetup,
           publishMessage || null,
+          targetState,
         );
 
         showToast('Published setup');
@@ -696,12 +697,18 @@ function PublishModal({
   isLocal: boolean;
   open: boolean;
   onClose: () => void;
-  onPublish: (message: string) => void | Promise<void>;
+  onPublish: (
+    message: string,
+    targetState: 'published' | 'unlisted',
+  ) => void | Promise<void>;
   publishIssues: { message: string; type: 'warning' | 'error' }[];
   publishLoading: boolean;
 }) {
   const router = useRouter();
   const [publishMessage, setPublishMessage] = useState('');
+  const [visibility, setVisibility] = useState<'published' | 'unlisted'>(
+    setup.state === 'unlisted' ? 'unlisted' : 'published',
+  );
 
   const migrationUrl = `/setups/my?migrate=${setup.publicId}`;
 
@@ -863,6 +870,53 @@ function PublishModal({
         )}
 
         <div className={styles.field}>
+          <label>
+            <i className="fas fa-eye" />
+            Visibility
+          </label>
+          <RadioInput.Group
+            name="publish-visibility"
+            simple
+            onChange={(value) =>
+              setVisibility(value as 'published' | 'unlisted')
+            }
+          >
+            <RadioInput.Option
+              checked={visibility === 'published'}
+              id="publish-visibility-published"
+              label={
+                <span className={styles.visibilityLabel}>
+                  <span className={styles.visibilityTitle}>
+                    <i className="fas fa-globe" />
+                    Published
+                  </span>
+                  <span className={styles.visibilityDescription}>
+                    Visible in the community feed
+                  </span>
+                </span>
+              }
+              value="published"
+            />
+            <RadioInput.Option
+              checked={visibility === 'unlisted'}
+              id="publish-visibility-unlisted"
+              label={
+                <span className={styles.visibilityLabel}>
+                  <span className={styles.visibilityTitle}>
+                    <i className="fas fa-eye-slash" />
+                    Unlisted
+                  </span>
+                  <span className={styles.visibilityDescription}>
+                    Only accessible via direct link
+                  </span>
+                </span>
+              }
+              value="unlisted"
+            />
+          </RadioInput.Group>
+        </div>
+
+        <div className={styles.field}>
           <label htmlFor="publish-message">
             <i className="fas fa-message" />
             Revision message <span className={styles.optional}>(optional)</span>
@@ -891,7 +945,7 @@ function PublishModal({
           <Button
             disabled={publishIssues.some((w) => w.type === 'error')}
             loading={publishLoading}
-            onClick={() => void onPublish(publishMessage)}
+            onClick={() => void onPublish(publishMessage, visibility)}
             className={styles.publishButton}
           >
             <i className="fas fa-upload" />
@@ -905,21 +959,18 @@ function PublishModal({
   }
 
   return (
-    <Modal className={styles.publishModal} open={open} onClose={onClose}>
-      <div className={styles.modalHeader}>
-        <h2>
-          <i className="fas fa-upload" />
-          {isLocal
+    <Modal
+      className={styles.publishModal}
+      open={open}
+      onClose={onClose}
+      header={
+        isLocal
+          ? 'Publish Setup'
+          : setup.latestRevision === null
             ? 'Publish Setup'
-            : setup.latestRevision === null
-              ? 'Publish Setup'
-              : 'Publish New Revision'}
-        </h2>
-        <button onClick={onClose}>
-          <i className="fas fa-times" />
-          <span className="sr-only">Close</span>
-        </button>
-      </div>
+            : 'Publish New Revision'
+      }
+    >
       {content}
     </Modal>
   );

--- a/web/app/setups/[id]/edit/style.module.scss
+++ b/web/app/setups/[id]/edit/style.module.scss
@@ -1130,6 +1130,34 @@
       color: var(--blert-font-color-secondary);
       font-size: 0.8rem;
     }
+
+    .visibilityLabel {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      text-align: left;
+
+      .visibilityTitle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--blert-font-color-primary);
+
+        i {
+          color: var(--blert-purple);
+          font-size: 0.9rem;
+        }
+      }
+
+      .visibilityDescription {
+        font-size: 0.85rem;
+        font-weight: 400;
+        color: var(--blert-font-color-secondary);
+        line-height: 1.4;
+      }
+    }
   }
 
   .actions {

--- a/web/app/setups/[id]/page.tsx
+++ b/web/app/setups/[id]/page.tsx
@@ -20,6 +20,7 @@ import CollapsibleDescription from './collapsible-description';
 import Panels from './panels';
 import { SlotTooltipRenderer } from '../slot';
 import { SetupViewingContextProvider } from '../viewing-context';
+import { VisibilityToggleButton } from './visibility-actions';
 import VoteBar from '../vote-bar';
 
 import styles from './style.module.scss';
@@ -96,6 +97,21 @@ export default async function GearSetupPage({
                   </span>
                 </div>
               )}
+              {isAuthor && setup.state === 'unlisted' && (
+                <div className={styles.unlistedBanner}>
+                  <i className="fas fa-eye-slash" />
+                  <span>
+                    This setup is unlisted. Only people with the link can view
+                    it.
+                  </span>
+                  {isLatestRevision && (
+                    <VisibilityToggleButton
+                      publicId={setup.publicId}
+                      currentState="unlisted"
+                    />
+                  )}
+                </div>
+              )}
               <div className={styles.setupInfo}>
                 <div className={styles.setupMeta}>
                   <span className={styles.author}>
@@ -113,6 +129,14 @@ export default async function GearSetupPage({
                     <i className="fas fa-eye" />
                     <span>{setup.views.toLocaleString()}</span>
                   </span>
+                  {isAuthor &&
+                    isLatestRevision &&
+                    setup.state === 'published' && (
+                      <VisibilityToggleButton
+                        publicId={setup.publicId}
+                        currentState="published"
+                      />
+                    )}
                 </div>
                 <div className={styles.voteSection}>
                   <VoteBar
@@ -131,6 +155,8 @@ export default async function GearSetupPage({
                 showClone={loggedIn}
                 showDelete={isAuthor}
                 showEdit={isAuthor && isLatestRevision}
+                currentRevision={targetRevision}
+                isLatestRevision={isLatestRevision}
                 setup={setup}
                 gearSetup={gearSetup}
               />
@@ -187,5 +213,9 @@ export async function generateMetadata(
       ...metadata.twitter,
       title,
     },
+    robots:
+      setupMetadata.state === 'unlisted'
+        ? { index: false, follow: false }
+        : undefined,
   };
 }

--- a/web/app/setups/[id]/style.module.scss
+++ b/web/app/setups/[id]/style.module.scss
@@ -87,6 +87,115 @@
       justify-content: center;
     }
   }
+
+  .unlistedBanner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 1.5rem;
+    padding: 12px 16px;
+    background: linear-gradient(
+      135deg,
+      rgba(var(--blert-yellow-base), 0.1) 0%,
+      rgba(var(--blert-yellow-base), 0.05) 100%
+    );
+    border: 1px solid rgba(var(--blert-yellow-base), 0.25);
+    border-radius: 8px;
+    font-size: 0.9rem;
+    line-height: 1.4;
+
+    > i {
+      position: relative;
+      top: 2px;
+      color: var(--blert-yellow);
+      font-size: 1em;
+    }
+
+    > span {
+      flex: 1;
+    }
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      flex-wrap: wrap;
+      text-align: center;
+      justify-content: center;
+    }
+  }
+}
+
+.unlistedBannerAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--blert-surface-dark);
+  border: 1px solid var(--blert-divider-color);
+  border-radius: 6px;
+  color: var(--blert-font-color-primary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  flex-shrink: 0;
+
+  i {
+    font-size: 0.9em;
+  }
+
+  &:hover:not(:disabled) {
+    background: var(--blert-surface-light);
+    border-color: var(--blert-purple);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.visibilityChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: rgba(var(--blert-purple-base), 0.12);
+  border: 1px solid rgba(var(--blert-purple-base), 0.35);
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--blert-font-color-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  i {
+    color: var(--blert-purple);
+    font-size: 0.9em;
+  }
+
+  .chipDivider {
+    width: 1px;
+    height: 12px;
+    background: rgba(var(--blert-purple-base), 0.4);
+  }
+
+  .chipAction {
+    color: var(--blert-font-color-secondary);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.6);
+    transform: translateY(-1px);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 }
 
 .setupInfo {
@@ -447,13 +556,32 @@
 // Actions styling
 .actions {
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    width: 100%;
+  }
+}
+
+.actionRow {
+  display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     width: 100%;
     justify-content: center;
     flex-wrap: wrap;
+  }
+}
+
+.primaryRow {
+  > * {
+    flex: 1;
+    justify-content: center;
   }
 }
 
@@ -479,6 +607,12 @@
     background: rgba(var(--blert-purple-base), 0.8);
     transform: translateY(-1px);
   }
+}
+
+.cloneModalBody {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .actionButton {

--- a/web/app/setups/[id]/visibility-actions.tsx
+++ b/web/app/setups/[id]/visibility-actions.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+import { updateSetupVisibility } from '@/actions/setup';
+import ConfirmationModal from '@/components/confirmation-modal';
+import { useToast } from '@/components/toast';
+import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
+
+import styles from './style.module.scss';
+
+type Props = {
+  publicId: string;
+  currentState: 'published' | 'unlisted';
+};
+
+export function VisibilityToggleButton({ publicId, currentState }: Props) {
+  const router = useRouter();
+  const showToast = useToast();
+  const [loading, setLoading] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const nextState = currentState === 'unlisted' ? 'published' : 'unlisted';
+
+  const confirm = useCallback(async () => {
+    setLoading(true);
+    try {
+      const updated = await updateSetupVisibility(publicId, nextState);
+      if (updated === null) {
+        showToast('Failed to update visibility', 'error');
+        return;
+      }
+      showToast(
+        nextState === 'published'
+          ? 'Setup is now published'
+          : 'Setup is now unlisted',
+        'success',
+      );
+      setConfirmOpen(false);
+      router.refresh();
+    } catch {
+      showToast('Failed to update visibility', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [nextState, publicId, router, showToast]);
+
+  const trigger =
+    currentState === 'unlisted' ? (
+      <button
+        type="button"
+        className={styles.unlistedBannerAction}
+        onClick={() => setConfirmOpen(true)}
+        disabled={loading}
+      >
+        <i className="fas fa-globe" />
+        Make public
+      </button>
+    ) : (
+      <button
+        type="button"
+        className={styles.visibilityChip}
+        onClick={() => setConfirmOpen(true)}
+        disabled={loading}
+        data-tooltip-id={GLOBAL_TOOLTIP_ID}
+        data-tooltip-content="Click to unlist this setup"
+      >
+        <i className="fas fa-globe" />
+        Public
+        <span className={styles.chipDivider} />
+        <span className={styles.chipAction}>Unlist</span>
+      </button>
+    );
+
+  return (
+    <>
+      {trigger}
+      <ConfirmationModal
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => void confirm()}
+        title={
+          nextState === 'unlisted'
+            ? 'Unlist this setup?'
+            : 'Publish this setup?'
+        }
+        message={
+          nextState === 'unlisted'
+            ? 'The setup will be hidden from the community feed, search results, and public listings. People with the direct link can still view it.'
+            : 'The setup will be listed in the community feed and indexed by search engines. Anyone will be able to discover and view it.'
+        }
+        confirmText={nextState === 'unlisted' ? 'Unlist' : 'Publish'}
+        loading={loading}
+      />
+    </>
+  );
+}

--- a/web/app/setups/filterable-setup-list.tsx
+++ b/web/app/setups/filterable-setup-list.tsx
@@ -26,6 +26,13 @@ type FilterableSetupListProps = {
 
 const MAX_SCALE = 8;
 
+const SETUP_STATE_ICONS: Record<SetupState, string> = {
+  draft: 'fa-edit',
+  published: 'fa-check-circle',
+  archived: 'fa-archive',
+  unlisted: 'fa-eye-slash',
+};
+
 function scaleName(scale: number) {
   switch (scale) {
     case 1:
@@ -250,6 +257,7 @@ export function FilterableSetupList({
                 <option value="">All States</option>
                 <option value="draft">Draft</option>
                 <option value="published">Published</option>
+                <option value="unlisted">Unlisted</option>
                 <option value="archived">Archived</option>
               </select>
             </div>
@@ -364,13 +372,7 @@ export function FilterableSetupList({
                           className={`${styles.meta} ${styles.state} ${styles[setup.state]}`}
                         >
                           <i
-                            className={`fas ${
-                              setup.state === 'draft'
-                                ? 'fa-edit'
-                                : setup.state === 'published'
-                                  ? 'fa-check-circle'
-                                  : 'fa-archive'
-                            }`}
+                            className={`fas ${SETUP_STATE_ICONS[setup.state]}`}
                           />
                           {setup.state}
                         </span>

--- a/web/app/setups/setup-list.module.scss
+++ b/web/app/setups/setup-list.module.scss
@@ -406,6 +406,10 @@
             background: rgba(var(--blert-green-base), 0.5);
           }
 
+          &.unlisted {
+            background: rgba(var(--blert-yellow-base), 0.5);
+          }
+
           &.archived {
             background: rgba(var(--blert-red-base), 0.5);
           }

--- a/web/app/setups/static-setup-list.tsx
+++ b/web/app/setups/static-setup-list.tsx
@@ -3,7 +3,7 @@
 import { challengeName } from '@blert/common';
 import Link from 'next/link';
 
-import { SetupListItem } from '@/actions/setup';
+import { SetupListItem, SetupState } from '@/actions/setup';
 import VoteBar from '@/components/vote-bar';
 
 import styles from './setup-list.module.scss';
@@ -15,6 +15,13 @@ function formatDate(date: Date | string): string {
     day: 'numeric',
   });
 }
+
+const SETUP_STATE_ICONS: Record<SetupState, string> = {
+  draft: 'fa-edit',
+  published: 'fa-check-circle',
+  archived: 'fa-archive',
+  unlisted: 'fa-eye-slash',
+};
 
 type StaticSetupListProps = {
   setups: SetupListItem[];
@@ -58,13 +65,7 @@ export function StaticSetupList({
                         className={`${styles.meta} ${styles.state} ${styles[setup.state]}`}
                       >
                         <i
-                          className={`fas ${
-                            setup.state === 'draft'
-                              ? 'fa-edit'
-                              : setup.state === 'published'
-                                ? 'fa-check-circle'
-                                : 'fa-archive'
-                          }`}
+                          className={`fas ${SETUP_STATE_ICONS[setup.state]}`}
                         />
                         {setup.state}
                       </span>

--- a/web/app/setups/style.module.scss
+++ b/web/app/setups/style.module.scss
@@ -229,10 +229,18 @@
   }
 
   &.highlighted {
-    outline: 2px solid var(--blert-purple);
-    outline-offset: 2px;
-    border-radius: 5px;
-    transition: outline-color 0.2s ease;
+    background: linear-gradient(
+      180deg,
+      rgba(var(--blert-purple-base), 0.08) 0%,
+      rgba(var(--blert-purple-base), 0.02) 100%
+    );
+    box-shadow:
+      inset 0 0 0 2px rgba(var(--blert-purple-base), 0.9),
+      inset 0 0 24px rgba(var(--blert-purple-base), 0.25);
+    border-radius: 8px;
+    transition:
+      background 0.2s ease,
+      box-shadow 0.2s ease;
   }
 }
 


### PR DESCRIPTION
Adds a new unlisted gear setup state which is viewable by URL but not discoverable through browsing. Allows publishing a setup as unlisted and toggling an existing setup between unlisted and public.

Fixes #229.