### PR TITLE
web: Redo home page to generalize challenges

### DIFF
--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   aggregateSessions,
+  countUniquePlayers,
   findChallenges,
   loadSessionsPage,
   loadSessionWithStats,
@@ -683,143 +684,220 @@ describe('sessions', () => {
   });
 });
 
-describe('findChallenges', () => {
-  describe('bloat down filters', () => {
-    let playerId: number;
-    let sessionId: number;
-    let zeroDownChallengeId: number;
-    let oneDownChallengeId: number;
+describe('challenges', () => {
+  let playerIds: number[];
+  let sessionId: number;
+  let challengeIds: number[];
 
-    beforeEach(async () => {
-      [{ id: playerId }] = await sql<{ id: number }[]>`
-        INSERT INTO players ${sql([
-          {
-            username: 'PlayerA',
-            normalized_username: normalizeRsn('PlayerA'),
-          },
-        ])} RETURNING id
-      `;
+  beforeEach(async () => {
+    const players = [
+      { username: 'PlayerA', normalized_username: normalizeRsn('PlayerA') },
+      { username: 'PlayerB', normalized_username: normalizeRsn('PlayerB') },
+      { username: 'PlayerC', normalized_username: normalizeRsn('PlayerC') },
+    ];
+    const playerResults = await sql`
+      INSERT INTO players ${sql(players, ['username', 'normalized_username'])} RETURNING id
+    `;
+    playerIds = playerResults.map((p) => p.id);
 
-      [{ id: sessionId }] = await sql<{ id: number }[]>`
-        INSERT INTO challenge_sessions ${sql([
-          {
-            uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-            challenge_type: ChallengeType.TOB,
-            challenge_mode: ChallengeMode.TOB_REGULAR,
-            scale: 2,
-            party_hash: partyHash(['PlayerA']),
-            start_time: new Date('2024-01-01T10:00:00Z'),
-            end_time: new Date('2024-01-01T10:30:00Z'),
-            status: SessionStatus.COMPLETED,
-          },
-        ])} RETURNING id
-      `;
-
-      const challenges = await sql<{ id: number }[]>`
-        INSERT INTO challenges ${sql([
-          {
-            session_id: sessionId,
-            uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-            type: ChallengeType.TOB,
-            mode: ChallengeMode.TOB_REGULAR,
-            stage: Stage.TOB_BLOAT,
-            status: ChallengeStatus.WIPED,
-            start_time: new Date('2024-01-01T10:00:00Z'),
-            finish_time: new Date('2024-01-01T10:10:00Z'),
-            scale: 2,
-            challenge_ticks: 600,
-            overall_ticks: 650,
-            total_deaths: 2,
-          },
-          {
-            session_id: sessionId,
-            uuid: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
-            type: ChallengeType.TOB,
-            mode: ChallengeMode.TOB_REGULAR,
-            stage: Stage.TOB_VERZIK,
-            status: ChallengeStatus.COMPLETED,
-            start_time: new Date('2024-01-01T11:00:00Z'),
-            finish_time: new Date('2024-01-01T11:20:00Z'),
-            scale: 2,
-            challenge_ticks: 1200,
-            overall_ticks: 1250,
-            total_deaths: 0,
-          },
-        ])} RETURNING id
-      `;
-      [zeroDownChallengeId, oneDownChallengeId] = challenges.map((c) => c.id);
-
-      await sql`
-        INSERT INTO challenge_players ${sql([
-          {
-            challenge_id: zeroDownChallengeId,
-            player_id: playerId,
-            username: 'PlayerA',
-            orb: 0,
-            primary_gear: 0,
-          },
-          {
-            challenge_id: oneDownChallengeId,
-            player_id: playerId,
-            username: 'PlayerA',
-            orb: 0,
-            primary_gear: 0,
-          },
-        ])}
-      `;
-
-      await sql`
-        INSERT INTO tob_challenge_stats ${sql([
-          {
-            challenge_id: zeroDownChallengeId,
-            bloat_down_count: 0,
-          },
-          {
-            challenge_id: oneDownChallengeId,
-            bloat_down_count: 1,
-          },
-        ])}
-      `;
-
-      await sql`
-        INSERT INTO bloat_downs ${sql([
-          {
-            challenge_id: oneDownChallengeId,
-            down_number: 1,
-            down_tick: 41,
-            walk_ticks: 41,
-            accurate: true,
-          },
-        ])}
-      `;
-    });
-
-    afterEach(async () => {
-      await sql`DELETE FROM challenge_players`;
-      await sql`DELETE FROM challenges`;
-      await sql`DELETE FROM challenge_sessions`;
-      await sql`DELETE FROM players`;
-    });
-
-    it('matches zero-down raids for tob.bloatDownCount=eq0', async () => {
-      const [challenges] = await findChallenges(10, {
-        tob: { bloatDownCount: ['==', 0] },
-      });
-
-      expect(challenges).toHaveLength(1);
-      expect(challenges[0].uuid).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
-    });
-
-    it('combines persisted down count and bloat down filters', async () => {
-      const [challenges] = await findChallenges(10, {
-        tob: {
-          bloatDowns: new Map([[1, ['==', 41]]]),
-          bloatDownCount: ['==', 1],
+    [{ id: sessionId }] = await sql<{ id: number }[]>`
+      INSERT INTO challenge_sessions ${sql([
+        {
+          uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          challenge_type: ChallengeType.TOB,
+          challenge_mode: ChallengeMode.TOB_REGULAR,
+          scale: 2,
+          party_hash: partyHash(['PlayerA']),
+          start_time: new Date('2024-01-01T10:00:00Z'),
+          end_time: new Date('2024-01-01T10:30:00Z'),
+          status: SessionStatus.COMPLETED,
         },
+      ])} RETURNING id
+    `;
+
+    // 0: TOB wiped at bloat — PlayerA, PlayerB
+    // 1: TOB completed — PlayerA, PlayerB, PlayerC
+    // 2: Colosseum completed — PlayerA
+    // 3: TOB abandoned — PlayerA, PlayerB (excluded by default)
+    const challenges = [
+      {
+        session_id: sessionId,
+        uuid: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        type: ChallengeType.TOB,
+        status: ChallengeStatus.WIPED,
+        start_time: new Date('2024-01-01T10:00:00Z'),
+        scale: 2,
+      },
+      {
+        session_id: sessionId,
+        uuid: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        type: ChallengeType.TOB,
+        status: ChallengeStatus.COMPLETED,
+        start_time: new Date('2024-01-01T11:00:00Z'),
+        scale: 2,
+      },
+      {
+        session_id: sessionId,
+        uuid: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        type: ChallengeType.COLOSSEUM,
+        status: ChallengeStatus.COMPLETED,
+        start_time: new Date('2024-01-01T12:00:00Z'),
+        scale: 1,
+      },
+      {
+        session_id: sessionId,
+        uuid: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        type: ChallengeType.TOB,
+        status: ChallengeStatus.ABANDONED,
+        start_time: new Date('2024-01-01T13:00:00Z'),
+        scale: 2,
+      },
+    ];
+    const challengeResults = await sql`
+      INSERT INTO challenges ${sql(challenges, ['session_id', 'uuid', 'type', 'status', 'start_time', 'scale'])} RETURNING id
+    `;
+    challengeIds = challengeResults.map((c) => c.id);
+
+    // Set TOB-specific fields on the first two challenges.
+    await sql`
+      UPDATE challenges SET
+        mode = ${ChallengeMode.TOB_REGULAR},
+        stage = ${Stage.TOB_BLOAT},
+        finish_time = '2024-01-01T10:10:00Z',
+        challenge_ticks = 600,
+        overall_ticks = 650,
+        total_deaths = 2
+      WHERE id = ${challengeIds[0]}
+    `;
+    await sql`
+      UPDATE challenges SET
+        mode = ${ChallengeMode.TOB_REGULAR},
+        stage = ${Stage.TOB_VERZIK},
+        finish_time = '2024-01-01T11:20:00Z',
+        challenge_ticks = 1200,
+        overall_ticks = 1250,
+        total_deaths = 0
+      WHERE id = ${challengeIds[1]}
+    `;
+
+    const cp = (cIdx: number, pIdx: number, username: string) => ({
+      challenge_id: challengeIds[cIdx],
+      player_id: playerIds[pIdx],
+      username,
+      orb: pIdx,
+      primary_gear: 0,
+    });
+
+    await sql`
+      INSERT INTO challenge_players ${sql(
+        [
+          cp(0, 0, 'PlayerA'),
+          cp(0, 1, 'PlayerB'),
+          cp(1, 0, 'PlayerA'),
+          cp(1, 1, 'PlayerB'),
+          cp(1, 2, 'PlayerC'),
+          cp(2, 0, 'PlayerA'),
+          cp(3, 0, 'PlayerA'),
+          cp(3, 1, 'PlayerB'),
+        ],
+        ['challenge_id', 'player_id', 'username', 'orb', 'primary_gear'],
+      )}
+    `;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM bloat_downs`;
+    await sql`DELETE FROM tob_challenge_stats`;
+    await sql`DELETE FROM challenge_players`;
+    await sql`DELETE FROM challenges`;
+    await sql`DELETE FROM challenge_sessions`;
+    await sql`DELETE FROM players`;
+  });
+
+  describe('findChallenges', () => {
+    describe('bloat down filters', () => {
+      beforeEach(async () => {
+        await sql`
+          INSERT INTO tob_challenge_stats ${sql([
+            { challenge_id: challengeIds[0], bloat_down_count: 0 },
+            { challenge_id: challengeIds[1], bloat_down_count: 1 },
+          ])}
+        `;
+
+        await sql`
+          INSERT INTO bloat_downs ${sql([
+            {
+              challenge_id: challengeIds[1],
+              down_number: 1,
+              down_tick: 41,
+              walk_ticks: 41,
+              accurate: true,
+            },
+          ])}
+        `;
       });
 
-      expect(challenges).toHaveLength(1);
-      expect(challenges[0].uuid).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc');
+      it('matches zero-down raids for tob.bloatDownCount=eq0', async () => {
+        const [challenges] = await findChallenges(10, {
+          tob: { bloatDownCount: ['==', 0] },
+        });
+
+        expect(challenges).toHaveLength(1);
+        expect(challenges[0].uuid).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+      });
+
+      it('combines persisted down count and bloat down filters', async () => {
+        const [challenges] = await findChallenges(10, {
+          tob: {
+            bloatDowns: new Map([[1, ['==', 41]]]),
+            bloatDownCount: ['==', 1],
+          },
+        });
+
+        expect(challenges).toHaveLength(1);
+        expect(challenges[0].uuid).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc');
+      });
+    });
+  });
+
+  describe('countUniquePlayers', () => {
+    it('should count all distinct players across non-abandoned challenges', async () => {
+      const count = await countUniquePlayers({});
+      expect(count).toBe(3);
+    });
+
+    it('should filter by challenge type', async () => {
+      const tobCount = await countUniquePlayers({
+        type: ['==', ChallengeType.TOB],
+      });
+      expect(tobCount).toBe(3);
+
+      const coloCount = await countUniquePlayers({
+        type: ['==', ChallengeType.COLOSSEUM],
+      });
+      expect(coloCount).toBe(1);
+    });
+
+    it('should count all participants in a party-filtered query', async () => {
+      // PlayerA appears in challenges with B and C.
+      const count = await countUniquePlayers({ party: ['PlayerA'] });
+      expect(count).toBe(3);
+    });
+
+    it('should combine party and type filters', async () => {
+      // PlayerC only has TOB challenges.
+      const count = await countUniquePlayers({
+        party: ['PlayerC'],
+        type: ['==', ChallengeType.COLOSSEUM],
+      });
+      expect(count).toBe(0);
+    });
+
+    it('should return 0 for no matching challenges', async () => {
+      const count = await countUniquePlayers({
+        type: ['==', ChallengeType.INFERNO],
+      });
+      expect(count).toBe(0);
     });
   });
 });

--- a/web/app/actions/activity.ts
+++ b/web/app/actions/activity.ts
@@ -3,6 +3,7 @@ import {
   ActivityFeedItem as RedisActivityFeedItem,
   ActivityFeedItemType,
   ActivityFeedData,
+  ChallengeType,
   normalizeRsn,
 } from '@blert/common';
 
@@ -83,12 +84,16 @@ type ChallengePlayerRow = {
   player_id: string;
 };
 
-export async function getPlayersPerHour(startTime: Date) {
+export async function getPlayersPerHour(
+  startTime: Date,
+  challengeType?: ChallengeType,
+) {
   const players = await sql<ChallengePlayerRow[]>`
     SELECT c.id, c.start_time, cp.player_id
     FROM challenges c
     JOIN challenge_players cp ON c.id = cp.challenge_id
     WHERE c.start_time >= ${startTime}
+      ${challengeType !== undefined ? sql`AND c.type = ${challengeType}` : sql``}
   `;
 
   const byHour = Array.from({ length: 25 }, () => new Set<string>());

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -664,13 +664,11 @@ function addSplitsTable(
   accurateSplits?: boolean,
 ) {
   const table = splitsTableName(split);
+  const types = allSplitModes(generalizeSplit(split));
   joins.push({
-    table: sql`(
-        SELECT challenge_id, ticks, accurate
-        FROM challenge_splits
-        WHERE type = ANY(${allSplitModes(generalizeSplit(split))})
-      ) ${sql(table)}`,
-    on: sql`${baseTable}.id = ${sql(table)}.challenge_id`,
+    table: sql`challenge_splits ${sql(table)}`,
+    on: sql`${baseTable}.id = ${sql(table)}.challenge_id
+        AND ${sql(table)}.type = ANY(${types})`,
     type: 'left',
     tableName: table,
   });
@@ -1447,6 +1445,41 @@ export async function aggregateChallenges<
   });
 
   return result as GroupedAggregationResult<F, G>;
+}
+
+/**
+ * Counts the number of distinct players that participated in any challenge
+ * matching the given query.
+ */
+export async function countUniquePlayers(
+  query: ChallengeQuery,
+): Promise<number> {
+  const components = applyFilters(query);
+  if (components === null) {
+    return 0;
+  }
+
+  const { baseTable, joins, conditions } = components;
+
+  // Use a dedicated alias so the count isn't restricted by a party filter's
+  // challenge_players join.
+  const allJoins: Join[] = [
+    ...joins,
+    {
+      table: sql`challenge_players cp_count`,
+      on: sql`challenges.id = cp_count.challenge_id`,
+      tableName: 'cp_count',
+    },
+  ];
+
+  const [row] = await sql<[{ count: string }]>`
+    SELECT COUNT(DISTINCT cp_count.player_id) AS count
+    FROM ${baseTable}
+    ${join(allJoins)}
+    ${where(conditions)}
+  `;
+
+  return parseInt(row.count);
 }
 
 export type SessionQuery = {

--- a/web/app/api/activity/players/route.ts
+++ b/web/app/api/activity/players/route.ts
@@ -1,7 +1,9 @@
+import { ChallengeType } from '@blert/common';
 import { NextRequest } from 'next/server';
 
 import { getPlayersPerHour, playerActivityByHour } from '@/actions/activity';
 import { withApiRoute } from '@/api/handler';
+import { expectSingle, numericParam } from '@/api/query';
 
 function periodToStartTime(period: string) {
   const startTime = new Date();
@@ -28,18 +30,21 @@ function periodToStartTime(period: string) {
 export const GET = withApiRoute(
   { route: '/api/activity/players' },
   async (request: NextRequest) => {
-    const params = request.nextUrl.searchParams;
+    const searchParams = request.nextUrl.searchParams;
+    const params = Object.fromEntries(searchParams);
 
-    const period = params.get('period') ?? 'day';
+    const period = expectSingle(params, 'period') ?? 'day';
     const startTime = periodToStartTime(period);
 
-    if (params.has('username')) {
-      const username = params.get('username')!;
+    const challengeType = numericParam<ChallengeType>(params, 'type');
+
+    if (searchParams.has('username')) {
+      const username = searchParams.get('username')!;
       const playersPerHour = await playerActivityByHour(username, startTime);
       return Response.json(playersPerHour);
     }
 
-    const playersPerHour = await getPlayersPerHour(startTime);
+    const playersPerHour = await getPlayersPerHour(startTime, challengeType);
     return Response.json(playersPerHour);
   },
 );

--- a/web/app/api/v1/challenges/stats/players/route.ts
+++ b/web/app/api/v1/challenges/stats/players/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from 'next/server';
+
+import { ChallengeQuery, countUniquePlayers } from '@/actions/challenge';
+import { withApiRoute } from '@/api/handler';
+
+import { parseChallengeQueryParams } from '../../query';
+
+export const GET = withApiRoute(
+  { route: '/api/v1/challenges/stats/players' },
+  async (request: NextRequest) => {
+    const searchParams = request.nextUrl.searchParams;
+
+    let query: ChallengeQuery;
+
+    try {
+      const q = parseChallengeQueryParams(searchParams);
+      if (q === null) {
+        return new Response(null, { status: 400 });
+      }
+      query = q;
+    } catch {
+      return new Response(null, { status: 400 });
+    }
+
+    const count = await countUniquePlayers(query);
+    return Response.json({ count });
+  },
+);

--- a/web/app/home/home-cards.tsx
+++ b/web/app/home/home-cards.tsx
@@ -10,6 +10,7 @@ import {
   SplitType,
   stageName,
 } from '@blert/common';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactTimeago, { Unit } from 'react-timeago';
@@ -21,24 +22,104 @@ import ActivityChart from '@/components/activity-chart';
 import Card, { CardLink } from '@/components/card';
 import Carousel from '@/components/carousel';
 import RadioInput from '@/components/radio-input';
+import { challengeLogo } from '@/logo';
 import { useClientOnly } from '@/hooks/client-only';
+import { challengeTerm } from '@/utils/challenge';
 import { challengePartyNames } from '@/utils/challenge-description';
 import { ticksToFormattedSeconds } from '@/utils/tick';
 import { challengeUrl, queryString } from '@/utils/url';
 
 import styles from './style.module.scss';
 
-const DEFAULT_REFRESH_INTERVAL = 15 * 1000;
+const DEFAULT_REFRESH_INTERVAL = 30 * 1000;
 
 const enum LocalStorageKey {
+  SELECTED_CHALLENGE = 'home-selected-challenge',
   STATS_TIME_PERIOD = 'home-stats-time-period',
   LEADERBOARD_TIME_PERIOD = 'home-leaderboard-time-period',
   ACTIVITY_FILTER = 'home-activity-filter',
 }
 
-type ActivityFeedProps = {
-  limit?: number;
-  initialFeed?: ActivityFeedItem[];
+const SUPPORTED_CHALLENGES = [
+  ChallengeType.TOB,
+  ChallengeType.COLOSSEUM,
+  ChallengeType.INFERNO,
+  ChallengeType.MOKHAIOTL,
+] as const;
+
+type SupportedChallenge = (typeof SUPPORTED_CHALLENGES)[number];
+
+type ChallengeInfo = {
+  flavorBefore: string;
+  name: string;
+  description: string;
+  hubUrl: string;
+  browseText: string;
+  leaderboardSplit: SplitType;
+  leaderboardScales: number[];
+  leaderboardUrl: string;
+  color: string;
+  colorEnd: string;
+  image?: string;
+};
+
+const CHALLENGE_INFO: Record<SupportedChallenge, ChallengeInfo> = {
+  [ChallengeType.TOB]: {
+    flavorBefore: 'Enter the',
+    name: 'Theatre of Blood',
+    description:
+      'Replay every crab spawn, Nylo wave, maze, and everything in between ' +
+      'from Maiden to Verzik.',
+    hubUrl: '/raids/tob',
+    browseText: 'Browse Raids',
+    leaderboardSplit: SplitType.TOB_REG_CHALLENGE,
+    leaderboardScales: [5, 4, 3, 2],
+    leaderboardUrl: '/leaderboards/tob',
+    color: '#d4ba2b',
+    colorEnd: '#e8a020',
+  },
+  [ChallengeType.COLOSSEUM]: {
+    flavorBefore: 'Conquer the',
+    name: 'Colosseum',
+    description:
+      'Track modifier choices, solve pillar stacks, and analyze each wave as ' +
+      'you fight your way to Sol Heredit.',
+    hubUrl: '/challenges/colosseum',
+    browseText: 'Browse Runs',
+    leaderboardSplit: SplitType.COLOSSEUM_CHALLENGE,
+    leaderboardScales: [1],
+    leaderboardUrl: '/leaderboards/colosseum',
+    color: '#33a4af',
+    colorEnd: '#58c8b8',
+  },
+  [ChallengeType.INFERNO]: {
+    flavorBefore: 'Survive the',
+    name: 'Inferno',
+    description:
+      'Break down wave spawns, positioning, and prayer flicks from the ' +
+      'moment you enter the Inferno to Zuk.',
+    hubUrl: '/challenges/inferno',
+    browseText: 'Browse Runs',
+    leaderboardSplit: SplitType.INFERNO_CHALLENGE,
+    leaderboardScales: [1],
+    leaderboardUrl: '/leaderboards/inferno',
+    color: '#a14f1a',
+    colorEnd: '#d4783a',
+  },
+  [ChallengeType.MOKHAIOTL]: {
+    flavorBefore: 'Face the',
+    name: 'Doom of Mokhaiotl',
+    description:
+      'Follow each delve as you descend into the ruins, tracking every orb, ' +
+      'larva, and acid splat as the room shrinks around you.',
+    hubUrl: '/challenges/mokhaiotl',
+    browseText: 'Browse Runs',
+    leaderboardSplit: SplitType.MOKHAIOTL_CHALLENGE,
+    leaderboardScales: [1],
+    leaderboardUrl: '/leaderboards/mokhaiotl',
+    color: '#c16056',
+    colorEnd: '#d98a7a',
+  },
 };
 
 function scaleName(scale: number) {
@@ -52,72 +133,6 @@ function scaleName(scale: number) {
     default:
       return `${scale}-player`;
   }
-}
-
-function ErrorState({ onRetry }: { onRetry: () => void }) {
-  return (
-    <div className={styles.feedError}>
-      <div className={styles.errorIcon}>
-        <i className="fas fa-exclamation-circle" />
-      </div>
-      <div className={styles.errorContent}>
-        <h3>Failed to load activity feed</h3>
-        <p>There was a problem fetching the latest activity.</p>
-      </div>
-      <button onClick={onRetry} className={styles.retryButton}>
-        <i className="fas fa-sync-alt" /> Try Again
-      </button>
-    </div>
-  );
-}
-
-type PlayerActivity = {
-  startHour: number;
-  data: {
-    hour: number;
-    count: number;
-  }[];
-};
-
-function ActivityChartWrapper() {
-  const [activityData, setActivityData] = useState<PlayerActivity>({
-    startHour: new Date().getUTCHours(),
-    data: [],
-  });
-
-  const fetchData = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/activity/players`);
-      const payload = (await res.json()) as number[];
-      setActivityData({
-        startHour: new Date().getUTCHours(),
-        data: payload.map((p, i) => ({ hour: i, count: p })),
-      });
-    } catch {
-      // TODO(frolv): Handle error.
-    }
-  }, [setActivityData]);
-
-  useEffect(() => {
-    void fetchData();
-    const interval = setInterval(
-      () => void fetchData(),
-      DEFAULT_REFRESH_INTERVAL,
-    );
-    return () => clearInterval(interval);
-  }, [fetchData]);
-
-  return (
-    <ActivityChart
-      data={activityData.data}
-      icon="fas fa-users"
-      title="Active Players"
-      timeRange="Last 24h"
-      valueLabel="players"
-      height={100}
-      startHour={activityData.startHour}
-    />
-  );
 }
 
 const enum TimePeriod {
@@ -144,6 +159,160 @@ function startOfTimePeriod(period: TimePeriod): Date {
   return start;
 }
 
+type ChallengeSelectorProps = {
+  selected: SupportedChallenge;
+  onSelect: (type: SupportedChallenge) => void;
+};
+
+function ChallengeSelector({ selected, onSelect }: ChallengeSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const [totalCount, setTotalCount] = useState<number | null>(null);
+  const [uniquePlayers, setUniquePlayers] = useState<number | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const info = CHALLENGE_INFO[selected];
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (
+        dropdownRef.current !== null &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  useEffect(() => {
+    setTotalCount(null);
+    setUniquePlayers(null);
+
+    const controller = new AbortController();
+    const params = queryString({ type: selected });
+
+    fetch(`/api/v1/challenges/stats?${params}`, {
+      signal: controller.signal,
+    })
+      .then((res) => {
+        if (res.ok) {
+          return res.json() as Promise<{ '*': { count: number } }>;
+        }
+        throw new Error('Failed to fetch total count');
+      })
+      .then((data) => {
+        setTotalCount(data['*'].count);
+      })
+      .catch(() => {
+        // Ignore API errors as stats are just decorative.
+      });
+
+    fetch(`/api/v1/challenges/stats/players?${params}`, {
+      signal: controller.signal,
+    })
+      .then((res) => {
+        if (res.ok) {
+          return res.json() as Promise<{ count: number }>;
+        }
+        throw new Error('Failed to fetch unique players');
+      })
+      .then((data) => {
+        setUniquePlayers(data.count);
+      })
+      .catch(() => {
+        // Ignore API errors as stats are just decorative.
+      });
+
+    return () => controller.abort();
+  }, [selected]);
+
+  const term = challengeTerm(selected, true).toLowerCase();
+
+  return (
+    <div
+      className={styles.challengeSelectorWrap}
+      style={
+        {
+          '--challenge-color': info.color,
+          '--challenge-color-end': info.colorEnd,
+        } as React.CSSProperties
+      }
+    >
+      <Card primary className={styles.challengeSelector}>
+        <div className={styles.selectorHeader}>
+          <span className={styles.flavorText}>{info.flavorBefore}</span>
+          <div className={styles.dropdown} ref={dropdownRef}>
+            <button
+              className={styles.dropdownToggle}
+              onClick={() => setOpen(!open)}
+            >
+              <span>{info.name}</span>
+              <i
+                className={`fas fa-chevron-down ${styles.dropdownCaret} ${open ? styles.open : ''}`}
+              />
+            </button>
+            {open && (
+              <div className={styles.dropdownMenu}>
+                {SUPPORTED_CHALLENGES.map((type) => (
+                  <button
+                    key={type}
+                    className={`${styles.dropdownItem} ${type === selected ? styles.active : ''}`}
+                    onClick={() => {
+                      onSelect(type);
+                      setOpen(false);
+                    }}
+                  >
+                    <span
+                      className={styles.dropdownDot}
+                      style={{ background: CHALLENGE_INFO[type].color }}
+                    />
+                    {CHALLENGE_INFO[type].name}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className={styles.selectorBody}>
+          <div className={styles.selectorImage}>
+            <Image
+              src={info.image ?? challengeLogo(selected)}
+              alt={info.name}
+              width={72}
+              height={72}
+              style={{ objectFit: 'contain' }}
+            />
+          </div>
+          <p className={styles.challengeDescription}>{info.description}</p>
+        </div>
+        <div className={styles.selectorStats}>
+          {totalCount !== null && (
+            <div className={styles.selectorStat}>
+              <span className={styles.selectorStatValue}>
+                {totalCount.toLocaleString()}
+              </span>
+              <span className={styles.selectorStatLabel}>{term} recorded</span>
+            </div>
+          )}
+          {uniquePlayers !== null && (
+            <div className={styles.selectorStat}>
+              <span className={`${styles.selectorStatValue} ${styles.muted}`}>
+                {uniquePlayers.toLocaleString()}
+              </span>
+              <span className={styles.selectorStatLabel}>players tracked</span>
+            </div>
+          )}
+        </div>
+
+        <Link href={info.hubUrl} className={styles.selectorCta}>
+          {info.browseText} <i className="fas fa-arrow-right" />
+        </Link>
+      </Card>
+    </div>
+  );
+}
+
 type Stats = {
   total: number;
   completions: number;
@@ -151,25 +320,23 @@ type Stats = {
     scale: number;
     percentage: number;
   };
-};
-
-type ChallengeStatsProps = {
-  initialStats?: Stats;
+  avgCompletionTicks: number | null;
 };
 
 type GroupedCount = Record<number, { '*': { count: number } }>;
 
-export function ChallengeStats({ initialStats }: ChallengeStatsProps) {
-  const [stats, setStats] = useState<Stats>(
-    initialStats ?? {
-      total: 0,
-      completions: 0,
-      mostPopularScale: {
-        scale: 0,
-        percentage: 0,
-      },
-    },
-  );
+type ChallengeStatsProps = {
+  challengeType: SupportedChallenge;
+};
+
+function ChallengeStatsCard({ challengeType }: ChallengeStatsProps) {
+  const term = challengeTerm(challengeType, true);
+  const [stats, setStats] = useState<Stats>({
+    total: 0,
+    completions: 0,
+    mostPopularScale: { scale: 0, percentage: 0 },
+    avgCompletionTicks: null,
+  });
   const [timePeriod, setTimePeriod] = useState<TimePeriod>(TimePeriod.DAY);
 
   useEffect(() => {
@@ -181,81 +348,96 @@ export function ChallengeStats({ initialStats }: ChallengeStatsProps) {
     }
   }, []);
 
-  const changeTimePeriod = useCallback(
-    (period: TimePeriod) => {
-      setTimePeriod(period);
-      window.localStorage.setItem(
-        LocalStorageKey.STATS_TIME_PERIOD,
-        period.toString(),
-      );
+  const changeTimePeriod = useCallback((period: TimePeriod) => {
+    setTimePeriod(period);
+    window.localStorage.setItem(
+      LocalStorageKey.STATS_TIME_PERIOD,
+      period.toString(),
+    );
+  }, []);
+
+  const fetchStats = useCallback(
+    async (signal?: AbortSignal) => {
+      const start = startOfTimePeriod(timePeriod);
+      const filterParams = queryString({
+        type: challengeType,
+        startTime: `ge${start.getTime()}`,
+      });
+
+      try {
+        const [scalePayload, statusPayload, avgPayload] = await Promise.all([
+          fetch(`/api/v1/challenges/stats?${filterParams}&group=scale`, {
+            signal,
+          }).then((res) => res.json() as Promise<GroupedCount>),
+          fetch(`/api/v1/challenges/stats?${filterParams}&group=status`, {
+            signal,
+          }).then((res) => res.json() as Promise<GroupedCount>),
+          fetch(
+            `/api/v1/challenges/stats?${filterParams}&status=${ChallengeStatus.COMPLETED}&aggregate=challengeTicks:avg`,
+            { signal },
+          ).then(
+            (res) =>
+              res.json() as Promise<{
+                '*': { count: number };
+                challengeTicks?: { avg: number };
+              }>,
+          ),
+        ]);
+
+        const totalChallenges = Object.values(scalePayload).reduce(
+          (acc, curr) => acc + curr['*'].count,
+          0,
+        );
+
+        let mostPopularScale = 0;
+        let mostPopularScaleCount = 0;
+        for (const [scale, result] of Object.entries(scalePayload)) {
+          if (result['*'].count > mostPopularScaleCount) {
+            mostPopularScale = parseInt(scale);
+            mostPopularScaleCount = result['*'].count;
+          }
+        }
+
+        setStats({
+          total: totalChallenges,
+          completions:
+            statusPayload[ChallengeStatus.COMPLETED]?.['*'].count ?? 0,
+          mostPopularScale: {
+            scale: mostPopularScale,
+            percentage:
+              totalChallenges > 0
+                ? (mostPopularScaleCount / totalChallenges) * 100
+                : 0,
+          },
+          avgCompletionTicks: avgPayload.challengeTicks?.avg ?? null,
+        });
+      } catch {
+        // Ignore API errors as stats will refresh.
+      }
     },
-    [setTimePeriod],
+    [challengeType, timePeriod],
   );
 
-  const fetchStats = useCallback(async () => {
-    const challengeType = ChallengeType.TOB;
-    const start = startOfTimePeriod(timePeriod);
-
-    const filterParams = queryString({
-      type: challengeType,
-      startTime: `ge${start.getTime()}`,
-    });
-
-    try {
-      const [scalePayload, statusPayload] = await Promise.all([
-        fetch(`/api/v1/challenges/stats?${filterParams}&group=scale`).then(
-          (res) => res.json() as Promise<GroupedCount>,
-        ),
-        fetch(`/api/v1/challenges/stats?${filterParams}&group=status`).then(
-          (res) => res.json() as Promise<GroupedCount>,
-        ),
-      ]);
-
-      const totalChallenges = Object.values(scalePayload).reduce(
-        (acc, curr) => acc + curr['*'].count,
-        0,
-      );
-
-      let mostPopularScale = 0;
-      let mostPopularScaleCount = 0;
-      for (const [scale, result] of Object.entries(scalePayload)) {
-        if (result['*'].count > mostPopularScaleCount) {
-          mostPopularScale = parseInt(scale);
-          mostPopularScaleCount = result['*'].count;
-        }
-      }
-
-      const stats: Stats = {
-        total: totalChallenges,
-        completions: statusPayload[ChallengeStatus.COMPLETED]?.['*'].count ?? 0,
-        mostPopularScale: {
-          scale: mostPopularScale,
-          percentage:
-            totalChallenges > 0
-              ? (mostPopularScaleCount / totalChallenges) * 100
-              : 0,
-        },
-      };
-      setStats(stats);
-    } catch {
-      // TODO(frolv): Handle error.
-    }
-  }, [setStats, timePeriod]);
-
   useEffect(() => {
-    void fetchStats();
+    const controller = new AbortController();
+    void fetchStats(controller.signal);
     const interval = setInterval(
-      () => void fetchStats(),
+      () => void fetchStats(controller.signal),
       DEFAULT_REFRESH_INTERVAL,
     );
-    return () => clearInterval(interval);
+    return () => {
+      controller.abort();
+      clearInterval(interval);
+    };
   }, [fetchStats]);
+
+  const hasMultipleScales =
+    CHALLENGE_INFO[challengeType].leaderboardScales.length > 1;
 
   return (
     <Card
-      primary
       header={{
-        title: 'Theatre of Blood',
+        title: 'Stats',
         action: (
           <RadioInput.Group
             name="time-selector"
@@ -289,7 +471,7 @@ export function ChallengeStats({ initialStats }: ChallengeStatsProps) {
       <div className={styles.statsRow}>
         <div className={styles.stat}>
           <span className={styles.value}>{stats.total}</span>
-          <span className={styles.label}>Raids</span>
+          <span className={styles.label}>{term}</span>
         </div>
         <div className={styles.stat}>
           <span className={styles.value}>{stats.completions}</span>
@@ -302,23 +484,348 @@ export function ChallengeStats({ initialStats }: ChallengeStatsProps) {
               : '0.0'}
             %
           </span>
-          <span className={styles.label}>Completion Rate</span>
+          <span className={styles.label}>Comp. Rate</span>
         </div>
       </div>
       <div className={styles.quickStats}>
-        <div className={styles.quickStat}>
-          <i className="fas fa-person-running" />
-          <span>
-            {stats.mostPopularScale.scale === 0
-              ? 'No raids completed'
-              : `Top Scale: ${scaleName(stats.mostPopularScale.scale)} ` +
-                `(${stats.mostPopularScale.percentage.toFixed(1)}% of raids)`}
-          </span>
-        </div>
+        {hasMultipleScales ? (
+          <div className={styles.quickStat}>
+            <i className="fas fa-person-running" />
+            <span>
+              {stats.mostPopularScale.scale === 0
+                ? `No ${term.toLowerCase()} completed`
+                : `Top scale: ${scaleName(stats.mostPopularScale.scale)} ` +
+                  `(${stats.mostPopularScale.percentage.toFixed(1)}% of ${term.toLowerCase()})`}
+            </span>
+          </div>
+        ) : (
+          stats.avgCompletionTicks !== null && (
+            <div className={styles.quickStat}>
+              <i className="fas fa-clock" />
+              <span>
+                {stats.avgCompletionTicks === 0
+                  ? `No ${term.toLowerCase()} completed`
+                  : `Avg. completion: ${ticksToFormattedSeconds(Math.round(stats.avgCompletionTicks))}`}
+              </span>
+            </div>
+          )
+        )}
       </div>
-      <ActivityChartWrapper />
-      <CardLink href="/raids/tob" text="Browse Raids" />
+      <ActivityChartWrapper challengeType={challengeType} />
     </Card>
+  );
+}
+
+function ActivityChartWrapper({
+  challengeType,
+}: {
+  challengeType: SupportedChallenge;
+}) {
+  const [activityData, setActivityData] = useState<{
+    startHour: number;
+    data: { hour: number; count: number }[];
+  }>({
+    startHour: new Date().getUTCHours(),
+    data: [],
+  });
+
+  const fetchData = useCallback(
+    async (signal?: AbortSignal) => {
+      try {
+        const params = queryString({ type: challengeType });
+        const res = await fetch(`/api/activity/players?${params}`, { signal });
+        const payload = (await res.json()) as number[];
+        setActivityData({
+          startHour: new Date().getUTCHours(),
+          data: payload.map((p, i) => ({ hour: i, count: p })),
+        });
+      } catch {
+        // Ignore API errors as stats will refresh.
+      }
+    },
+    [challengeType],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchData(controller.signal);
+    const interval = setInterval(
+      () => void fetchData(controller.signal),
+      DEFAULT_REFRESH_INTERVAL,
+    );
+    return () => {
+      controller.abort();
+      clearInterval(interval);
+    };
+  }, [fetchData]);
+
+  return (
+    <ActivityChart
+      data={activityData.data}
+      icon="fas fa-users"
+      title="Active Players"
+      timeRange="Last 24h"
+      valueLabel="players"
+      height={100}
+      startHour={activityData.startHour}
+    />
+  );
+}
+
+type LeaderboardEntry = {
+  rank: number;
+  time: number;
+  party: PlayerWithCurrentUsername[];
+  uuid: string;
+  date: Date;
+  tieCount?: number;
+};
+
+type ScaleLeaderboard = {
+  scale: number;
+  entries: LeaderboardEntry[];
+};
+
+type LeaderboardCardProps = {
+  challengeType: SupportedChallenge;
+};
+
+const CAROUSEL_WIDTH = 320;
+
+function Leaderboard({
+  leaderboard,
+  challengeType,
+}: {
+  leaderboard: ScaleLeaderboard;
+  challengeType: SupportedChallenge;
+}) {
+  const isClient = useClientOnly();
+  const info = CHALLENGE_INFO[challengeType];
+  const hasMultipleScales = info.leaderboardScales.length > 1;
+
+  return (
+    <div className={styles.leaderboardList} style={{ width: CAROUSEL_WIDTH }}>
+      {hasMultipleScales && (
+        <h3 className={styles.carouselTitle}>{scaleName(leaderboard.scale)}</h3>
+      )}
+      <div className={styles.leaderboardEntries}>
+        {leaderboard.entries.length > 0 ? (
+          leaderboard.entries.map((entry) => (
+            <Link
+              key={entry.uuid}
+              href={challengeUrl(challengeType, entry.uuid)}
+              className={styles.leaderboardEntry}
+            >
+              <div className={styles.date}>
+                {isClient && <ReactTimeago date={entry.date} />}
+              </div>
+              <div className={styles.topRow}>
+                <div className={styles.rank}>
+                  <span
+                    className={`${styles.medal} ${
+                      entry.rank === 1
+                        ? styles.gold
+                        : entry.rank === 2
+                          ? styles.silver
+                          : entry.rank === 3
+                            ? styles.bronze
+                            : ''
+                    }`}
+                  >
+                    {entry.rank === 1 ? '🥇' : entry.rank === 2 ? '🥈' : '🥉'}
+                  </span>
+                  {entry.rank}
+                </div>
+                <div className={styles.timeRow}>
+                  <span className={styles.time}>
+                    {ticksToFormattedSeconds(entry.time)}
+                  </span>
+                  {entry.tieCount !== undefined && entry.tieCount > 0 && (
+                    <span className={styles.tieBadge}>
+                      <i className="fas fa-users" />+{entry.tieCount}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className={styles.partyInfo}>
+                <div className={styles.party}>
+                  {entry.party.map((p) => p.username).join(', ')}
+                </div>
+              </div>
+            </Link>
+          ))
+        ) : (
+          <div className={styles.emptyState}>
+            <i className="fas fa-trophy" />
+            <p>No completions recorded in this time period.</p>
+            <p>Record your next run to be first on the leaderboard!</p>
+          </div>
+        )}
+        <CardLink href={info.leaderboardUrl} text="View Full Leaderboards" />
+      </div>
+    </div>
+  );
+}
+
+function LeaderboardCard({ challengeType }: LeaderboardCardProps) {
+  const [timePeriod, setTimePeriod] = useState<TimePeriod>(TimePeriod.DAY);
+  const [leaderboards, setLeaderboards] = useState<ScaleLeaderboard[]>([]);
+  const info = CHALLENGE_INFO[challengeType];
+  const hasMultipleScales = info.leaderboardScales.length > 1;
+
+  useEffect(() => {
+    const storedTimePeriod = window.localStorage.getItem(
+      LocalStorageKey.LEADERBOARD_TIME_PERIOD,
+    );
+    if (storedTimePeriod !== null) {
+      setTimePeriod(parseInt(storedTimePeriod) as TimePeriod);
+    }
+  }, []);
+
+  const changeTimePeriod = useCallback((period: TimePeriod) => {
+    setTimePeriod(period);
+    window.localStorage.setItem(
+      LocalStorageKey.LEADERBOARD_TIME_PERIOD,
+      period.toString(),
+    );
+  }, []);
+
+  const fetchLeaderboards = useCallback(
+    async (signal?: AbortSignal) => {
+      const params = {
+        splits: [info.leaderboardSplit],
+        limit: 3,
+        from: startOfTimePeriod(timePeriod).getTime(),
+      };
+
+      try {
+        type LeaderboardResponse = Record<SplitType, RankedSplit[]>;
+        const responses = await Promise.all(
+          info.leaderboardScales.map((scale) =>
+            fetch(`/api/v1/leaderboards?${queryString({ ...params, scale })}`, {
+              signal,
+            }).then((res) => res.json() as Promise<LeaderboardResponse>),
+          ),
+        );
+
+        const leaderboards = responses.map((res, i) => ({
+          scale: info.leaderboardScales[i],
+          entries: (res[info.leaderboardSplit] ?? []).map((entry, j) => ({
+            rank: j + 1,
+            time: entry.ticks,
+            party: entry.party,
+            uuid: entry.uuid,
+            date: entry.date,
+            tieCount: entry.tieCount,
+          })),
+        }));
+
+        setLeaderboards(leaderboards);
+      } catch {
+        // Ignore API errors as stats will refresh.
+      }
+    },
+    [info, timePeriod],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchLeaderboards(controller.signal);
+    const interval = setInterval(
+      () => void fetchLeaderboards(controller.signal),
+      DEFAULT_REFRESH_INTERVAL * 5,
+    );
+    return () => {
+      controller.abort();
+      clearInterval(interval);
+    };
+  }, [fetchLeaderboards]);
+
+  return (
+    <Card
+      header={{
+        title: 'Top Times',
+        action: (
+          <RadioInput.Group
+            name="leaderboard-time-selector"
+            className={styles.filters}
+            onChange={(value) => changeTimePeriod(value as TimePeriod)}
+            compact
+            joined
+          >
+            <RadioInput.Option
+              value={TimePeriod.DAY}
+              id="leaderboard-time-selector-day"
+              label="Day"
+              checked={timePeriod === TimePeriod.DAY}
+            />
+            <RadioInput.Option
+              value={TimePeriod.MONTH}
+              id="leaderboard-time-selector-month"
+              label="Month"
+              checked={timePeriod === TimePeriod.MONTH}
+            />
+            <RadioInput.Option
+              value={TimePeriod.ALL}
+              id="leaderboard-time-selector-all"
+              label="All Time"
+              checked={timePeriod === TimePeriod.ALL}
+            />
+          </RadioInput.Group>
+        ),
+      }}
+    >
+      <div className={styles.carousel}>
+        {hasMultipleScales ? (
+          leaderboards.length > 0 ? (
+            <Carousel
+              itemWidth={CAROUSEL_WIDTH}
+              autoCycle
+              cycleDuration={11300}
+              showArrows={false}
+            >
+              {leaderboards.map((leaderboard) => (
+                <div key={leaderboard.scale}>
+                  <Leaderboard
+                    leaderboard={leaderboard}
+                    challengeType={challengeType}
+                  />
+                </div>
+              ))}
+            </Carousel>
+          ) : (
+            <div className={styles.emptyState}>
+              <i className="fas fa-trophy" />
+              <p>No leaderboards found for this period</p>
+            </div>
+          )
+        ) : (
+          leaderboards.length > 0 && (
+            <Leaderboard
+              leaderboard={leaderboards[0]}
+              challengeType={challengeType}
+            />
+          )
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className={styles.feedError}>
+      <div className={styles.errorIcon}>
+        <i className="fas fa-exclamation-circle" />
+      </div>
+      <div className={styles.errorContent}>
+        <h3>Failed to load activity feed</h3>
+        <p>There was a problem fetching the latest activity.</p>
+      </div>
+      <button onClick={onRetry} className={styles.retryButton}>
+        <i className="fas fa-sync-alt" /> Try Again
+      </button>
+    </div>
   );
 }
 
@@ -389,7 +896,9 @@ function FeedItem({ item, index }: { item: ActivityFeedItem; index: number }) {
           <strong>{challengePartyNames(challenge as Challenge)}</strong>{' '}
           {status}
           {challenge.status === ChallengeStatus.COMPLETED ? ' a ' : ' in a '}
-          {scaleName(challenge.scale).toLowerCase()} {name}
+          {challenge.scale > 1 &&
+            `${scaleName(challenge.scale).toLowerCase()} `}
+          {name}
           {challenge.status === ChallengeStatus.COMPLETED && (
             <>
               {' in '}
@@ -402,17 +911,6 @@ function FeedItem({ item, index }: { item: ActivityFeedItem; index: number }) {
       );
       break;
     }
-    // TODO(frolv): Implement PB feed.
-    // case ActivityFeedItemType.PB: {
-    //   icon = '🏆';
-    //   content = (
-    //     <span>
-    //       <strong>Username</strong> achieved a new PB of{' '}
-    //       <strong>14:23</strong>
-    //     </span>
-    //   );
-    //   break;
-    // }
   }
 
   return (
@@ -443,11 +941,10 @@ function feedKeys(feed: ActivityFeedItem[]) {
   return feed.map((item) => item.time.getTime().toString()).join(',');
 }
 
-const enum FeedType {
-  ALL,
-  CHALLENGES,
-  PBS,
-}
+type ActivityFeedProps = {
+  limit?: number;
+  initialFeed?: ActivityFeedItem[];
+};
 
 export function ActivityFeed({
   limit = 5,
@@ -459,27 +956,6 @@ export function ActivityFeed({
     initialFeed.length === 0,
   );
   const [error, setError] = useState(false);
-  const [_feedType, _setFeedType] = useState<FeedType>(FeedType.ALL);
-
-  useEffect(() => {
-    const storedFeedType = window.localStorage.getItem(
-      LocalStorageKey.ACTIVITY_FILTER,
-    );
-    if (storedFeedType !== null) {
-      _setFeedType(parseInt(storedFeedType) as FeedType);
-    }
-  }, []);
-
-  const _changeFeedType = useCallback(
-    (type: FeedType) => {
-      _setFeedType(type);
-      window.localStorage.setItem(
-        LocalStorageKey.ACTIVITY_FILTER,
-        type.toString(),
-      );
-    },
-    [_setFeedType],
-  );
 
   const fetchActivity = useCallback(async () => {
     try {
@@ -495,7 +971,6 @@ export function ActivityFeed({
         time: new Date(item.time),
       }));
 
-      // Only update feed if there are new items to avoid unnecessary animations.
       if (feedKeys(data) !== feedItemKeys.current) {
         setFeed(data);
         feedItemKeys.current = feedKeys(data);
@@ -519,33 +994,6 @@ export function ActivityFeed({
 
   return (
     <Card header={{ title: 'Live Activity' }} className={styles.activityFeed}>
-      {/* TODO(frolv): Enable filtering once PB feed is implemented.
-        <RadioInput.Group
-          name="feed-type"
-          className={styles.filters}
-          onChange={(value) => changeFeedType(value as FeedType)}
-          compact
-          joined
-        >
-          <RadioInput.Option
-            value={FeedType.ALL}
-            id="feed-type-all"
-            label="All"
-            checked={feedType === FeedType.ALL}
-          />
-          <RadioInput.Option
-            value={FeedType.CHALLENGES}
-            id="feed-type-challenges"
-            label="Challenges"
-            checked={feedType === FeedType.CHALLENGES}
-          />
-          <RadioInput.Option
-            value={FeedType.PBS}
-            id="feed-type-pbs"
-            label="PBs"
-            checked={feedType === FeedType.PBS}
-          />
-        </RadioInput.Group> */}
       <div className={styles.feedItems}>
         {error ? (
           <ErrorState onRetry={() => void fetchActivity()} />
@@ -575,8 +1023,6 @@ type GuideCardItem = {
   views?: number;
   author?: string;
 };
-
-const CAROUSEL_WIDTH = 320;
 
 const SHOWCASE_GUIDES: GuideCardItem[] = [
   {
@@ -614,7 +1060,7 @@ export function GuidesCard() {
         })),
       );
     } catch {
-      // TODO(frolv): Handle error.
+      // Ignore API errors as stats will refresh.
     }
   }, []);
 
@@ -627,291 +1073,116 @@ export function GuidesCard() {
     return () => clearInterval(interval);
   }, [fetchSetups]);
 
-  const renderGuideList = (
-    items: GuideCardItem[],
-    viewAllLink: { href: string; text: string },
-  ) => (
-    <div className={styles.guideList} style={{ width: CAROUSEL_WIDTH }}>
-      {items.map((item, i) => (
-        <Link key={i} href={item.href} className={styles.guideItem}>
-          <span className={styles.guideTitle}>{item.title}</span>
-          <div className={styles.guideInfo}>
-            {item.guideType && (
-              <span className={styles.guideType}>{item.guideType}</span>
-            )}
-            {item.author && (
-              <span className={styles.guideAuthor}>by {item.author}</span>
-            )}
-            {item.updatedAt && (
-              <span className={styles.guideDate}>
-                Updated <ReactTimeago date={item.updatedAt} />
+  return (
+    <div className={styles.communityGrid}>
+      <Card header={{ title: 'Browse Guides' }} className={styles.guidesPanel}>
+        <div className={styles.communityList}>
+          {SHOWCASE_GUIDES.map((item, i) => (
+            <Link key={i} href={item.href} className={styles.guideItem}>
+              <span className={styles.guideTitle}>
+                <i className="fas fa-book" />
+                {item.title}
               </span>
-            )}
-          </div>
-          <p className={styles.guideDesc}>{item.description}</p>
-          {item.score !== undefined && (
-            <div className={styles.setupStats}>
-              <div className={styles.score}>
-                <i className="fas fa-star" />
-                <span>{item.score}</span>
-              </div>
-              <div className={styles.views}>
-                <i className="fas fa-eye" />
-                <span>{item.views}</span>
-              </div>
-            </div>
-          )}
-        </Link>
-      ))}
-      <CardLink href={viewAllLink.href} text={viewAllLink.text} />
-    </div>
-  );
-
-  return (
-    <Card header={{ title: 'Community Contributions' }}>
-      <div className={styles.carousel}>
-        <Carousel
-          itemWidth={CAROUSEL_WIDTH}
-          autoCycle
-          cycleDuration={8000}
-          showArrows={false}
-        >
-          <div className={styles.carouselItem}>
-            <h3 className={styles.carouselTitle}>Latest Guides</h3>
-            {renderGuideList(SHOWCASE_GUIDES, {
-              href: '/guides',
-              text: 'View All Guides',
-            })}
-          </div>
-          <div className={styles.carouselItem}>
-            <h3 className={styles.carouselTitle}>Highest Rated Gear Setups</h3>
-            {renderGuideList(setups, {
-              href: '/setups',
-              text: 'View All Setups',
-            })}
-          </div>
-        </Carousel>
-      </div>
-    </Card>
-  );
-}
-
-type LeaderboardEntry = {
-  rank: number;
-  time: number;
-  party: PlayerWithCurrentUsername[];
-  uuid: string;
-  date: Date;
-  tieCount?: number;
-};
-
-type ScaleLeaderboard = {
-  scale: number;
-  entries: LeaderboardEntry[];
-};
-
-function Leaderboard({ leaderboard }: { leaderboard: ScaleLeaderboard }) {
-  const isClient = useClientOnly();
-
-  return (
-    <div className={styles.leaderboardList} style={{ width: CAROUSEL_WIDTH }}>
-      <h3 className={styles.carouselTitle}>
-        {scaleName(leaderboard.scale)} Theatre of Blood
-      </h3>
-      <div className={styles.leaderboardEntries}>
-        {leaderboard.entries.length > 0 ? (
-          leaderboard.entries.map((entry) => (
-            <Link
-              key={entry.uuid}
-              href={challengeUrl(ChallengeType.TOB, entry.uuid)}
-              className={styles.leaderboardEntry}
-            >
-              <div className={styles.date}>
-                {isClient && <ReactTimeago date={entry.date} />}
-              </div>
-              <div className={styles.topRow}>
-                <div className={styles.rank}>
-                  <span
-                    className={`${styles.medal} ${
-                      entry.rank === 1
-                        ? styles.gold
-                        : entry.rank === 2
-                          ? styles.silver
-                          : entry.rank === 3
-                            ? styles.bronze
-                            : ''
-                    }`}
-                  >
-                    {entry.rank === 1 ? '🥇' : entry.rank === 2 ? '🥈' : '🥉'}
+              <div className={styles.guideInfo}>
+                {item.guideType && (
+                  <span className={styles.guideType}>{item.guideType}</span>
+                )}
+                {item.updatedAt && (
+                  <span className={styles.guideDate}>
+                    Updated <ReactTimeago date={item.updatedAt} />
                   </span>
-                  {entry.rank}
-                </div>
-                <div className={styles.timeRow}>
-                  <span className={styles.time}>
-                    {ticksToFormattedSeconds(entry.time)}
-                  </span>
-                  {entry.tieCount !== undefined && entry.tieCount > 0 && (
-                    <span className={styles.tieBadge}>
-                      <i className="fas fa-users" />+{entry.tieCount}
-                    </span>
-                  )}
-                </div>
+                )}
               </div>
-              <div className={styles.partyInfo}>
-                <div className={styles.party}>
-                  {entry.party.map((p) => p.username).join(', ')}
-                </div>
-              </div>
+              <p className={styles.guideDesc}>{item.description}</p>
             </Link>
-          ))
-        ) : (
-          <div className={styles.emptyState}>
-            <i className="fas fa-trophy" />
-            <p>
-              No regular {scaleName(leaderboard.scale)} raids have been
-              completed in this time period.
-            </p>
-            <p>Record your next raid to be first on the leaderboard!</p>
-          </div>
-        )}
-        <CardLink
-          href={`/leaderboards/tob/regular/${leaderboard.scale}`}
-          text="View Full Leaderboards"
-        />
-      </div>
+          ))}
+        </div>
+        <CardLink href="/guides" text="View All Guides" />
+      </Card>
+      <Card
+        header={{ title: 'Top Community Gear Setups' }}
+        className={styles.setupsPanel}
+      >
+        <div className={styles.communityList}>
+          {setups.map((item, i) => (
+            <Link key={i} href={item.href} className={styles.guideItem}>
+              <span className={styles.guideTitle}>
+                <i className="fas fa-shield-halved" />
+                {item.title}
+              </span>
+              <div className={styles.guideInfo}>
+                {item.author && (
+                  <span className={styles.guideAuthor}>by {item.author}</span>
+                )}
+              </div>
+              {item.score !== undefined && (
+                <div className={styles.setupStats}>
+                  <div className={styles.score}>
+                    <i className="fas fa-star" />
+                    <span>{item.score}</span>
+                  </div>
+                  <div className={styles.views}>
+                    <i className="fas fa-eye" />
+                    <span>{item.views}</span>
+                  </div>
+                </div>
+              )}
+            </Link>
+          ))}
+        </div>
+        <CardLink href="/setups" text="View All Setups" />
+      </Card>
     </div>
   );
 }
 
-export function LeaderboardCard({
-  initialLeaderboards = [],
-}: {
-  initialLeaderboards?: ScaleLeaderboard[];
-}) {
-  const [timePeriod, setTimePeriod] = useState<TimePeriod>(TimePeriod.DAY);
-  const [leaderboards, setLeaderboards] =
-    useState<ScaleLeaderboard[]>(initialLeaderboards);
+export function HomeCards() {
+  const [selectedChallenge, setSelectedChallenge] =
+    useState<SupportedChallenge | null>(null);
 
   useEffect(() => {
-    const storedTimePeriod = window.localStorage.getItem(
-      LocalStorageKey.LEADERBOARD_TIME_PERIOD,
+    const stored = window.localStorage.getItem(
+      LocalStorageKey.SELECTED_CHALLENGE,
     );
-    if (storedTimePeriod !== null) {
-      setTimePeriod(parseInt(storedTimePeriod) as TimePeriod);
+    if (stored !== null) {
+      const parsed = parseInt(stored);
+      if (SUPPORTED_CHALLENGES.includes(parsed as SupportedChallenge)) {
+        setSelectedChallenge(parsed as SupportedChallenge);
+        return;
+      }
     }
+    setSelectedChallenge(ChallengeType.TOB);
   }, []);
 
-  const changeTimePeriod = useCallback(
-    (period: TimePeriod) => {
-      setTimePeriod(period);
-      window.localStorage.setItem(
-        LocalStorageKey.LEADERBOARD_TIME_PERIOD,
-        period.toString(),
-      );
-    },
-    [setTimePeriod],
-  );
-
-  const fetchLeaderboards = useCallback(async () => {
-    const params = {
-      splits: [SplitType.TOB_REG_CHALLENGE],
-      limit: 3,
-      from: startOfTimePeriod(timePeriod).getTime(),
-    };
-
-    try {
-      type LeaderboardResponse = Record<SplitType, RankedSplit[]>;
-      const responses = await Promise.all(
-        [5, 4, 3, 2].map((scale) =>
-          fetch(
-            `/api/v1/leaderboards?${queryString({ ...params, scale })}`,
-          ).then((res) => res.json() as Promise<LeaderboardResponse>),
-        ),
-      );
-
-      const leaderboards = responses.map((res, i) => ({
-        scale: 5 - i,
-        entries: (res[SplitType.TOB_REG_CHALLENGE] ?? []).map((entry, j) => ({
-          rank: j + 1,
-          time: entry.ticks,
-          party: entry.party,
-          uuid: entry.uuid,
-          date: entry.date,
-          tieCount: entry.tieCount,
-        })),
-      }));
-
-      setLeaderboards(leaderboards);
-    } catch {
-      // TODO(frolv): Handle error.
-    }
-  }, [timePeriod, setLeaderboards]);
-
-  useEffect(() => {
-    void fetchLeaderboards();
-    const interval = setInterval(
-      () => void fetchLeaderboards(),
-      // Leaderboard don't change that often, so update them less frequently.
-      DEFAULT_REFRESH_INTERVAL * 5,
+  const handleSelect = useCallback((type: SupportedChallenge) => {
+    setSelectedChallenge(type);
+    window.localStorage.setItem(
+      LocalStorageKey.SELECTED_CHALLENGE,
+      type.toString(),
     );
-    return () => clearInterval(interval);
-  }, [fetchLeaderboards]);
+  }, []);
+
+  if (selectedChallenge === null) {
+    return (
+      <div className={styles.statsGrid}>
+        {Array.from({ length: 3 }, (_, i) => (
+          <Card key={i} className={styles.skeletonCard}>
+            <div className={styles.skeletonText} style={{ width: '100%' }}>
+              <div className={styles.skeletonLine} style={{ width: '60%' }} />
+              <div className={styles.skeletonLine} style={{ width: '80%' }} />
+              <div className={styles.skeletonLine} style={{ width: '40%' }} />
+            </div>
+          </Card>
+        ))}
+      </div>
+    );
+  }
 
   return (
-    <Card
-      header={{
-        title: 'Top Times',
-        action: (
-          <RadioInput.Group
-            name="leaderboard-time-selector"
-            className={styles.filters}
-            onChange={(value) => changeTimePeriod(value as TimePeriod)}
-            compact
-            joined
-          >
-            <RadioInput.Option
-              value={TimePeriod.DAY}
-              id="leaderboard-time-selector-day"
-              label="Day"
-              checked={timePeriod === TimePeriod.DAY}
-            />
-            <RadioInput.Option
-              value={TimePeriod.MONTH}
-              id="leaderboard-time-selector-month"
-              label="Month"
-              checked={timePeriod === TimePeriod.MONTH}
-            />
-            <RadioInput.Option
-              value={TimePeriod.ALL}
-              id="leaderboard-time-selector-all"
-              label="All Time"
-              checked={timePeriod === TimePeriod.ALL}
-            />
-          </RadioInput.Group>
-        ),
-      }}
-    >
-      <div className={styles.carousel}>
-        {leaderboards.length > 0 ? (
-          <Carousel
-            itemWidth={CAROUSEL_WIDTH}
-            autoCycle
-            cycleDuration={11300}
-            showArrows={false}
-          >
-            {leaderboards.map((leaderboard) => (
-              <div key={leaderboard.scale} className={styles.carouselItem}>
-                <Leaderboard leaderboard={leaderboard} />
-              </div>
-            ))}
-          </Carousel>
-        ) : (
-          <div className={styles.emptyState}>
-            <i className="fas fa-trophy" />
-            <p>No leaderboards found for this period</p>
-          </div>
-        )}
-      </div>
-    </Card>
+    <div className={styles.statsGrid}>
+      <ChallengeSelector selected={selectedChallenge} onSelect={handleSelect} />
+      <ChallengeStatsCard challengeType={selectedChallenge} />
+      <LeaderboardCard challengeType={selectedChallenge} />
+    </div>
   );
 }

--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -1,88 +1,14 @@
-import { ChallengeStatus, SplitType } from '@blert/common';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import {
-  aggregateChallenges,
-  findBestSplitTimes,
-  RankedSplit,
-} from '@/actions/challenge';
 import { getSignedInUserId } from '@/actions/users';
 import Card from '@/components/card';
-import {
-  ActivityFeed,
-  ChallengeStats,
-  GuidesCard,
-  LeaderboardCard,
-} from './home-cards';
+import { ActivityFeed, GuidesCard, HomeCards } from './home-cards';
 
 import styles from './style.module.scss';
 
-const LEADERBOARD_SCALES = [5, 4, 3, 2];
-
 export default async function Home() {
-  const today = new Date();
-  today.setUTCHours(0, 0, 0, 0);
-
   const isLoggedIn = (await getSignedInUserId()) !== null;
-
-  const statsQueries = Promise.all([
-    aggregateChallenges(
-      { startTime: ['>=', today] },
-      { '*': 'count' },
-      {},
-      'scale',
-    ),
-    aggregateChallenges(
-      { startTime: ['>=', today] },
-      { '*': 'count' },
-      {},
-      'status',
-    ),
-  ]);
-
-  const leaderboardQueries = Promise.all(
-    LEADERBOARD_SCALES.map((scale) =>
-      findBestSplitTimes([SplitType.TOB_REG_CHALLENGE], scale, 3, today),
-    ),
-  );
-
-  const [[byScale, byStatus], leaderboardData] = await Promise.all([
-    statsQueries,
-    leaderboardQueries,
-  ]);
-
-  let totalChallenges = 0;
-  let mostPopularScale = 0;
-  let mostPopularScaleCount = 0;
-  Object.entries(byScale ?? {}).forEach(([scale, count]) => {
-    totalChallenges += count['*'].count;
-    if (count['*'].count > mostPopularScaleCount) {
-      mostPopularScale = parseInt(scale);
-      mostPopularScaleCount = count['*'].count;
-    }
-  });
-  const stats = {
-    total: totalChallenges,
-    completions: byStatus?.[ChallengeStatus.COMPLETED]?.['*']?.count ?? 0,
-    mostPopularScale: {
-      scale: mostPopularScale,
-      percentage: (mostPopularScaleCount / totalChallenges) * 100,
-    },
-  };
-
-  const leaderboards = leaderboardData.map((res, i) => ({
-    scale: 5 - i,
-    entries: (res[SplitType.TOB_REG_CHALLENGE] ?? []).map(
-      (entry: RankedSplit, i: number) => ({
-        rank: i + 1,
-        time: entry.ticks,
-        party: entry.party,
-        uuid: entry.uuid,
-        date: entry.date,
-      }),
-    ),
-  }));
 
   return (
     <div className={styles.home}>
@@ -92,7 +18,7 @@ export default async function Home() {
             <h1>Track Your PvM Progress</h1>
             <p>
               Join hundreds of players using Blert to analyze and improve their
-              Theatre of Blood raids.
+              Old School RuneScape PvM abilities.
             </p>
           </div>
           <div className={styles.ctaButtons}>
@@ -116,13 +42,11 @@ export default async function Home() {
           </div>
         </div>
 
-        <div className={styles.statsGrid}>
-          <ChallengeStats initialStats={stats} />
-          <GuidesCard />
-          <LeaderboardCard initialLeaderboards={leaderboards} />
-        </div>
+        <HomeCards />
 
         <ActivityFeed />
+
+        <GuidesCard />
 
         <Card
           header={{ title: 'Status Updates' }}

--- a/web/app/home/style.module.scss
+++ b/web/app/home/style.module.scss
@@ -30,6 +30,203 @@
   gap: 24px;
 }
 
+.challengeSelectorWrap {
+  display: flex;
+}
+
+.challengeSelector {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+  border-left: 3px solid var(--challenge-color, var(--blert-purple));
+  width: 100%;
+
+  &:hover {
+    border-left-color: var(--challenge-color, var(--blert-purple));
+  }
+
+  .selectorHeader {
+    margin-bottom: 16px;
+  }
+
+  .flavorText {
+    display: block;
+    font-size: 0.8em;
+    color: var(--blert-font-color-secondary);
+    margin-bottom: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 500;
+  }
+
+  .dropdown {
+    position: relative;
+  }
+
+  .dropdownToggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+
+    span {
+      font-size: 1.5em;
+      font-weight: 700;
+      background: linear-gradient(
+        135deg,
+        var(--challenge-color, var(--blert-purple)),
+        var(--challenge-color-end, var(--blert-purple))
+      );
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+
+    .dropdownCaret {
+      color: var(--challenge-color, var(--blert-purple));
+      font-size: 0.8em;
+      transition: transform 0.2s ease;
+
+      &.open {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  .dropdownMenu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    min-width: 220px;
+    background: var(--blert-surface-dark);
+    border: 1px solid var(--blert-divider-color);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    z-index: 10;
+    overflow: hidden;
+  }
+
+  .dropdownItem {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 10px 16px;
+    background: none;
+    border: none;
+    color: var(--blert-font-color-primary);
+    font-size: 0.95em;
+    text-align: left;
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      background: rgba(var(--blert-purple-base), 0.1);
+    }
+
+    &.active {
+      font-weight: 600;
+    }
+
+    .dropdownDot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+  }
+
+  .selectorBody {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+
+  .selectorImage {
+    flex-shrink: 0;
+    width: 80px;
+    height: 80px;
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--blert-surface-dark);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .challengeDescription {
+    flex: 1;
+    font-size: 0.9em;
+    line-height: 1.5;
+    color: rgba(var(--blert-font-color-primary-base), 0.8);
+    margin: 0;
+  }
+
+  .selectorStats {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .selectorStat {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 10px 12px;
+    background: var(--blert-surface-dark);
+    border-radius: 6px;
+  }
+
+  .selectorStatValue {
+    font-size: 1.3em;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--challenge-color, var(--blert-purple));
+
+    &.muted {
+      color: var(--blert-font-color-primary);
+      font-size: 1.1em;
+    }
+  }
+
+  .selectorStatLabel {
+    font-size: 0.85em;
+    color: var(--blert-font-color-secondary);
+  }
+
+  .selectorCta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+    margin-top: auto;
+    color: var(--challenge-color, var(--blert-purple));
+    font-weight: 600;
+    font-size: 0.9em;
+    text-decoration: none;
+    transition: all 0.2s ease;
+
+    i {
+      font-size: 0.85em;
+      transition: transform 0.2s ease;
+    }
+
+    &:hover {
+      opacity: 0.8;
+
+      i {
+        transform: translateX(4px);
+      }
+    }
+  }
+}
+
 .statsRow {
   display: flex;
   justify-content: space-between;
@@ -45,19 +242,26 @@
   flex: 1;
   min-width: 0;
 
+  &:not(:last-child) {
+    border-right: 1px solid rgba(var(--blert-surface-light-base), 0.5);
+  }
+
   .value {
     font-size: 2em;
-    font-weight: 500;
+    font-weight: 700;
     color: var(--blert-font-color-primary);
     line-height: 1.2;
     margin-bottom: auto;
+    font-variant-numeric: tabular-nums;
   }
 
   .label {
-    font-size: 0.9em;
+    font-size: 0.75em;
     color: var(--blert-font-color-secondary);
     margin-top: 6px;
     white-space: nowrap;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
   }
 }
 
@@ -114,8 +318,10 @@
 .statusPanel {
   .statusCard {
     padding: 16px;
+    padding-left: 20px;
     background: var(--blert-surface-dark);
     border-radius: 8px;
+    border-left: 3px solid var(--blert-green);
 
     &:not(:last-child) {
       margin-bottom: 12px;
@@ -304,6 +510,27 @@
     var(--blert-panel-background-color),
     var(--blert-surface-light)
   );
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    0 4px 20px rgba(0, 0, 0, 0.25),
+    0 1px 4px rgba(0, 0, 0, 0.15);
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--blert-purple),
+      transparent
+    );
+    animation: borderShimmer 3s ease-in-out infinite;
+  }
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
     flex-direction: column;
@@ -318,6 +545,7 @@
       background: linear-gradient(to right, #fff, var(--blert-purple));
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
+      background-clip: text;
     }
 
     p {
@@ -365,6 +593,7 @@
 
   &:hover {
     background: rgba(var(--blert-purple-base), 0.8);
+    box-shadow: 0 0 16px rgba(var(--blert-purple-base), 0.35);
   }
 }
 
@@ -427,13 +656,6 @@
     width: 16px;
     text-align: center;
   }
-}
-
-.guideInfo {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 4px;
 }
 
 .guideDate {
@@ -665,6 +887,10 @@
   }
 }
 
+.skeletonCard {
+  min-height: 390px;
+}
+
 .skeletonText {
   display: flex;
   flex-direction: column;
@@ -695,23 +921,46 @@
 }
 
 .carouselTitle {
-  font-size: 1.1em;
-  color: var(--blert-font-color-primary);
-  margin: 0 0 16px 0;
+  font-size: 0.95em;
+  color: var(--blert-font-color-secondary);
+  margin: 0 0 10px 0;
   font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-.guideList {
+.communityGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+
+.communityList {
   display: flex;
   flex-direction: column;
-  padding: 0 5px;
-  gap: 12px;
+  gap: 10px;
+}
+
+.guidesPanel {
+  border-top: 2px solid var(--blert-blue);
+
+  &:hover {
+    border-top-color: var(--blert-blue);
+  }
+}
+
+.setupsPanel {
+  border-top: 2px solid var(--blert-yellow);
+
+  &:hover {
+    border-top-color: var(--blert-yellow);
+  }
 }
 
 .guideItem {
   display: flex;
   flex-direction: column;
-  padding: 16px;
+  padding: 14px;
   background: var(--blert-surface-dark);
   border-radius: 6px;
   text-decoration: none;
@@ -723,21 +972,31 @@
   }
 
   .guideTitle {
-    font-size: 1.1em;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 1em;
     font-weight: 500;
     color: var(--blert-font-color-primary);
-    margin-bottom: 8px;
+    margin-bottom: 6px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: 100%;
+
+    i {
+      color: var(--blert-font-color-secondary);
+      font-size: 0.85em;
+      width: 16px;
+      text-align: center;
+      flex-shrink: 0;
+    }
   }
 
   .guideInfo {
     display: flex;
     gap: 12px;
     align-items: center;
-    margin-bottom: 8px;
     font-size: 0.85em;
     color: var(--blert-font-color-secondary);
 
@@ -751,20 +1010,19 @@
   }
 
   .guideDesc {
-    margin: 0;
-    font-size: 0.9em;
+    margin: 6px 0 0 0;
+    font-size: 0.85em;
     line-height: 1.5;
     color: var(--blert-font-color-secondary);
-    margin-bottom: 12px;
   }
 
   .setupStats {
     display: flex;
     gap: 16px;
-    margin-top: auto;
-    padding-top: 12px;
+    margin-top: 8px;
+    padding-top: 8px;
     border-top: 1px solid var(--blert-divider-color);
-    font-size: 0.9em;
+    font-size: 0.85em;
 
     .score,
     .views {
@@ -774,13 +1032,13 @@
       color: var(--blert-font-color-secondary);
 
       i {
-        font-size: 0.9em;
+        font-size: 0.85em;
       }
     }
 
     .score {
       i {
-        color: var(--blert-purple);
+        color: var(--blert-yellow);
       }
     }
   }
@@ -796,8 +1054,13 @@
 .leaderboardEntries {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   width: 100%;
+
+  a:last-child {
+    font-size: 0.9em;
+    padding: 6px 8px;
+  }
 }
 
 .emptyState {
@@ -828,8 +1091,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 16px;
+  gap: 6px;
+  padding: 10px 14px;
   background: var(--blert-surface-dark);
   border-radius: 6px;
   text-decoration: none;
@@ -843,9 +1106,9 @@
 
   .date {
     position: absolute;
-    top: 12px;
-    right: 16px;
-    font-size: 0.85em;
+    top: 10px;
+    right: 14px;
+    font-size: 0.8em;
     color: var(--blert-font-color-secondary);
     opacity: 0.8;
   }
@@ -915,8 +1178,18 @@
 
     .party {
       color: var(--blert-font-color-secondary);
-      font-size: 0.9em;
-      line-height: 1.4;
+      font-size: 0.85em;
+      line-height: 1.3;
     }
+  }
+}
+
+@keyframes borderShimmer {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
   }
 }

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -47,7 +47,7 @@ const RATE_LIMITS: RouteMatcher[] = [
   {
     test: (path) => path.startsWith('/api/v1/challenges/stats'),
     config: {
-      limit: 60,
+      limit: 80,
       windowSec: 60,
       keyPrefix: 'ratelimit:v1:challenge-stats',
     },
@@ -71,7 +71,7 @@ const RATE_LIMITS: RouteMatcher[] = [
   {
     test: (path) => path.startsWith('/api/v1/'),
     config: {
-      limit: 80,
+      limit: 100,
       windowSec: 60,
       keyPrefix: 'ratelimit:v1:default',
     },


### PR DESCRIPTION
Changes the home page from ToB-only stats and copy to allow selecting a challenge type whose stats to view. Replaces the community card with a challenge selector which controls the stats and leaderboards cards. Creates a new community section below the activity feed.