### PR TITLE
web: Remove page counts from search

### DIFF
--- a/web/app/api/v1/challenges/route.ts
+++ b/web/app/api/v1/challenges/route.ts
@@ -96,7 +96,7 @@ export const GET = withApiRoute(
     const findOptions: Required<FindChallengesOptions> = {
       accurateSplits: true,
       fullRecordings: false,
-      count: true,
+      count: false,
       extraFields: {
         splits: Array.from(splits),
         stats: loadStats,
@@ -122,14 +122,10 @@ export const GET = withApiRoute(
       }
     }
 
-    const [challenges, count] = await findChallenges(limit, query, findOptions);
+    const [challenges] = await findChallenges(limit, query, findOptions);
     if (challenges === null) {
       return new Response(null, { status: 404 });
     }
-    return NextResponse.json(challenges, {
-      headers: {
-        'X-Total-Count': count ? count.toString() : '0',
-      },
-    });
+    return NextResponse.json(challenges);
   },
 );

--- a/web/app/search/challenges/page.tsx
+++ b/web/app/search/challenges/page.tsx
@@ -88,11 +88,15 @@ export default async function SearchPage({
   baseQuery.sort = undefined;
   baseQuery.customConditions = undefined;
 
-  const [[initialChallenges, remaining], initialStats] = await Promise.all([
-    findChallenges(INITIAL_RESULTS, initialQuery, {
-      ...queryOptions,
-      count: true,
-    }),
+  const [initialChallenges, initialStats] = await Promise.all([
+    findChallenges(INITIAL_RESULTS, initialQuery, queryOptions).then(
+      ([challenges]) => {
+        if (params.before !== undefined) {
+          challenges.reverse();
+        }
+        return challenges;
+      },
+    ),
     aggregateChallenges(baseQuery, { '*': 'count' }, queryOptions).then(
       (result) =>
         result !== null
@@ -103,20 +107,10 @@ export default async function SearchPage({
     ),
   ]);
 
-  let initialRemaining: number;
-  if (params.before !== undefined) {
-    initialRemaining =
-      initialStats.count - (remaining ?? initialStats.count) + INITIAL_RESULTS;
-    initialChallenges.reverse();
-  } else {
-    initialRemaining = remaining ?? initialStats.count;
-  }
-
   return (
     <Search
       initialContext={initialContext}
       initialChallenges={initialChallenges}
-      initialRemaining={initialRemaining}
       initialStats={initialStats}
     />
   );

--- a/web/app/search/challenges/search.tsx
+++ b/web/app/search/challenges/search.tsx
@@ -36,7 +36,6 @@ type SearchProps = {
   initialContext: SearchContext;
   initialChallenges: ChallengeOverview[];
   initialStats: FilteredStats;
-  initialRemaining: number;
 };
 
 class LoadChallengeError extends Error {
@@ -153,7 +152,6 @@ export default function Search({
   initialContext,
   initialChallenges,
   initialStats,
-  initialRemaining,
 }: SearchProps) {
   const [initialFetch, setInitialFetch] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -163,13 +161,13 @@ export default function Search({
   const [challenges, setChallenges] =
     useState<ChallengeOverview[]>(initialChallenges);
   const [stats, setStats] = useState<FilteredStats>(initialStats);
-  const [remaining, setRemaining] = useState(initialRemaining);
 
   const resultsPerPage = 25; // TODO(frolv): Make this configurable.
-  const offset = stats.count - remaining;
 
-  const page = Math.floor(offset / resultsPerPage) + 1;
-  const totalPages = Math.ceil(stats.count / resultsPerPage);
+  const [hasMore, setHasMore] = useState(
+    initialChallenges.length >= resultsPerPage,
+  );
+  const [hasPrevious, setHasPrevious] = useState(false);
 
   const errorForStatus = (status?: number): LoadErrorState => {
     if (status === 429) {
@@ -199,57 +197,77 @@ export default function Search({
     const updatedUrl = `/search/challenges?${queryString(paginationParams)}`;
     window.history.replaceState(null, '', updatedUrl);
 
-    paginationParams.limit = resultsPerPage;
+    paginationParams.limit = resultsPerPage + 1;
     paginationParams.extraFields = extraFieldsToUrlParam(ctx.extraFields);
 
     setLoading(true);
     setLoadError(null);
 
     try {
-      const [[newChallenges, newRemaining], newStats] = await Promise.all([
-        fetch(`/api/v1/challenges?${queryString(paginationParams)}`).then(
-          async (res) => {
-            if (!res.ok) {
-              throw new LoadChallengeError('Search request failed', res.status);
-            }
-            const rem = res.headers.get('X-Total-Count');
-            const payload = (await res.json()) as ChallengeOverview[];
-            const parsed = payload.map((c) => ({
-              ...c,
-              startTime: new Date(c.startTime),
-            }));
-            return [
-              parsed,
-              rem !== null && !Number.isNaN(parseInt(rem, 10))
-                ? parseInt(rem, 10)
-                : null,
-            ] as [ChallengeOverview[], number | null];
-          },
-        ),
-        fetch(`/api/v1/challenges/stats?${queryString(baseParams)}`).then(
-          async (res) => {
-            if (!res.ok) {
-              throw new LoadChallengeError('Stats request failed', res.status);
-            }
-            return (await res.json()) as { '*': { count: number } | undefined };
-          },
-        ),
+      const challengesPromise = fetch(
+        `/api/v1/challenges?${queryString(paginationParams)}`,
+      ).then(async (res) => {
+        if (!res.ok) {
+          throw new LoadChallengeError('Search request failed', res.status);
+        }
+        const payload = (await res.json()) as ChallengeOverview[];
+        return payload.map((c) => ({
+          ...c,
+          startTime: new Date(c.startTime),
+        }));
+      });
+
+      const isPaginating =
+        action === FetchAction.FORWARD || action === FetchAction.BACK;
+
+      const statsPromise = isPaginating
+        ? Promise.resolve(null)
+        : fetch(`/api/v1/challenges/stats?${queryString(baseParams)}`).then(
+            async (res) => {
+              if (!res.ok) {
+                throw new LoadChallengeError(
+                  'Stats request failed',
+                  res.status,
+                );
+              }
+              return (await res.json()) as {
+                '*': { count: number } | undefined;
+              };
+            },
+          );
+
+      const [fetchedChallenges, newStats] = await Promise.all([
+        challengesPromise,
+        statsPromise,
       ]);
 
-      const totalCount = newStats['*']?.count ?? 0;
+      const totalCount = newStats?.['*']?.count ?? stats.count;
 
-      if (
-        action === FetchAction.BACK ||
-        paginationParams.before !== undefined
-      ) {
-        newChallenges.reverse();
-        setRemaining(
-          newRemaining !== null
-            ? totalCount - newRemaining + resultsPerPage
-            : totalCount,
-        );
+      const isBack =
+        action === FetchAction.BACK || paginationParams.before !== undefined;
+
+      const overfetched = fetchedChallenges.length > resultsPerPage;
+      let newChallenges;
+
+      if (isBack) {
+        fetchedChallenges.reverse();
+        newChallenges = overfetched
+          ? fetchedChallenges.slice(fetchedChallenges.length - resultsPerPage)
+          : fetchedChallenges;
+        setHasPrevious(overfetched);
+        setHasMore(true);
+      } else if (action === FetchAction.FORWARD) {
+        newChallenges = fetchedChallenges.slice(0, resultsPerPage);
+        setHasMore(overfetched);
+        setHasPrevious(true);
       } else {
-        setRemaining(newRemaining ?? totalCount);
+        // Initial load or filter change.
+        newChallenges = fetchedChallenges.slice(0, resultsPerPage);
+        setHasMore(overfetched);
+        setHasPrevious(
+          ctx.pagination.after !== undefined ||
+            ctx.pagination.before !== undefined,
+        );
       }
 
       setChallenges(newChallenges);
@@ -309,16 +327,16 @@ export default function Search({
         return;
       }
 
-      if (e.key === 'ArrowLeft' && page > 1) {
+      if (e.key === 'ArrowLeft' && hasPrevious) {
         void loadChallenges(FetchAction.BACK);
-      } else if (e.key === 'ArrowRight' && page < totalPages) {
+      } else if (e.key === 'ArrowRight' && hasMore) {
         void loadChallenges(FetchAction.FORWARD);
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [context, challenges, loading, loadError, page, totalPages]);
+  }, [context, challenges, loading, loadError, hasPrevious, hasMore]);
 
   return (
     <>
@@ -343,22 +361,18 @@ export default function Search({
         <div className={styles.pagination}>
           <div className={styles.controls}>
             <button
-              disabled={loading || loadError !== null || page <= 1}
+              disabled={loading || loadError !== null || !hasPrevious}
               onClick={() => void loadChallenges(FetchAction.BACK)}
             >
               <i className="fas fa-chevron-left" />
-              <span className="sr-only">Previous</span>
+              <span>Back</span>
             </button>
-            <p>
-              Page {page}
-              {totalPages > 0 && ` of ${totalPages}`}
-            </p>
             <button
-              disabled={loading || loadError !== null || page >= totalPages}
+              disabled={loading || loadError !== null || !hasMore}
               onClick={() => void loadChallenges(FetchAction.FORWARD)}
             >
+              <span>Next</span>
               <i className="fas fa-chevron-right" />
-              <span className="sr-only">Next</span>
             </button>
           </div>
         </div>

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -299,7 +299,7 @@
   .pagination {
     display: flex;
     justify-content: center;
-    margin: 1em 0;
+    margin: 0.8em 0;
 
     .controls {
       display: flex;
@@ -307,10 +307,12 @@
       flex-direction: row;
       padding: 12px 16px;
       border-radius: 8px;
-      gap: 8px;
+      gap: 16px;
 
       button {
-        width: 36px;
+        width: 70px;
+        display: flex;
+        gap: 8px;
         height: 36px;
         border-radius: 6px;
         background: rgba(var(--blert-purple-base), 0.1);
@@ -330,6 +332,11 @@
         &:not(:disabled):hover {
           background: rgba(var(--blert-purple-base), 0.2);
           transform: translateY(-1px);
+        }
+
+        i {
+          position: relative;
+          top: 2px;
         }
       }
 


### PR DESCRIPTION
Page count queries are slow as they have to enumerate all rows, adding unnecessary latency to search results for questionable user benefit. The main queries already use keyset pagination; this removes the counts and page numbers, keeping just Back/Next buttons.

The total initial count of challenges matching filters is still fetched once when filters are changed.