### PR TITLE
web: Add cache helper

### DIFF
--- a/web/__tests__/api/cache.test.ts
+++ b/web/__tests__/api/cache.test.ts
@@ -1,0 +1,229 @@
+import { RedisClientType } from 'redis';
+
+import redis from '@/actions/redis';
+import { cached, cachedRaw } from '@/api/cache';
+import { recordCacheResult } from '@/utils/metrics';
+
+jest.mock('@/actions/redis');
+jest.mock('@/utils/metrics');
+
+type MockRedisClient = {
+  get: jest.Mock;
+  set: jest.Mock;
+};
+
+const mockedRedis = redis as jest.MockedFunction<typeof redis>;
+const mockedRecordCacheResult = recordCacheResult as jest.MockedFunction<
+  typeof recordCacheResult
+>;
+
+function createMockClient(): MockRedisClient {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+  };
+}
+
+const OPTIONS = { name: 'test' };
+
+describe('cachedRaw', () => {
+  let mockClient: MockRedisClient;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    mockedRedis.mockResolvedValue(mockClient as unknown as RedisClientType);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a JSON string on a cache miss and stores it', async () => {
+    mockClient.get.mockResolvedValue(null);
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue({ count: 42 });
+    const cachedFn = cachedRaw(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toBe(JSON.stringify({ count: 42 }));
+    expect(fn).toHaveBeenCalledWith('abc');
+    expect(mockClient.get).toHaveBeenCalledWith('web:cache:test:abc');
+    expect(mockClient.set).toHaveBeenCalledWith(
+      'web:cache:test:abc',
+      JSON.stringify({ count: 42 }),
+      { EX: 3600 },
+    );
+    expect(mockedRecordCacheResult).toHaveBeenCalledWith('test', 'miss');
+  });
+
+  it('returns the raw cached string on a hit without calling the function', async () => {
+    mockClient.get.mockResolvedValue('{"count":99}');
+
+    const fn = jest.fn().mockResolvedValue({ count: 0 });
+    const cachedFn = cachedRaw(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toBe('{"count":99}');
+    expect(fn).not.toHaveBeenCalled();
+    expect(mockClient.set).not.toHaveBeenCalled();
+    expect(mockedRecordCacheResult).toHaveBeenCalledWith('test', 'hit');
+  });
+
+  it('applies the transform on a cache hit', async () => {
+    mockClient.get.mockResolvedValue('{"count":99}');
+
+    const fn = jest.fn().mockResolvedValue({ count: 0 });
+    const transform = jest.fn(JSON.parse);
+    const cachedFn = cachedRaw(
+      { ...OPTIONS, parse: transform },
+      (x: string) => x,
+      fn,
+    );
+
+    const result = await cachedFn('abc');
+
+    expect(result).toEqual({ count: 99 });
+    expect(transform).toHaveBeenCalledWith('{"count":99}');
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('treats a failed transform as an error and rewrites the cache', async () => {
+    mockClient.get.mockResolvedValue('not-valid-json');
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue({ count: 7 });
+    const cachedFn = cachedRaw(
+      { ...OPTIONS, parse: JSON.parse },
+      (x: string) => x,
+      fn,
+    );
+
+    const result = await cachedFn('abc');
+
+    expect(result).toEqual({ count: 7 });
+    expect(fn).toHaveBeenCalledWith('abc');
+    expect(mockClient.set).toHaveBeenCalledWith(
+      'web:cache:test:abc',
+      JSON.stringify({ count: 7 }),
+      { EX: 3600 },
+    );
+    expect(mockedRecordCacheResult.mock.calls).toEqual([['test', 'error']]);
+  });
+
+  it('uses a custom TTL', async () => {
+    mockClient.get.mockResolvedValue(null);
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue('val');
+    const cachedFn = cachedRaw(
+      { name: 'test', ttlSec: 120 },
+      (x: string) => x,
+      fn,
+    );
+
+    await cachedFn('abc');
+
+    expect(mockClient.set).toHaveBeenCalledWith(
+      'web:cache:test:abc',
+      JSON.stringify('val'),
+      { EX: 120 },
+    );
+  });
+
+  it('falls through to the function when Redis get fails', async () => {
+    mockClient.get.mockRejectedValue(new Error('redis down'));
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue(7);
+    const cachedFn = cachedRaw(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toBe(JSON.stringify(7));
+    expect(fn).toHaveBeenCalledWith('abc');
+    expect(mockedRedis).toHaveBeenCalledTimes(1);
+    expect(mockClient.set).not.toHaveBeenCalled();
+    expect(mockedRecordCacheResult.mock.calls).toEqual([['test', 'error']]);
+  });
+
+  it('still returns the result when Redis set fails', async () => {
+    mockClient.get.mockResolvedValue(null);
+    mockClient.set.mockRejectedValue(new Error('redis down'));
+
+    const fn = jest.fn().mockResolvedValue(7);
+    const cachedFn = cachedRaw(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toBe(JSON.stringify(7));
+    expect(mockedRecordCacheResult).toHaveBeenCalledWith('test', 'miss');
+  });
+
+  it('passes all arguments to both the key function and the underlying function', async () => {
+    mockClient.get.mockResolvedValue(null);
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue('ok');
+    const keyFn = jest.fn().mockReturnValue('multi-arg-key');
+    const cachedFn = cachedRaw(OPTIONS, keyFn, fn);
+
+    await cachedFn('a', 2, true);
+
+    expect(keyFn).toHaveBeenCalledWith('a', 2, true);
+    expect(fn).toHaveBeenCalledWith('a', 2, true);
+  });
+});
+
+describe('cached', () => {
+  let mockClient: MockRedisClient;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    mockedRedis.mockResolvedValue(mockClient as unknown as RedisClientType);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deserializes the cached JSON on a hit', async () => {
+    mockClient.get.mockResolvedValue(JSON.stringify({ count: 99 }));
+
+    const fn = jest.fn().mockResolvedValue({ count: 0 });
+    const cachedFn = cached(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toEqual({ count: 99 });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('falls through on corrupt cached data', async () => {
+    mockClient.get.mockResolvedValue('not-valid-json');
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue({ count: 7 });
+    const cachedFn = cached(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toEqual({ count: 7 });
+    expect(fn).toHaveBeenCalledWith('abc');
+  });
+
+  it('returns the parsed value on a cache miss', async () => {
+    mockClient.get.mockResolvedValue(null);
+    mockClient.set.mockResolvedValue('OK');
+
+    const fn = jest.fn().mockResolvedValue(42);
+    const cachedFn = cached(OPTIONS, (x: string) => x, fn);
+
+    const result = await cachedFn('abc');
+
+    expect(result).toBe(42);
+    expect(fn).toHaveBeenCalledWith('abc');
+  });
+});

--- a/web/__tests__/api/v1/challenges/stats/players/route.test.ts
+++ b/web/__tests__/api/v1/challenges/stats/players/route.test.ts
@@ -1,0 +1,141 @@
+import { ChallengeMode, ChallengeType } from '@blert/common';
+import { NextRequest } from 'next/server';
+import { RedisClientType } from 'redis';
+
+jest.mock('@/actions/challenge', () => ({
+  countUniquePlayers: jest.fn(),
+}));
+jest.mock('@/actions/redis');
+jest.mock('@/utils/metrics', () => ({
+  observeHttpRequest: jest.fn(),
+  recordCacheResult: jest.fn(),
+}));
+
+import { countUniquePlayers } from '@/actions/challenge';
+import redis from '@/actions/redis';
+import { GET } from '@/api/v1/challenges/stats/players/route';
+
+type MockRedisClient = {
+  get: jest.Mock;
+  set: jest.Mock;
+};
+
+const mockedCountUniquePlayers = countUniquePlayers as jest.MockedFunction<
+  typeof countUniquePlayers
+>;
+const mockedRedis = redis as jest.MockedFunction<typeof redis>;
+
+function createMockClient(): MockRedisClient {
+  return {
+    get: jest.fn(),
+    set: jest.fn(),
+  };
+}
+
+function createRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/v1/challenges/stats/players');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+describe('GET /api/v1/challenges/stats/players', () => {
+  let mockClient: MockRedisClient;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    mockClient.get.mockResolvedValue(null);
+    mockClient.set.mockResolvedValue('OK');
+    mockedRedis.mockResolvedValue(mockClient as unknown as RedisClientType);
+    mockedCountUniquePlayers.mockResolvedValue(42);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('caches requests with normalized type, mode, and scale filters', async () => {
+    const request = createRequest({
+      scale: '5,3,5',
+      type: `${ChallengeType.COLOSSEUM},${ChallengeType.TOB}`,
+      mode: `${ChallengeMode.TOB_HARD},${ChallengeMode.TOB_REGULAR}`,
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ count: 42 });
+
+    const expectedParams = new URLSearchParams({
+      mode: [ChallengeMode.TOB_REGULAR, ChallengeMode.TOB_HARD]
+        .sort((lhs, rhs) => lhs - rhs)
+        .join(','),
+      scale: '3,5',
+      type: [ChallengeType.TOB, ChallengeType.COLOSSEUM]
+        .sort((lhs, rhs) => lhs - rhs)
+        .join(','),
+    });
+    expectedParams.sort();
+    const expectedKey = `web:cache:challenges:stats:players:${expectedParams.toString()}`;
+
+    expect(mockClient.get).toHaveBeenCalledWith(expectedKey);
+    expect(mockClient.set).toHaveBeenCalledWith(
+      expectedKey,
+      JSON.stringify({ count: 42 }),
+      { EX: 3600 },
+    );
+  });
+
+  it('caches supported comparator filters with canonical keys', async () => {
+    const request = createRequest({
+      type: String(ChallengeType.TOB),
+      scale: 'ge4',
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ count: 42 });
+
+    const expectedParams = new URLSearchParams({
+      scale: '>=4',
+      type: `==${ChallengeType.TOB}`,
+    });
+    expectedParams.sort();
+    const expectedKey = `web:cache:challenges:stats:players:${expectedParams.toString()}`;
+
+    expect(mockClient.get).toHaveBeenCalledWith(expectedKey);
+    expect(mockClient.set).toHaveBeenCalledWith(
+      expectedKey,
+      JSON.stringify({ count: 42 }),
+      { EX: 3600 },
+    );
+  });
+
+  it('bypasses Redis when unsupported filters are present', async () => {
+    const request = createRequest({
+      type: String(ChallengeType.TOB),
+      status: '1',
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ count: 42 });
+    expect(mockedRedis).not.toHaveBeenCalled();
+  });
+
+  it('bypasses Redis for unsupported namespaced filters', async () => {
+    const request = createRequest({
+      type: String(ChallengeType.TOB),
+      'split:28': 'le600',
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ count: 42 });
+    expect(mockedRedis).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -409,7 +409,7 @@ export type SortableFields =
   | SplitSortableFields
   | MokhaiotlSortableFields;
 
-type SingleOrArray<T> = T | T[];
+export type SingleOrArray<T> = T | T[];
 
 export type TobQuery = {
   bloatDowns?: Map<number, Comparator<number>>;

--- a/web/app/api/cache.ts
+++ b/web/app/api/cache.ts
@@ -1,0 +1,117 @@
+import redis from '@/actions/redis';
+import logger from '@/utils/log';
+import { recordCacheResult } from '@/utils/metrics';
+
+const KEY_PREFIX = 'web:cache:';
+const DEFAULT_TTL_SEC = 3600;
+
+type CachedRawOptions<T> = {
+  /**
+   * Static name for this cached function. Used as a metric label and as the
+   * cache key prefix.
+   */
+  name: string;
+  /** TTL in seconds for cached values. Defaults to 3600. */
+  ttlSec?: number;
+  /**
+   * Transforms the raw cached JSON string before returning. If the transform
+   * throws, the cache entry is treated as a miss.
+   */
+  parse?: (raw: string) => T;
+};
+
+type CachedOptions = Omit<CachedRawOptions<unknown>, 'parse'>;
+
+/**
+ * Wraps an async function with a cache layer that returns raw JSON strings.
+ *
+ * The `keyFn` callback returns a dynamic suffix that is appended to the
+ * static `name` to form the full cache key. Results are stored as JSON
+ * strings with a configurable TTL. If a `parse` function is provided it is
+ * applied to cache hits; if it throws, the entry is treated as a miss.
+ *
+ * On cache errors the underlying function is called directly so the request
+ * is never blocked by a cache failure.
+ */
+export function cachedRaw<Args extends unknown[], T, R>(
+  options: Required<Pick<CachedRawOptions<R>, 'parse'>> &
+    Omit<CachedRawOptions<R>, 'parse'>,
+  keyFn: (...args: Args) => string,
+  fn: (...args: Args) => Promise<T>,
+): (...args: Args) => Promise<R>;
+
+export function cachedRaw<Args extends unknown[], T>(
+  options: CachedOptions,
+  keyFn: (...args: Args) => string,
+  fn: (...args: Args) => Promise<T>,
+): (...args: Args) => Promise<string>;
+
+export function cachedRaw<Args extends unknown[], T, R>(
+  options: CachedRawOptions<R>,
+  keyFn: (...args: Args) => string,
+  fn: (...args: Args) => Promise<T>,
+): (...args: Args) => Promise<R | string> {
+  const { name, ttlSec = DEFAULT_TTL_SEC, parse } = options;
+  const keyPrefix = KEY_PREFIX + name + ':';
+
+  return async (...args: Args): Promise<R | string> => {
+    const key = keyPrefix + keyFn(...args);
+    let client: Awaited<ReturnType<typeof redis>> | null = null;
+    let cacheResult: 'miss' | 'error' = 'miss';
+    let shouldWrite = true;
+
+    try {
+      client = await redis();
+      const hit = await client.get(key);
+      if (hit !== null) {
+        try {
+          const value = parse !== undefined ? parse(hit) : hit;
+          recordCacheResult(name, 'hit');
+          return value;
+        } catch (error) {
+          cacheResult = 'error';
+          logger.error('cache_parse_error', {
+            key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    } catch (error) {
+      cacheResult = 'error';
+      shouldWrite = false;
+      logger.error('cache_read_error', {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    recordCacheResult(name, cacheResult);
+    const result = await fn(...args);
+    const json = JSON.stringify(result);
+
+    if (shouldWrite) {
+      try {
+        const writeClient = client ?? (await redis());
+        await writeClient.set(key, json, { EX: ttlSec });
+      } catch (error) {
+        logger.error('cache_write_error', {
+          key,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    return parse !== undefined ? parse(json) : json;
+  };
+}
+
+/**
+ * Like {@link cachedRaw}, but deserializes the cached JSON before returning.
+ */
+export function cached<Args extends unknown[], T>(
+  options: CachedOptions,
+  keyFn: (...args: Args) => string,
+  fn: (...args: Args) => Promise<T>,
+): (...args: Args) => Promise<T> {
+  return cachedRaw({ ...options, parse: JSON.parse }, keyFn, fn);
+}

--- a/web/app/api/v1/challenges/stats/players/route.ts
+++ b/web/app/api/v1/challenges/stats/players/route.ts
@@ -1,9 +1,139 @@
+import { ChallengeMode, ChallengeType } from '@blert/common';
 import { NextRequest } from 'next/server';
 
-import { ChallengeQuery, countUniquePlayers } from '@/actions/challenge';
+import {
+  ChallengeQuery,
+  countUniquePlayers,
+  SingleOrArray,
+} from '@/actions/challenge';
+import { Comparator } from '@/actions/query';
+import { cachedRaw } from '@/api/cache';
 import { withApiRoute } from '@/api/handler';
 
 import { parseChallengeQueryParams } from '../../query';
+
+const cachedCountUniquePlayers = cachedRaw(
+  { name: 'challenges:stats:players' },
+  (_: ChallengeQuery, params: string) => params,
+  async (query: ChallengeQuery, _params: string) => ({
+    count: await countUniquePlayers(query),
+  }),
+);
+
+const CACHEABLE_PARAMS = new Set<keyof ChallengeQuery>([
+  'type',
+  'mode',
+  'scale',
+]);
+const CACHEABLE_TYPES = numericEnumValues(ChallengeType);
+const CACHEABLE_MODES = numericEnumValues(ChallengeMode);
+const CACHEABLE_SCALES = new Set([1, 2, 3, 4, 5]);
+
+function numericEnumValues(enumObject: object): Set<number> {
+  return new Set(
+    Object.values(enumObject).filter(
+      (value): value is number => typeof value === 'number',
+    ),
+  );
+}
+
+function normalizeNumericList(
+  value: SingleOrArray<number>,
+  allowedValues: ReadonlySet<number>,
+): string | null {
+  const values = Array.isArray(value) ? value : [value];
+  if (values.length === 0) {
+    return null;
+  }
+
+  const numbers = new Set<number>();
+  for (const v of values) {
+    if (!allowedValues.has(v)) {
+      return null;
+    }
+    numbers.add(v);
+  }
+
+  return Array.from(numbers).sort().join(',');
+}
+
+function normalizeComparatorParam(
+  value: Comparator<number>,
+  allowedValues: ReadonlySet<number>,
+): string | null {
+  if (value[0] === 'in') {
+    return normalizeNumericList(value[1], allowedValues);
+  }
+
+  if (value[0] === 'range') {
+    const [start, end] = value[1];
+    if (allowedValues.has(start) && allowedValues.has(end)) {
+      return `${start}..${end}`;
+    }
+    return null;
+  }
+
+  const [op, val] = value;
+  if (allowedValues.has(val)) {
+    return `${op}${val}`;
+  }
+  return null;
+}
+
+function cacheKey(
+  params: URLSearchParams,
+  query: ChallengeQuery,
+): string | null {
+  // Only cache a small set of filters which return broad, stable counts.
+  if (
+    !params
+      .keys()
+      .every((key) => CACHEABLE_PARAMS.has(key as keyof ChallengeQuery))
+  ) {
+    return null;
+  }
+
+  const key = new URLSearchParams();
+  for (const param of CACHEABLE_PARAMS) {
+    let normalized: string | null;
+    const value = query[param];
+    if (value === undefined) {
+      continue;
+    }
+
+    switch (param) {
+      case 'type':
+        normalized = normalizeComparatorParam(
+          value as Required<ChallengeQuery>['type'],
+          CACHEABLE_TYPES,
+        );
+        break;
+      case 'mode':
+        normalized = normalizeNumericList(
+          value as Required<ChallengeQuery>['mode'],
+          CACHEABLE_MODES,
+        );
+        break;
+      case 'scale':
+        normalized = normalizeComparatorParam(
+          value as Required<ChallengeQuery>['scale'],
+          CACHEABLE_SCALES,
+        );
+        break;
+      default:
+        continue;
+    }
+
+    if (normalized === null) {
+      return null;
+    }
+
+    key.set(param, normalized);
+  }
+
+  key.sort();
+  return key.toString();
+}
 
 export const GET = withApiRoute(
   { route: '/api/v1/challenges/stats/players' },
@@ -22,7 +152,18 @@ export const GET = withApiRoute(
       return new Response(null, { status: 400 });
     }
 
-    const count = await countUniquePlayers(query);
-    return Response.json({ count });
+    const key = cacheKey(searchParams, query);
+    if (key === null) {
+      const count = await countUniquePlayers(query);
+      return Response.json({ count }, { status: 200 });
+    }
+
+    const body = await cachedCountUniquePlayers(query, key);
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
+    });
   },
 );

--- a/web/app/utils/metrics.ts
+++ b/web/app/utils/metrics.ts
@@ -140,6 +140,19 @@ export function recordRedisEvent(type: 'connect' | 'error'): void {
   redisEventsCounter.inc({ type });
 }
 
+const cacheCounter = getOrCreateCounter({
+  name: 'web_cache_requests_total',
+  help: 'Cache lookup results',
+  labelNames: ['key', 'result'] as const,
+});
+
+export function recordCacheResult(
+  key: string,
+  result: 'hit' | 'miss' | 'error',
+): void {
+  cacheCounter.inc({ key: sanitizeLabel(key), result });
+}
+
 const emailSendCounter = getOrCreateCounter({
   name: 'web_email_send_total',
   help: 'Email send attempts',


### PR DESCRIPTION
Creates a helper function that can be used to cache an object with a TTL and updates the player count route to use it.