### PR TITLE
web: Unify search UI

### DIFF
--- a/web/app/components/comparable-input/style.module.scss
+++ b/web/app/components/comparable-input/style.module.scss
@@ -1,6 +1,16 @@
 .comparableInput {
   position: relative;
 
+  input[type='number']::-webkit-inner-spin-button,
+  input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  input[type='number'] {
+    -moz-appearance: textfield;
+  }
+
   .comparator {
     position: absolute;
     left: 1px;

--- a/web/app/components/input/input.tsx
+++ b/web/app/components/input/input.tsx
@@ -16,6 +16,8 @@ export type InputProps = {
   invalid?: boolean;
   label: string;
   labelBg?: string;
+  min?: number;
+  max?: number;
   maxLength?: number;
   minLength?: number;
   pattern?: string;
@@ -68,6 +70,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           maxLength={props.maxLength}
           minLength={props.minLength}
           name={props.id}
+          min={props.min}
+          max={props.max}
           onBlur={props.onBlur}
           onChange={props.onChange}
           onFocus={props.onFocus}

--- a/web/app/components/menu/menu.tsx
+++ b/web/app/components/menu/menu.tsx
@@ -52,6 +52,13 @@ export const MENU_DIVIDER: MenuItem = { label: '' };
 
 type MenuProps = {
   attach?: 'top' | 'bottom';
+  /**
+   * Default direction in which submenus should cascade, as a hint to the menu
+   * renderer. Individual levels still flip to the opposite side if they would
+   * overflow.
+   * @default 'right'
+   */
+  cascadeDirection?: 'left' | 'right';
   itemClass?: string;
   items: MenuItem[];
   menuClass?: string;
@@ -99,12 +106,19 @@ function MenuImpl(props: MenuImplProps) {
     let adjustY = 0;
     let shouldFlipLeft = props.parentFlippedLeft ?? false;
 
-    if (!shouldFlipLeft && rect.right > vw - VIEWPORT_PADDING) {
-      // Flip to left side of parent.
+    // Treat overflow symmetrically: if the preferred direction would overflow
+    // and the opposite fits, flip. If both fit, or both overflow, keep the
+    // preferred direction.
+    const wouldOverflowLeft = parentRect.left - rect.width < VIEWPORT_PADDING;
+    const wouldOverflowRight = rect.right > vw - VIEWPORT_PADDING;
+
+    if (shouldFlipLeft && wouldOverflowLeft && !wouldOverflowRight) {
+      shouldFlipLeft = false;
+    } else if (!shouldFlipLeft && wouldOverflowRight && !wouldOverflowLeft) {
       shouldFlipLeft = true;
-      adjustX = -(parentRect.width + rect.width);
-    } else if (shouldFlipLeft) {
-      // Parent was flipped, so we should also render to the left.
+    }
+
+    if (shouldFlipLeft) {
       adjustX = -(parentRect.width + rect.width);
     }
 
@@ -130,13 +144,10 @@ function MenuImpl(props: MenuImplProps) {
 
   if (props.parent) {
     const rect = props.parent.getBoundingClientRect();
-    style.top = rect.top - 1;
-    style.left = rect.right;
+    style.top = rect.top - 1 + (positionAdjustment?.y ?? 0);
+    style.left = rect.right + (positionAdjustment?.x ?? 0);
     style.borderRadius = '5px';
-
-    if (positionAdjustment) {
-      style.transform = `translate(${positionAdjustment.x}px, ${positionAdjustment.y}px)`;
-    }
+    style.zIndex = 1000 + props.depth;
   } else {
     if (props.attach === 'top') {
       style.borderRadius = '5px 5px 0 0';
@@ -161,7 +172,12 @@ function MenuImpl(props: MenuImplProps) {
   }
 
   return (
-    <div className={className} ref={menuRef} style={style}>
+    <div
+      className={className}
+      ref={menuRef}
+      style={style}
+      data-menu-depth={props.depth}
+    >
       {props.items.map((item, i) => {
         let ElementType: keyof JSX.IntrinsicElements;
         let onMouseDown;
@@ -262,7 +278,10 @@ function MenuImpl(props: MenuImplProps) {
                 depth={props.depth + 1}
                 items={item.subMenu}
                 parent={menuRef.current?.children[i] as HTMLElement}
-                parentFlippedLeft={flippedLeft}
+                parentFlippedLeft={
+                  flippedLeft ||
+                  (props.depth === 0 && props.cascadeDirection === 'left')
+                }
               />
             )}
           </ElementType>
@@ -469,6 +488,22 @@ export default function Menu(props: MenuProps) {
   }, [activeElements, items, open, onBrowse, onSelection, onClose]);
 
   useEffect(() => {
+    const root = document.getElementById('portal-root');
+    const menuPortal = document.createElement('div');
+    menuPortal.classList.add('menu-portal');
+    root?.appendChild(menuPortal);
+    portalNode.current = menuPortal as HTMLElement;
+    setReady(true);
+
+    return () => {
+      if (portalNode.current !== null) {
+        root?.removeChild(portalNode.current);
+        portalNode.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
     if (!open) {
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
@@ -478,24 +513,11 @@ export default function Menu(props: MenuProps) {
     }
 
     setAllowClose(false);
-    setWrapperAdjustment(null);
     closeTimeoutRef.current = setTimeout(() => {
       setAllowClose(true);
     }, 100);
 
-    const root = document.getElementById('portal-root');
-
-    const menuPortal = document.createElement('div');
-    menuPortal.classList.add('menu-portal');
-    root?.appendChild(menuPortal);
-    portalNode.current = menuPortal as HTMLElement;
-
-    setReady(true);
-
     return () => {
-      if (portalNode.current !== null) {
-        document.getElementById('portal-root')?.removeChild(portalNode.current);
-      }
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
       }
@@ -527,7 +549,7 @@ export default function Menu(props: MenuProps) {
 
   // Adjust root menu position if it overflows the viewport.
   useLayoutEffect(() => {
-    if (!wrapperRef.current || !ready || !props.position) {
+    if (!wrapperRef.current || !ready || !props.open) {
       return;
     }
 
@@ -536,27 +558,54 @@ export default function Menu(props: MenuProps) {
       return;
     }
 
-    const rect = menuElement.getBoundingClientRect();
+    const menuRect = menuElement.getBoundingClientRect();
     const vw = window.innerWidth;
     const vh = window.innerHeight;
+
+    let rawLeft: number;
+    let rawTop: number;
+
+    if (props.position) {
+      rawLeft = props.position.x;
+      rawTop = props.position.y;
+    } else if (props.targetId) {
+      const target = document.getElementById(props.targetId);
+      if (target === null) {
+        return;
+      }
+      const targetRect = target.getBoundingClientRect();
+      rawLeft = targetRect.left;
+      if (props.attach === 'top') {
+        rawTop = targetRect.top;
+      } else if (props.attach === 'bottom') {
+        rawTop = targetRect.top + targetRect.height;
+      } else {
+        rawTop = targetRect.top + targetRect.height + 5;
+      }
+    } else {
+      return;
+    }
 
     let adjustX = 0;
     let adjustY = 0;
 
-    if (rect.right > vw - VIEWPORT_PADDING) {
-      adjustX = vw - VIEWPORT_PADDING - rect.right;
+    const rawRight = rawLeft + menuRect.width;
+    const rawBottom = rawTop + menuRect.height;
+
+    if (rawRight > vw - VIEWPORT_PADDING) {
+      adjustX = vw - VIEWPORT_PADDING - rawRight;
     }
 
-    if (rect.left + adjustX < VIEWPORT_PADDING) {
-      adjustX = VIEWPORT_PADDING - rect.left;
+    if (rawLeft + adjustX < VIEWPORT_PADDING) {
+      adjustX = VIEWPORT_PADDING - rawLeft;
     }
 
-    if (rect.bottom > vh - VIEWPORT_PADDING) {
-      adjustY = vh - VIEWPORT_PADDING - rect.bottom;
+    if (rawBottom > vh - VIEWPORT_PADDING) {
+      adjustY = vh - VIEWPORT_PADDING - rawBottom;
     }
 
-    if (rect.top + adjustY < VIEWPORT_PADDING) {
-      adjustY = VIEWPORT_PADDING - rect.top;
+    if (rawTop + adjustY < VIEWPORT_PADDING) {
+      adjustY = VIEWPORT_PADDING - rawTop;
     }
 
     if (adjustX !== 0 || adjustY !== 0) {
@@ -568,7 +617,14 @@ export default function Menu(props: MenuProps) {
     } else {
       setWrapperAdjustment(null);
     }
-  }, [ready, menuTarget, props.position]);
+  }, [
+    ready,
+    menuTarget,
+    props.open,
+    props.position,
+    props.attach,
+    props.targetId,
+  ]);
 
   if (
     portalNode.current === null ||

--- a/web/app/components/menu/style.module.scss
+++ b/web/app/components/menu/style.module.scss
@@ -11,13 +11,27 @@
   }
 
   background-color: var(--blert-surface-dark);
-  border: 1px solid rgba(var(--blert-purple-base), 0.2);
+  border: 1px solid rgba(var(--blert-purple-base), 0.45);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.4),
-    0 2px 8px rgba(0, 0, 0, 0.2);
+    0 8px 32px rgba(0, 0, 0, 0.55),
+    0 2px 8px rgba(0, 0, 0, 0.35);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+
+  // Progressive background lift per submenu depth so cascades stay
+  // distinguishable even when they stack on top of each other.
+  &[data-menu-depth='1'] {
+    background-color: rgb(27, 28, 37);
+  }
+  &[data-menu-depth='2'] {
+    background-color: rgb(31, 32, 42);
+  }
+  &[data-menu-depth='3'],
+  &[data-menu-depth='4'],
+  &[data-menu-depth='5'] {
+    background-color: rgb(34, 36, 47);
+  }
 
   .entry {
     padding: 4px 8px;

--- a/web/app/components/tick-input/tick-input.tsx
+++ b/web/app/components/tick-input/tick-input.tsx
@@ -10,7 +10,7 @@ import styles from './style.module.scss';
 
 type TickInputProps = Omit<
   InputProps,
-  'horizontalPadding' | 'onChange' | 'placeholder' | 'type' | 'value'
+  'horizontalPadding' | 'onBlur' | 'onChange' | 'placeholder' | 'type' | 'value'
 > & {
   comparator?: boolean;
   initialTicks?: number;
@@ -18,12 +18,17 @@ type TickInputProps = Omit<
   ticks?: number | null;
   initialComparator?: Comparator;
   onChange?: (ticks: number | null, comparator?: Comparator) => void;
+  /** Fires after the input loses focus, with its normalized tick value. */
+  onBlur?: (ticks: number | null, comparator?: Comparator) => void;
   /** Large tick adjustment step for +/- buttons. Defaults to 5. */
   adjustStep?: number;
   /** Lock input to 'time' or 'ticks' mode. Omit to allow toggling. */
   inputMode?: 'time' | 'ticks';
-  /** Called when the user presses Enter to confirm the current value. */
-  onConfirm?: (ticks: number | null) => void;
+  /**
+   * Called when the user confirms an edit, either by pressing Enter or
+   * clicking an adjustment button.
+   */
+  onConfirm?: (ticks: number | null, comparator?: Comparator) => void;
   /** Round time-mode input up to a tick multiple; tick-mode values are untouched. */
   round?: number;
 };
@@ -154,7 +159,9 @@ export default function TickInput(props: TickInputProps) {
       : ticksToFormattedSeconds(adjusted);
     setValue(newValue);
     setInvalid(false);
-    props.onChange?.(adjusted, props.comparator ? comparator : undefined);
+    const reportedComparator = props.comparator ? comparator : undefined;
+    props.onChange?.(adjusted, reportedComparator);
+    props.onConfirm?.(adjusted, reportedComparator);
   }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -172,7 +179,7 @@ export default function TickInput(props: TickInputProps) {
       if (ticks !== null && props.round && !displayTicks) {
         ticks = Math.ceil(ticks / props.round) * props.round;
       }
-      props.onConfirm(ticks);
+      props.onConfirm(ticks, props.comparator ? comparator : undefined);
     }
     props.onKeyDown?.(e);
   };
@@ -186,13 +193,20 @@ export default function TickInput(props: TickInputProps) {
   };
 
   const onBlur = () => {
+    const reportedComparator = props.comparator ? comparator : undefined;
+
     if (value === '') {
       setInvalid(false);
+      props.onBlur?.(null, reportedComparator);
       return;
     }
 
-    if (!displayTicks) {
-      let ticks = ticksFromTime(normalizeTimeString(value));
+    let ticks: number | null;
+    if (displayTicks) {
+      const parsed = Number(value);
+      ticks = Number.isFinite(parsed) ? parsed : null;
+    } else {
+      ticks = ticksFromTime(normalizeTimeString(value));
       if (ticks === null) {
         setInvalid(true);
         return;
@@ -204,9 +218,11 @@ export default function TickInput(props: TickInputProps) {
       const formatted = ticksToFormattedSeconds(ticks);
       if (formatted !== value) {
         setValue(formatted);
-        props.onChange?.(ticks, props.comparator ? comparator : undefined);
+        props.onChange?.(ticks, reportedComparator);
       }
     }
+
+    props.onBlur?.(ticks, reportedComparator);
   };
 
   const inputProps: InputProps = {

--- a/web/app/search/__tests__/filter-controls.test.ts
+++ b/web/app/search/__tests__/filter-controls.test.ts
@@ -1,0 +1,105 @@
+import { ChallengeMode, ChallengeType } from '@blert/common';
+
+import { toggleNoModeType, toggleTobMode } from '../filter-controls';
+
+describe('toggleTobMode', () => {
+  it('adds the target mode and TOB type when neither is present', () => {
+    const result = toggleTobMode([], [], ChallengeMode.TOB_REGULAR);
+    expect(result.type).toEqual([ChallengeType.TOB]);
+    expect(result.mode).toEqual([ChallengeMode.TOB_REGULAR]);
+  });
+
+  it('adds the target mode without duplicating the TOB type', () => {
+    const result = toggleTobMode(
+      [ChallengeType.TOB],
+      [ChallengeMode.TOB_REGULAR],
+      ChallengeMode.TOB_HARD,
+    );
+    expect(result.type).toEqual([ChallengeType.TOB]);
+    expect(result.mode).toEqual([
+      ChallengeMode.TOB_REGULAR,
+      ChallengeMode.TOB_HARD,
+    ]);
+  });
+
+  it('removes the target mode but keeps the TOB type when another TOB mode remains', () => {
+    const result = toggleTobMode(
+      [ChallengeType.TOB],
+      [ChallengeMode.TOB_REGULAR, ChallengeMode.TOB_HARD],
+      ChallengeMode.TOB_HARD,
+    );
+    expect(result.type).toEqual([ChallengeType.TOB]);
+    expect(result.mode).toEqual([ChallengeMode.TOB_REGULAR]);
+  });
+
+  it('removes TOB from type when the last TOB mode is removed', () => {
+    const result = toggleTobMode(
+      [ChallengeType.TOB],
+      [ChallengeMode.TOB_REGULAR],
+      ChallengeMode.TOB_REGULAR,
+    );
+    expect(result.type).toEqual([]);
+    expect(result.mode).toEqual([]);
+  });
+
+  it('preserves unrelated types when toggling a TOB mode', () => {
+    const result = toggleTobMode(
+      [ChallengeType.TOB, ChallengeType.INFERNO],
+      [ChallengeMode.TOB_REGULAR, ChallengeMode.NO_MODE],
+      ChallengeMode.TOB_REGULAR,
+    );
+    expect(result.type).toEqual([ChallengeType.INFERNO]);
+    expect(result.mode).toEqual([ChallengeMode.NO_MODE]);
+  });
+});
+
+describe('toggleNoModeType', () => {
+  it('adds the type and NO_MODE when neither is present', () => {
+    const result = toggleNoModeType([], [], ChallengeType.INFERNO);
+    expect(result.type).toEqual([ChallengeType.INFERNO]);
+    expect(result.mode).toEqual([ChallengeMode.NO_MODE]);
+  });
+
+  it('does not duplicate NO_MODE if another no-mode type already set it', () => {
+    const result = toggleNoModeType(
+      [ChallengeType.INFERNO],
+      [ChallengeMode.NO_MODE],
+      ChallengeType.COLOSSEUM,
+    );
+    expect(result.type).toEqual([
+      ChallengeType.INFERNO,
+      ChallengeType.COLOSSEUM,
+    ]);
+    expect(result.mode).toEqual([ChallengeMode.NO_MODE]);
+  });
+
+  it('removes the type and NO_MODE when it was the only no-mode type', () => {
+    const result = toggleNoModeType(
+      [ChallengeType.INFERNO],
+      [ChallengeMode.NO_MODE],
+      ChallengeType.INFERNO,
+    );
+    expect(result.type).toEqual([]);
+    expect(result.mode).toEqual([]);
+  });
+
+  it('keeps NO_MODE when another no-mode type remains', () => {
+    const result = toggleNoModeType(
+      [ChallengeType.INFERNO, ChallengeType.COLOSSEUM],
+      [ChallengeMode.NO_MODE],
+      ChallengeType.INFERNO,
+    );
+    expect(result.type).toEqual([ChallengeType.COLOSSEUM]);
+    expect(result.mode).toEqual([ChallengeMode.NO_MODE]);
+  });
+
+  it('leaves other modes (e.g. TOB) untouched', () => {
+    const result = toggleNoModeType(
+      [ChallengeType.TOB, ChallengeType.INFERNO],
+      [ChallengeMode.TOB_REGULAR, ChallengeMode.NO_MODE],
+      ChallengeType.INFERNO,
+    );
+    expect(result.type).toEqual([ChallengeType.TOB]);
+    expect(result.mode).toEqual([ChallengeMode.TOB_REGULAR]);
+  });
+});

--- a/web/app/search/__tests__/shared-filters.test.ts
+++ b/web/app/search/__tests__/shared-filters.test.ts
@@ -1,0 +1,207 @@
+import { ChallengeMode, ChallengeType } from '@blert/common';
+
+import { queryString } from '@/utils/url';
+
+import {
+  SharedFilters,
+  applySharedFilterParam,
+  buildEntityHref,
+  countSharedFilters,
+  emptySharedFilters,
+  numericList,
+  sharedFiltersToUrlParams,
+} from '../shared-filters';
+
+function parseParams(filters: SharedFilters): SharedFilters {
+  const next = emptySharedFilters();
+  const params = sharedFiltersToUrlParams(filters);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      continue;
+    }
+    const str = Array.isArray(value) ? value.join(',') : value.toString();
+    if (str === '' || (Array.isArray(value) && value.length === 0)) {
+      continue;
+    }
+    applySharedFilterParam(next, key, str);
+  }
+  return next;
+}
+
+describe('numericList', () => {
+  it('splits comma-separated numeric strings', () => {
+    expect(numericList('1,2,3')).toEqual([1, 2, 3]);
+  });
+
+  it('drops non-numeric tokens', () => {
+    expect(numericList('1,foo,3')).toEqual([1, 3]);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(numericList('')).toEqual([]);
+  });
+});
+
+describe('countSharedFilters', () => {
+  it('returns 0 when nothing is set', () => {
+    expect(countSharedFilters(emptySharedFilters())).toBe(0);
+  });
+
+  it('counts party, type/mode, scale, and date each as one', () => {
+    const filters: SharedFilters = {
+      ...emptySharedFilters(),
+      party: ['WWWWWWWWWWQQ'],
+      type: [ChallengeType.TOB],
+      mode: [ChallengeMode.TOB_REGULAR],
+      scale: [1],
+      startDate: new Date('2026-01-01'),
+    };
+    expect(countSharedFilters(filters)).toBe(4);
+  });
+
+  it('collapses type+mode into a single count', () => {
+    const filters: SharedFilters = {
+      ...emptySharedFilters(),
+      type: [ChallengeType.TOB],
+      mode: [ChallengeMode.TOB_REGULAR],
+    };
+    expect(countSharedFilters(filters)).toBe(1);
+  });
+
+  it('counts a lone endDate as a date filter', () => {
+    const filters: SharedFilters = {
+      ...emptySharedFilters(),
+      endDate: new Date('2026-01-31'),
+    };
+    expect(countSharedFilters(filters)).toBe(1);
+  });
+});
+
+describe('shared filter URL round-trip', () => {
+  it('preserves each shared field through serialize and parse', () => {
+    const filters: SharedFilters = {
+      ...emptySharedFilters(),
+      party: ['WWWWWWWWWWQQ', 'otter pet'],
+      type: [ChallengeType.TOB, ChallengeType.INFERNO],
+      mode: [ChallengeMode.TOB_REGULAR, ChallengeMode.NO_MODE],
+      scale: [1, 4, 5],
+      startDate: new Date('2026-01-01T00:00:00Z'),
+      endDate: new Date('2026-01-31T00:00:00Z'),
+    };
+
+    const roundTripped = parseParams(filters);
+    expect(roundTripped.party).toEqual(['WWWWWWWWWWQQ', 'otter pet']);
+    expect(roundTripped.type).toEqual([
+      ChallengeType.TOB,
+      ChallengeType.INFERNO,
+    ]);
+    expect(roundTripped.mode).toEqual([
+      ChallengeMode.TOB_REGULAR,
+      ChallengeMode.NO_MODE,
+    ]);
+    expect(roundTripped.scale).toEqual([1, 4, 5]);
+    expect(roundTripped.startDate?.getTime()).toBe(
+      filters.startDate!.getTime(),
+    );
+    // `endDate` is bumped by one day on serialize so ranges are inclusive of
+    // the selected end day, then decoded as that same Jan 31 UTC.
+    const expectedEndDate = new Date(filters.endDate!);
+    expectedEndDate.setDate(expectedEndDate.getDate() + 1);
+    expect(roundTripped.endDate?.getTime()).toBe(expectedEndDate.getTime());
+  });
+
+  it('drops empty arrays and null dates from URL params', () => {
+    const params = sharedFiltersToUrlParams(emptySharedFilters());
+    const serialized = queryString(params);
+    expect(serialized).toBe('');
+  });
+
+  it('encodes a start-only date range with a >= prefix', () => {
+    const filters: SharedFilters = {
+      ...emptySharedFilters(),
+      startDate: new Date('2026-01-01T00:00:00Z'),
+    };
+    const params = sharedFiltersToUrlParams(filters);
+    expect(params.startTime).toBe(`>=${filters.startDate!.getTime()}`);
+  });
+
+  it('encodes an end-only date range with a < prefix bumped by one day', () => {
+    const filters: SharedFilters = {
+      ...emptySharedFilters(),
+      endDate: new Date('2026-01-31T00:00:00Z'),
+    };
+    const bumped = new Date(filters.endDate!);
+    bumped.setDate(bumped.getDate() + 1);
+    const params = sharedFiltersToUrlParams(filters);
+    expect(params.startTime).toBe(`<${bumped.getTime()}`);
+  });
+});
+
+describe('applySharedFilterParam', () => {
+  it('reports false for unknown keys', () => {
+    const filters = emptySharedFilters();
+    expect(applySharedFilterParam(filters, 'unknown', 'value')).toBe(false);
+  });
+
+  it('reports true for every known shared key', () => {
+    const filters = emptySharedFilters();
+    expect(applySharedFilterParam(filters, 'party', 'WWWWWWWWWWQQ')).toBe(true);
+    expect(applySharedFilterParam(filters, 'mode', '0')).toBe(true);
+    expect(applySharedFilterParam(filters, 'scale', '1')).toBe(true);
+    expect(applySharedFilterParam(filters, 'type', '0')).toBe(true);
+    expect(
+      applySharedFilterParam(filters, 'startTime', '>=1700000000000'),
+    ).toBe(true);
+  });
+
+  it('trims whitespace around party names', () => {
+    const filters = emptySharedFilters();
+    applySharedFilterParam(filters, 'party', ' WWWWWWWWWWQQ , otter pet ');
+    expect(filters.party).toEqual(['WWWWWWWWWWQQ', 'otter pet']);
+  });
+});
+
+describe('buildEntityHref', () => {
+  it('returns the target path unchanged when no params are given', () => {
+    expect(buildEntityHref('/search/sessions', null)).toBe('/search/sessions');
+  });
+
+  it('preserves every shared filter param', () => {
+    const params = new URLSearchParams();
+    params.set('party', 'WWWWWWWWWWQQ,otter pet');
+    params.set('mode', '0,1');
+    params.set('scale', '1');
+    params.set('type', '0');
+    params.set('startTime', '>=1700000000000');
+    const href = buildEntityHref('/search/sessions', params);
+    const parsed = new URL(href, 'https://blert.io');
+    expect(parsed.pathname).toBe('/search/sessions');
+    expect(parsed.searchParams.get('party')).toBe('WWWWWWWWWWQQ,otter pet');
+    expect(parsed.searchParams.get('mode')).toBe('0,1');
+    expect(parsed.searchParams.get('scale')).toBe('1');
+    expect(parsed.searchParams.get('type')).toBe('0');
+    expect(parsed.searchParams.get('startTime')).toBe('>=1700000000000');
+  });
+
+  it('drops entity-specific params (e.g. splits, status, challengeCount)', () => {
+    const params = new URLSearchParams();
+    params.set('party', 'WWWWWWWWWWQQ');
+    params.set('status', '2');
+    params.set('split:1', 'ge1200');
+    params.set('challengeCount', 'ge5');
+    const href = buildEntityHref('/search/sessions', params);
+    const parsed = new URL(href, 'https://blert.io');
+    expect(parsed.searchParams.get('party')).toBe('WWWWWWWWWWQQ');
+    expect(parsed.searchParams.get('status')).toBeNull();
+    expect(parsed.searchParams.get('split:1')).toBeNull();
+    expect(parsed.searchParams.get('challengeCount')).toBeNull();
+  });
+
+  it('returns the target path with no query string when no shared params are present', () => {
+    const params = new URLSearchParams();
+    params.set('status', '2');
+    params.set('split:1', 'ge1200');
+    const href = buildEntityHref('/search/challenges', params);
+    expect(href).toBe('/search/challenges');
+  });
+});

--- a/web/app/search/challenges/__tests__/context.test.ts
+++ b/web/app/search/challenges/__tests__/context.test.ts
@@ -1,0 +1,197 @@
+import {
+  ChallengeMode,
+  ChallengeStatus,
+  ChallengeType,
+  SplitType,
+  Stage,
+} from '@blert/common';
+
+import { Comparator } from '@/components/tick-input';
+import { NextSearchParams, queryString } from '@/utils/url';
+
+import {
+  SearchFilters,
+  contextFromUrlParams,
+  countActiveFilters,
+  defaultSearchFilters,
+  emptyTobFilters,
+  filtersToUrlParams,
+} from '../context';
+
+function queryToParams(qs: string): NextSearchParams {
+  const params: NextSearchParams = {};
+  const search = new URLSearchParams(qs);
+  for (const key of Array.from(new Set(search.keys()))) {
+    const values = search.getAll(key);
+    params[key] = values.length > 1 ? values : values[0];
+  }
+  return params;
+}
+
+function roundTrip(filters: SearchFilters): SearchFilters {
+  const url = queryString(filtersToUrlParams(filters));
+  const ctx = contextFromUrlParams(queryToParams(url));
+  return ctx.filters;
+}
+
+describe('challenges filter URL round-trip', () => {
+  it('preserves all shared fields', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      party: ['WWWWWWWWWWQQ'],
+      type: [ChallengeType.INFERNO],
+      mode: [ChallengeMode.NO_MODE],
+      scale: [1],
+      startDate: new Date('2026-01-01T00:00:00Z'),
+    };
+    const result = roundTrip(filters);
+    expect(result.party).toEqual(['WWWWWWWWWWQQ']);
+    expect(result.type).toEqual([ChallengeType.INFERNO]);
+    expect(result.mode).toEqual([ChallengeMode.NO_MODE]);
+    expect(result.scale).toEqual([1]);
+    expect(result.startDate?.getTime()).toBe(filters.startDate!.getTime());
+  });
+
+  it('preserves status', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      status: [ChallengeStatus.COMPLETED, ChallengeStatus.WIPED],
+    };
+    const result = roundTrip(filters);
+    expect(result.status).toEqual([
+      ChallengeStatus.COMPLETED,
+      ChallengeStatus.WIPED,
+    ]);
+  });
+
+  it('preserves stage with comparator', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      stage: [Comparator.GREATER_THAN_OR_EQUAL, Stage.TOB_VERZIK],
+    };
+    const result = roundTrip(filters);
+    expect(result.stage).toEqual([
+      Comparator.GREATER_THAN_OR_EQUAL,
+      Stage.TOB_VERZIK,
+    ]);
+  });
+
+  it('preserves splits map entries', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      splits: new Map<number, [Comparator, number]>([
+        [SplitType.TOB_MAIDEN, [Comparator.LESS_THAN_OR_EQUAL, 110]],
+        [SplitType.TOB_BLOAT, [Comparator.EQUAL, 85]],
+      ]),
+    };
+    const result = roundTrip(filters);
+    expect(result.splits.get(SplitType.TOB_MAIDEN)).toEqual([
+      Comparator.LESS_THAN_OR_EQUAL,
+      110,
+    ]);
+    expect(result.splits.get(SplitType.TOB_BLOAT)).toEqual([
+      Comparator.EQUAL,
+      85,
+    ]);
+  });
+
+  it('preserves TOB sub-filters', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      tob: {
+        bloatDowns: new Map<number, [Comparator, number]>([
+          [1, [Comparator.EQUAL, 30]],
+          [2, [Comparator.LESS_THAN_OR_EQUAL, 40]],
+        ]),
+        bloatDownCount: [Comparator.GREATER_THAN_OR_EQUAL, 3],
+        nylocasPreCapStalls: [Comparator.EQUAL, 2],
+        nylocasPostCapStalls: null,
+        verzikRedsCount: [Comparator.LESS_THAN, 5],
+      },
+    };
+    const result = roundTrip(filters);
+    expect(result.tob.bloatDowns.get(1)).toEqual([Comparator.EQUAL, 30]);
+    expect(result.tob.bloatDowns.get(2)).toEqual([
+      Comparator.LESS_THAN_OR_EQUAL,
+      40,
+    ]);
+    expect(result.tob.bloatDownCount).toEqual([
+      Comparator.GREATER_THAN_OR_EQUAL,
+      3,
+    ]);
+    expect(result.tob.nylocasPreCapStalls).toEqual([Comparator.EQUAL, 2]);
+    expect(result.tob.nylocasPostCapStalls).toBeNull();
+    expect(result.tob.verzikRedsCount).toEqual([Comparator.LESS_THAN, 5]);
+  });
+
+  it('preserves options', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      accurateSplits: false,
+      fullRecordings: true,
+    };
+    const result = roundTrip(filters);
+    expect(result.accurateSplits).toBe(false);
+    expect(result.fullRecordings).toBe(true);
+  });
+
+  it('defaults accurateSplits to true when omitted', () => {
+    const result = contextFromUrlParams({});
+    expect(result.filters.accurateSplits).toBe(true);
+    expect(result.filters.fullRecordings).toBe(false);
+  });
+});
+
+describe('countActiveFilters', () => {
+  it('counts accurateSplits=true by default', () => {
+    const filters = defaultSearchFilters();
+    expect(countActiveFilters(filters)).toBe(1);
+  });
+
+  it('drops to 0 when accurateSplits is disabled and nothing else is set', () => {
+    const filters = defaultSearchFilters();
+    filters.accurateSplits = false;
+    expect(countActiveFilters(filters)).toBe(0);
+  });
+
+  it('counts fullRecordings when enabled', () => {
+    const filters = defaultSearchFilters();
+    expect(countActiveFilters(filters)).toBe(1);
+    filters.fullRecordings = true;
+    expect(countActiveFilters(filters)).toBe(2);
+  });
+
+  it('counts status, stage, and date each as one', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      status: [ChallengeStatus.COMPLETED],
+      stage: [Comparator.EQUAL, Stage.TOB_VERZIK],
+      startDate: new Date('2026-01-01T00:00:00Z'),
+    };
+    expect(countActiveFilters(filters)).toBe(4);
+  });
+
+  it('counts each custom split separately', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      splits: new Map<number, [Comparator, number]>([
+        [SplitType.TOB_MAIDEN, [Comparator.EQUAL, 100]],
+        [SplitType.TOB_BLOAT, [Comparator.EQUAL, 80]],
+      ]),
+    };
+    expect(countActiveFilters(filters)).toBe(3);
+  });
+
+  it('counts TOB sub-filters individually', () => {
+    const filters: SearchFilters = {
+      ...defaultSearchFilters(),
+      tob: {
+        ...emptyTobFilters(),
+        bloatDowns: new Map([[1, [Comparator.EQUAL, 30]]]),
+        bloatDownCount: [Comparator.EQUAL, 3],
+        verzikRedsCount: [Comparator.LESS_THAN, 5],
+      },
+    };
+    expect(countActiveFilters(filters)).toBe(4);
+  });
+});

--- a/web/app/search/challenges/context.ts
+++ b/web/app/search/challenges/context.ts
@@ -1,9 +1,4 @@
-import {
-  ChallengeMode,
-  ChallengeStatus,
-  ChallengeType,
-  Stage,
-} from '@blert/common';
+import { ChallengeStatus, Stage } from '@blert/common';
 
 import {
   ExtraChallengeFields,
@@ -12,6 +7,15 @@ import {
 } from '@/actions/challenge';
 import { Comparator } from '@/components/tick-input';
 import { NextSearchParams, UrlParam, UrlParams } from '@/utils/url';
+
+import {
+  SharedFilters,
+  applySharedFilterParam,
+  countSharedFilters,
+  emptySharedFilters,
+  numericList,
+  sharedFiltersToUrlParams,
+} from '../shared-filters';
 
 function serializeComparator(comparator: Comparator): string {
   switch (comparator) {
@@ -110,15 +114,45 @@ export function hasTobFilters(tob: TobFilters): boolean {
   );
 }
 
-export type SearchFilters = {
-  party: string[];
-  mode: ChallengeMode[];
-  scale: number[];
+function countTobFilters(tob: TobFilters): number {
+  let count = tob.bloatDowns.size;
+  if (tob.bloatDownCount !== null) {
+    count++;
+  }
+  if (tob.nylocasPreCapStalls !== null) {
+    count++;
+  }
+  if (tob.nylocasPostCapStalls !== null) {
+    count++;
+  }
+  if (tob.verzikRedsCount !== null) {
+    count++;
+  }
+  return count;
+}
+
+export function countActiveFilters(filters: SearchFilters): number {
+  let count = countSharedFilters(filters);
+  if (filters.status.length > 0) {
+    count++;
+  }
+  if (filters.stage !== null) {
+    count++;
+  }
+  count += filters.splits.size;
+  count += countTobFilters(filters.tob);
+  if (filters.accurateSplits) {
+    count++;
+  }
+  if (filters.fullRecordings) {
+    count++;
+  }
+  return count;
+}
+
+export type SearchFilters = SharedFilters & {
   status: ChallengeStatus[];
-  type: ChallengeType[];
   stage: [Comparator, Stage] | null;
-  startDate: Date | null;
-  endDate: Date | null;
   splits: Map<number, [Comparator, number]>;
   tob: TobFilters;
   accurateSplits: boolean;
@@ -127,19 +161,22 @@ export type SearchFilters = {
 
 export function defaultSearchFilters(): SearchFilters {
   return {
-    party: [],
-    mode: [],
-    scale: [],
+    ...emptySharedFilters(),
     status: [],
-    type: [],
     stage: null,
-    startDate: null,
-    endDate: null,
     splits: new Map(),
     tob: emptyTobFilters(),
     accurateSplits: true,
     fullRecordings: false,
   };
+}
+
+/**
+ * Whether every filter is at its default value. At defaults the only active
+ * contributor to {@link countActiveFilters} is `accurateSplits=true`.
+ */
+export function isDefaultSearchFilters(filters: SearchFilters): boolean {
+  return filters.accurateSplits && countActiveFilters(filters) === 1;
 }
 
 export type SearchContext = {
@@ -168,32 +205,9 @@ export function filtersToUrlParams(filters: SearchFilters): UrlParams {
     options.push('fullRecordings');
   }
 
-  const modes = [...filters.mode];
-  if (filters.type.includes(ChallengeType.COLOSSEUM)) {
-    modes.push(ChallengeMode.NO_MODE);
-  }
-
-  let startTime;
-
-  if (filters.startDate !== null && filters.endDate !== null) {
-    const endDate = new Date(filters.endDate);
-    endDate.setDate(endDate.getDate() + 1);
-    startTime = `${filters.startDate.getTime()}..${endDate.getTime()}`;
-  } else if (filters.startDate !== null) {
-    startTime = `>=${filters.startDate.getTime()}`;
-  } else if (filters.endDate !== null) {
-    const endDate = new Date(filters.endDate);
-    endDate.setDate(endDate.getDate() + 1);
-    startTime = `<${filters.endDate.getTime()}`;
-  }
-
   const params: UrlParams = {
-    party: filters.party,
-    scale: filters.scale,
+    ...sharedFiltersToUrlParams(filters),
     status: filters.status,
-    mode: modes,
-    type: filters.type,
-    startTime,
     options,
   };
 
@@ -228,13 +242,6 @@ export function filtersToUrlParams(filters: SearchFilters): UrlParams {
   return params;
 }
 
-function numericList<T = number>(value: string): T[] {
-  return value
-    .split(',')
-    .map((n) => parseInt(n))
-    .filter((n) => !isNaN(n)) as T[];
-}
-
 export function extraFieldsToUrlParam(
   extraFields: ExtraChallengeFields,
 ): UrlParam {
@@ -263,25 +270,13 @@ export function contextFromUrlParams(params: NextSearchParams): SearchContext {
   for (const [key, v] of Object.entries(params)) {
     const value = v as string;
 
+    if (applySharedFilterParam(context.filters, key, value)) {
+      continue;
+    }
+
     switch (key) {
-      case 'party':
-        context.filters.party = value.split(',');
-        break;
-
-      case 'mode':
-        context.filters.mode = numericList<ChallengeMode>(value);
-        break;
-
-      case 'scale':
-        context.filters.scale = numericList(value);
-        break;
-
       case 'status':
         context.filters.status = numericList<ChallengeStatus>(value);
-        break;
-
-      case 'type':
-        context.filters.type = numericList<ChallengeType>(value);
         break;
 
       case 'stage': {
@@ -291,18 +286,6 @@ export function contextFromUrlParams(params: NextSearchParams): SearchContext {
         }
         break;
       }
-
-      case 'startTime':
-        if (value.startsWith('>=')) {
-          context.filters.startDate = new Date(parseInt(value.slice(2)));
-        } else if (value.startsWith('<')) {
-          context.filters.endDate = new Date(parseInt(value.slice(1)));
-        } else {
-          const [start, end] = value.split('..').map((time) => parseInt(time));
-          context.filters.startDate = new Date(start);
-          context.filters.endDate = new Date(end);
-        }
-        break;
 
       case 'options': {
         const options = value.split(',');

--- a/web/app/search/challenges/filters.tsx
+++ b/web/app/search/challenges/filters.tsx
@@ -1,34 +1,44 @@
 import {
-  ChallengeMode,
   ChallengeStatus,
   ChallengeType,
   SplitType,
   Stage,
 } from '@blert/common';
-import React, { Dispatch, SetStateAction, useContext, useState } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
-import Button from '@/components/button';
 import Checkbox from '@/components/checkbox';
 import ComparableInput, { Comparator } from '@/components/comparable-input';
-import DatePicker from '@/components/date-picker';
 import Menu, { MenuItem } from '@/components/menu';
-import Modal from '@/components/modal';
-import PlayerSearch from '@/components/player-search';
-import TagList from '@/components/tag-list';
 import TickInput from '@/components/tick-input';
-import Tooltip from '@/components/tooltip';
-import { DisplayContext } from '@/display';
+import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
+
+import {
+  DateRangeFilter,
+  FilterField,
+  FilterRow,
+  FilterSection,
+  PartyFilter,
+  ScaleFilter,
+  StatusFilter,
+  TypeFilter,
+} from '../filter-controls';
 
 import {
   SearchContext,
   SearchFilters,
-  emptyTobFilters,
+  defaultSearchFilters,
   hasTobFilters,
 } from './context';
 
 import styles from './style.module.scss';
 
-const DATE_WIDTH = 300;
 const DATE_INPUT_WIDTH = 140;
 
 type FiltersProps = {
@@ -37,38 +47,18 @@ type FiltersProps = {
   loading: boolean;
 };
 
-type ArrayFields<T> = Pick<
-  T,
-  { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T]
->;
+const STATUS_OPTIONS = [
+  { value: ChallengeStatus.IN_PROGRESS, label: 'In Progress' },
+  { value: ChallengeStatus.COMPLETED, label: 'Completion' },
+  { value: ChallengeStatus.WIPED, label: 'Wipe' },
+  { value: ChallengeStatus.RESET, label: 'Reset' },
+];
 
-function isTobMode(mode: ChallengeMode) {
-  return mode >= ChallengeMode.TOB_ENTRY && mode <= ChallengeMode.TOB_HARD;
-}
-
-function toggleTobMode(
-  filters: SearchFilters,
-  mode: ChallengeMode,
-): SearchFilters {
-  const remove = filters.mode.includes(mode);
-  if (remove) {
-    const tobModes = filters.mode.filter(isTobMode).length;
-    return {
-      ...filters,
-      mode: filters.mode.filter((v) => v !== mode),
-      type:
-        tobModes === 1
-          ? filters.type.filter((v) => v !== ChallengeType.TOB)
-          : filters.type,
-    };
-  }
-
+export function resetChallengeFilters(prev: SearchContext): SearchContext {
   return {
-    ...filters,
-    mode: [...filters.mode, mode],
-    type: filters.type.includes(ChallengeType.TOB)
-      ? filters.type
-      : [...filters.type, ChallengeType.TOB],
+    ...prev,
+    filters: defaultSearchFilters(),
+    pagination: {},
   };
 }
 
@@ -144,22 +134,6 @@ export default function Filters({
   setContext,
   loading,
 }: FiltersProps) {
-  const [useDateRange, setUseDateRange] = useState(() => {
-    if (
-      context.filters.startDate !== null &&
-      context.filters.endDate !== null
-    ) {
-      return (
-        context.filters.startDate.getTime() !==
-        context.filters.endDate.getTime()
-      );
-    }
-
-    return (
-      context.filters.startDate !== null || context.filters.endDate !== null
-    );
-  });
-
   const [stageMenuOpen, setStageMenuOpen] = useState(false);
   const [stageOperatorMenuOpen, setStageOperatorMenuOpen] = useState(false);
 
@@ -168,445 +142,151 @@ export default function Filters({
   );
   const selectedStage = context.filters.stage?.[1] ?? null;
 
-  function toggle<
-    K extends keyof ArrayFields<SearchFilters>,
-    V = SearchFilters[K][number],
-  >(key: K, value: V) {
+  function updateFilters(update: Partial<SearchFilters>) {
     setContext((prev) => ({
       ...prev,
-      filters: {
-        ...prev.filters,
-        [key]: (prev.filters[key] as V[]).includes(value)
-          ? prev.filters[key].filter((v) => v !== value)
-          : [...prev.filters[key], value],
-      },
+      filters: { ...prev.filters, ...update },
       pagination: {},
     }));
   }
 
-  function checkbox<
-    K extends keyof ArrayFields<SearchFilters>,
-    V = SearchFilters[K][number],
-  >(key: K, value: V, label: string, disabled: boolean = false) {
-    const checked = (context.filters[key] as V[]).includes(value);
-    const isDisabled = disabled && !checked; // Allow unchecking if disabled.
-
-    return (
-      <Checkbox
-        checked={checked}
-        className={styles.checkbox}
-        disabled={loading || isDisabled}
-        onChange={() => toggle(key, value)}
-        label={label}
-        simple
-      />
-    );
-  }
-
-  function clearLabel(label: string, key: keyof ArrayFields<SearchFilters>) {
-    return (
-      <div className={styles.label}>
-        <label>{label}</label>
-        <button
-          className={styles.action}
-          disabled={loading}
-          onClick={() =>
-            setContext((prev) => {
-              if (prev.filters[key].length === 0) {
-                return prev;
-              }
-              return {
-                ...prev,
-                filters: { ...prev.filters, [key]: [] },
-                pagination: {},
-              };
-            })
-          }
-        >
-          Clear
-        </button>
-      </div>
-    );
-  }
-
-  const hasTeamChallenges =
-    context.filters.type.length === 0 ||
-    context.filters.type.includes(ChallengeType.TOB);
-
   const tobFiltersActive = hasTobFilters(context.filters.tob);
+  const disabledTypes = tobFiltersActive
+    ? [ChallengeType.INFERNO, ChallengeType.COLOSSEUM, ChallengeType.MOKHAIOTL]
+    : undefined;
 
   return (
     <div className={styles.filters}>
-      <div className={styles.filterGroup}>
-        <div className={`${styles.checkGroup} ${styles.item}`}>
-          <div className={styles.label}>
-            <label>Type</label>
-            <button
-              className={styles.action}
+      <FilterRow>
+        <TypeFilter
+          type={context.filters.type}
+          mode={context.filters.mode}
+          onChange={(type, mode) => updateFilters({ type, mode })}
+          disabled={loading}
+          disabledTypes={disabledTypes}
+          disabledTypesMessage="Clear ToB-only filters to select non-ToB challenge types"
+        />
+        <ScaleFilter
+          scale={context.filters.scale}
+          type={context.filters.type}
+          onChange={(scale) => updateFilters({ scale })}
+          disabled={loading}
+        />
+      </FilterRow>
+
+      <FilterRow>
+        <StatusFilter
+          status={context.filters.status}
+          options={STATUS_OPTIONS}
+          onChange={(status) => updateFilters({ status })}
+          disabled={loading}
+        />
+        <FilterField label="Options">
+          <div
+            data-tooltip-id={GLOBAL_TOOLTIP_ID}
+            data-tooltip-content="When sorting by split times, exclude those which are inaccurate."
+          >
+            <Checkbox
+              checked={context.filters.accurateSplits}
               disabled={loading}
-              onClick={() =>
-                setContext((prev) => {
-                  if (
-                    prev.filters.type.length === 0 &&
-                    prev.filters.mode.length === 0
-                  ) {
-                    return prev;
-                  }
-                  return {
-                    ...prev,
-                    filters: { ...prev.filters, type: [], mode: [] },
-                    pagination: {},
-                  };
+              onChange={() =>
+                updateFilters({
+                  accurateSplits: !context.filters.accurateSplits,
                 })
               }
-            >
-              Clear
-            </button>
-          </div>
-          <Checkbox
-            checked={
-              context.filters.type.includes(ChallengeType.TOB) &&
-              context.filters.mode.includes(ChallengeMode.TOB_REGULAR)
-            }
-            className={styles.checkbox}
-            disabled={loading}
-            onChange={() =>
-              setContext((prev) => ({
-                ...prev,
-                filters: toggleTobMode(prev.filters, ChallengeMode.TOB_REGULAR),
-                pagination: {},
-              }))
-            }
-            label="ToB Regular"
-            simple
-          />
-          <Checkbox
-            checked={
-              context.filters.type.includes(ChallengeType.TOB) &&
-              context.filters.mode.includes(ChallengeMode.TOB_HARD)
-            }
-            className={styles.checkbox}
-            disabled={loading}
-            onChange={() =>
-              setContext((prev) => ({
-                ...prev,
-                filters: toggleTobMode(prev.filters, ChallengeMode.TOB_HARD),
-                pagination: {},
-              }))
-            }
-            label="ToB Hard"
-            simple
-          />
-          {checkbox('type', ChallengeType.INFERNO, 'Inferno', tobFiltersActive)}
-          {checkbox(
-            'type',
-            ChallengeType.COLOSSEUM,
-            'Colosseum',
-            tobFiltersActive,
-          )}
-          {checkbox(
-            'type',
-            ChallengeType.MOKHAIOTL,
-            'Mokhaiotl',
-            tobFiltersActive,
-          )}
-        </div>
-        <div className={`${styles.checkGroup} ${styles.item}`}>
-          {clearLabel('Status', 'status')}
-          {checkbox('status', ChallengeStatus.IN_PROGRESS, 'In Progress')}
-          {checkbox('status', ChallengeStatus.COMPLETED, 'Completion')}
-          {checkbox('status', ChallengeStatus.WIPED, 'Wipe')}
-          {checkbox('status', ChallengeStatus.RESET, 'Reset')}
-        </div>
-        <div className={`${styles.checkGroup} ${styles.item}`}>
-          {clearLabel('Scale', 'scale')}
-          {checkbox('scale', 1, 'Solo')}
-          {checkbox('scale', 2, 'Duo', !hasTeamChallenges)}
-          {checkbox('scale', 3, 'Trio', !hasTeamChallenges)}
-          {checkbox('scale', 4, '4s', !hasTeamChallenges)}
-          {checkbox('scale', 5, '5s', !hasTeamChallenges)}
-        </div>
-        <div className={`${styles.checkGroup} ${styles.item}`}>
-          <div className={styles.label}>
-            <label>Stage</label>
-            <button
-              className={styles.action}
-              disabled={loading}
-              onClick={() => {
-                setStageOperator(Comparator.EQUAL);
-                setContext((prev) => ({
-                  ...prev,
-                  filters: { ...prev.filters, stage: null },
-                  pagination: {},
-                }));
-              }}
-            >
-              Clear
-            </button>
-          </div>
-          <div className={styles.stageFilter}>
-            <button
-              id="stage-operator-select"
-              className={styles.action}
-              onClick={() => setStageOperatorMenuOpen(true)}
-            >
-              {STAGE_OPERATORS.find((op) => op.value === stageOperator)
-                ?.label ?? 'Select operator'}
-              <i className="fas fa-chevron-down" style={{ marginLeft: 8 }} />
-            </button>
-            <button
-              id="stage-select"
-              className={styles.action}
-              onClick={() => setStageMenuOpen(true)}
-            >
-              {selectedStage
-                ? STAGE_MENU_ITEMS.flatMap((m) => m.subMenu!).find(
-                    (item) => item.value === selectedStage,
-                  )?.label
-                : 'Select stage'}
-              <i className="fas fa-chevron-down" style={{ marginLeft: 8 }} />
-            </button>
-            <Menu
-              onClose={() => setStageOperatorMenuOpen(false)}
-              onSelection={(value) => {
-                const operator = value as Comparator;
-                setStageOperator(operator);
-                setStageOperatorMenuOpen(false);
-                if (selectedStage !== null) {
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: {
-                      ...prev.filters,
-                      stage: [operator, selectedStage],
-                    },
-                    pagination: {},
-                  }));
-                } else {
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: {
-                      ...prev.filters,
-                      stage: null,
-                    },
-                    pagination: {},
-                  }));
-                }
-              }}
-              open={stageOperatorMenuOpen}
-              items={STAGE_OPERATORS}
-              targetId="stage-operator-select"
-              width={DATE_INPUT_WIDTH}
-            />
-            <Menu
-              onClose={() => setStageMenuOpen(false)}
-              onSelection={(value) => {
-                const stage = parseInt(value as string, 10);
-                setStageMenuOpen(false);
-                setContext((prev) => ({
-                  ...prev,
-                  filters: {
-                    ...prev.filters,
-                    stage: [stageOperator, stage],
-                  },
-                  pagination: {},
-                }));
-              }}
-              open={stageMenuOpen}
-              items={STAGE_MENU_ITEMS}
-              targetId="stage-select"
-              width={DATE_INPUT_WIDTH}
-            />
-          </div>
-        </div>
-        <div className={`${styles.checkGroup} ${styles.item}`}>
-          <div className={styles.label}>
-            <label>Extra options</label>
-          </div>
-          <Tooltip tooltipId="accurate-splits-tooltip">
-            <span>
-              When sorting by split times, exclude those which are inaccurate.
-            </span>
-          </Tooltip>
-          <div className={styles.checkbox}>
-            <div data-tooltip-id="accurate-splits-tooltip">
-              <Checkbox
-                checked={context.filters.accurateSplits}
-                disabled={loading}
-                onChange={() =>
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: {
-                      ...prev.filters,
-                      accurateSplits: !prev.filters.accurateSplits,
-                    },
-                    pagination: {},
-                  }))
-                }
-                label="Accurate splits"
-                simple
-              />
-            </div>
-          </div>
-          <Tooltip tooltipId="full-recordings-tooltip">
-            <span>Exclude challenges that are missing data for any stage.</span>
-          </Tooltip>
-          <div className={styles.checkbox}>
-            <div data-tooltip-id="full-recordings-tooltip">
-              <Checkbox
-                checked={context.filters.fullRecordings}
-                disabled={loading}
-                onChange={() =>
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: {
-                      ...prev.filters,
-                      fullRecordings: !prev.filters.fullRecordings,
-                    },
-                    pagination: {},
-                  }))
-                }
-                label="Full recordings"
-                simple
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-      <div className={styles.filterGroup}>
-        <div className={styles.item}>
-          {clearLabel('Party', 'party')}
-          <PlayerSearch
-            disabled={loading || context.filters.party.length >= 5}
-            label="Enter username"
-            labelBg="var(--blert-surface-dark)"
-            id="filters-player"
-            onSelection={(username) =>
-              setContext((prev) => {
-                if (prev.filters.party.includes(username)) {
-                  return prev;
-                }
-                return {
-                  ...prev,
-                  filters: {
-                    ...prev.filters,
-                    party: [...prev.filters.party, username],
-                  },
-                  pagination: {},
-                };
-              })
-            }
-          />
-          <TagList
-            onRemove={(username) =>
-              setContext((prev) => ({
-                ...prev,
-                filters: {
-                  ...prev.filters,
-                  party: prev.filters.party.filter((u) => u !== username),
-                },
-                pagination: {},
-              }))
-            }
-            tags={context.filters.party}
-            width={300}
-          />
-        </div>
-        <div className={styles.item}>
-          <div className={styles.label}>
-            <label>Date</label>
-          </div>
-          <div className={styles.dateWrapper}>
-            <div className={styles.date} style={{ width: DATE_WIDTH }}>
-              <DatePicker
-                disabled={loading}
-                icon="fas fa-calendar-alt"
-                isClearable
-                maxDate={
-                  useDateRange
-                    ? (context.filters.endDate ?? undefined)
-                    : undefined
-                }
-                placeholderText={useDateRange ? 'Start date' : undefined}
-                popperPlacement="bottom"
-                selected={context.filters.startDate}
-                onChange={(date) => {
-                  const endDate = useDateRange ? context.filters.endDate : date;
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: {
-                      ...prev.filters,
-                      startDate: date,
-                      endDate,
-                    },
-                    pagination: {},
-                  }));
-                }}
-                showIcon
-                width={useDateRange ? DATE_INPUT_WIDTH : DATE_WIDTH}
-              />
-              {useDateRange && (
-                <>
-                  <i className="fas fa-minus" />
-                  <DatePicker
-                    disabled={loading}
-                    icon="fas fa-calendar-alt"
-                    isClearable
-                    minDate={
-                      useDateRange
-                        ? (context.filters.startDate ?? undefined)
-                        : undefined
-                    }
-                    placeholderText="End date"
-                    popperPlacement="bottom"
-                    selected={context.filters.endDate}
-                    onChange={(date) =>
-                      setContext((prev) => ({
-                        ...prev,
-                        filters: { ...prev.filters, endDate: date },
-                        pagination: {},
-                      }))
-                    }
-                    showIcon
-                    width={DATE_INPUT_WIDTH}
-                  />
-                </>
-              )}
-            </div>
-            <Checkbox
-              checked={useDateRange}
-              className={styles.dateRangeCheckbox}
-              disabled={loading}
-              onChange={() => {
-                if (useDateRange) {
-                  if (context.filters.startDate !== null) {
-                    setContext((prev) => ({
-                      ...prev,
-                      filters: {
-                        ...prev.filters,
-                        endDate: prev.filters.startDate,
-                      },
-                      pagination: {},
-                    }));
-                  } else if (context.filters.endDate !== null) {
-                    setContext((prev) => ({
-                      ...prev,
-                      filters: {
-                        ...prev.filters,
-                        startDate: prev.filters.endDate,
-                      },
-                      pagination: {},
-                    }));
-                  }
-                }
-                setUseDateRange((prev) => !prev);
-              }}
-              label="Date range"
+              label="Accurate splits"
               simple
             />
           </div>
+          <div
+            data-tooltip-id={GLOBAL_TOOLTIP_ID}
+            data-tooltip-content="Exclude challenges that are missing data for any stage."
+          >
+            <Checkbox
+              checked={context.filters.fullRecordings}
+              disabled={loading}
+              onChange={() =>
+                updateFilters({
+                  fullRecordings: !context.filters.fullRecordings,
+                })
+              }
+              label="Full recordings"
+              simple
+            />
+          </div>
+        </FilterField>
+      </FilterRow>
+
+      <FilterField label="Stage">
+        <div className={styles.stageFilter}>
+          <button
+            id="stage-operator-select"
+            onClick={() => setStageOperatorMenuOpen(true)}
+            type="button"
+            disabled={loading}
+          >
+            {STAGE_OPERATORS.find((op) => op.value === stageOperator)?.label ??
+              'Select operator'}
+            <i className="fas fa-chevron-down" style={{ marginLeft: 8 }} />
+          </button>
+          <button
+            id="stage-select"
+            onClick={() => setStageMenuOpen(true)}
+            type="button"
+            disabled={loading}
+          >
+            {selectedStage
+              ? STAGE_MENU_ITEMS.flatMap((m) => m.subMenu!).find(
+                  (item) => item.value === selectedStage,
+                )?.label
+              : 'Select stage'}
+            <i className="fas fa-chevron-down" style={{ marginLeft: 8 }} />
+          </button>
+          <Menu
+            onClose={() => setStageOperatorMenuOpen(false)}
+            onSelection={(value) => {
+              const operator = value as Comparator;
+              setStageOperator(operator);
+              setStageOperatorMenuOpen(false);
+              if (selectedStage !== null) {
+                updateFilters({ stage: [operator, selectedStage] });
+              } else {
+                updateFilters({ stage: null });
+              }
+            }}
+            open={stageOperatorMenuOpen}
+            items={STAGE_OPERATORS}
+            targetId="stage-operator-select"
+            width={DATE_INPUT_WIDTH}
+          />
+          <Menu
+            onClose={() => setStageMenuOpen(false)}
+            onSelection={(value) => {
+              const stage = parseInt(value as string, 10);
+              setStageMenuOpen(false);
+              updateFilters({ stage: [stageOperator, stage] });
+            }}
+            open={stageMenuOpen}
+            items={STAGE_MENU_ITEMS}
+            targetId="stage-select"
+            width={DATE_INPUT_WIDTH}
+          />
         </div>
-      </div>
-      <div className={styles.divider} />
+      </FilterField>
+
+      <DateRangeFilter
+        startDate={context.filters.startDate}
+        endDate={context.filters.endDate}
+        onChange={(startDate, endDate) => updateFilters({ startDate, endDate })}
+        disabled={loading}
+      />
+
+      <PartyFilter
+        party={context.filters.party}
+        onChange={(party) => updateFilters({ party })}
+        disabled={loading}
+      />
+
       <CustomFilters
         context={context}
         loading={loading}
@@ -659,11 +339,16 @@ type PathValue<T, P extends string> = P extends `${infer K}.${infer Rest}`
 
 type InputKind = 'time' | 'ticks' | 'number';
 
+type BaseTarget = {
+  inputKind: InputKind;
+  min?: number;
+  max?: number;
+};
+
 type ScalarTarget = {
   [P in ScalarFilterPaths<SearchFilters>]: {
     path: P;
-    inputKind: InputKind;
-  };
+  } & BaseTarget;
 }[ScalarFilterPaths<SearchFilters>];
 
 type KeyedTarget = {
@@ -674,13 +359,17 @@ type KeyedTarget = {
       : PathValue<SearchFilters, P> extends Record<infer K, FilterValue>
         ? K
         : never;
-    inputKind: InputKind;
-  };
+  } & BaseTarget;
 }[KeyedFilterPaths<SearchFilters>];
 
 type FilterTarget = ScalarTarget | KeyedTarget;
 
-type FilterDef = FilterTarget & { label: string; round?: number };
+type FilterDef = FilterTarget & {
+  label: string;
+  round?: number;
+  min?: number;
+  max?: number;
+};
 
 function filterKey(target: FilterTarget): string {
   if ('key' in target) {
@@ -781,6 +470,8 @@ const CUSTOM_FILTERS_ITEMS: MenuItem[] = [
             value: def('Bloat down count', {
               path: 'tob.bloatDownCount',
               inputKind: 'number',
+              min: 0,
+              max: 20,
             }).id,
           },
           { label: '1st down walk', value: bd('1st down walk', 1).id },
@@ -1111,6 +802,52 @@ type SplitValues = {
   comparator: Comparator;
 };
 
+function cloneFiltersForCustomEdit(filters: SearchFilters): SearchFilters {
+  return {
+    ...filters,
+    splits: new Map(filters.splits),
+    tob: {
+      ...filters.tob,
+      bloatDowns: new Map(filters.tob.bloatDowns),
+    },
+  };
+}
+
+function filterValueEqual(
+  a: [Comparator, number] | null,
+  b: [Comparator, number] | null,
+): boolean {
+  if (a === null) {
+    return b === null;
+  }
+  if (b === null) {
+    return false;
+  }
+  return a[0] === b[0] && a[1] === b[1];
+}
+
+/**
+ * Whether two filter sets are equal across every custom-filter path registered
+ * in {@link FILTER_DEFS}.
+ */
+function customFiltersEqual(a: SearchFilters, b: SearchFilters): boolean {
+  for (const filterDef of Object.values(FILTER_DEFS)) {
+    if (
+      !filterValueEqual(
+        getFilterValue(a, filterDef),
+        getFilterValue(b, filterDef),
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function customFilterId(key: string): string {
+  return `filters-custom-${key}`;
+}
+
 function CustomFilters({
   context,
   loading,
@@ -1120,412 +857,229 @@ function CustomFilters({
   loading: boolean;
   setContext: Dispatch<SetStateAction<SearchContext>>;
 }) {
-  const display = useContext(DisplayContext);
-
   const [menuOpen, setMenuOpen] = useState(false);
-  const customInputsFromFilters = React.useCallback(
-    (filters: SearchFilters) => {
-      const inputs: Record<string, SplitValues> = {};
-      for (const [id, filterDef] of Object.entries(FILTER_DEFS)) {
-        const value = getFilterValue(filters, filterDef);
-        if (value !== null) {
-          inputs[id] = { ticks: value[1], comparator: value[0] };
-        }
+  const customInputsFromFilters = useCallback((filters: SearchFilters) => {
+    const inputs: Record<string, SplitValues> = {};
+    for (const [id, filterDef] of Object.entries(FILTER_DEFS)) {
+      const value = getFilterValue(filters, filterDef);
+      if (value !== null) {
+        inputs[id] = { ticks: value[1], comparator: value[0] };
       }
-      return inputs;
-    },
-    [],
-  );
+    }
+    return inputs;
+  }, []);
   const [customInputs, setCustomInputs] = useState<Record<string, SplitValues>>(
     () => customInputsFromFilters(context.filters),
   );
-  const [modified, setModified] = useState(false);
+  const pendingScrollRef = useRef<string | null>(null);
 
-  // Sync from context.filters on external changes (e.g. browser back/forward),
-  // but don't clobber the user's in-progress edits.
-  React.useEffect(() => {
-    if (modified) {
-      return;
-    }
-    setCustomInputs(customInputsFromFilters(context.filters));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [context.filters, customInputsFromFilters]);
-
-  const addInput = (id: string | number) => {
-    const key = String(id);
-    setModified(true);
+  // Re-sync from URL changes (e.g. browser back/forward). Preserve the user's
+  // insertion order — rebuilding from FILTER_DEFS would snap entries to their
+  // registration order and cause them to jump around after a commit.
+  useEffect(() => {
     setCustomInputs((prev) => {
-      if (prev[key] !== undefined) {
-        return prev;
-      }
-      return {
-        ...prev,
-        [key]: { ticks: null, comparator: Comparator.EQUAL },
-      };
-    });
-  };
+      const fromContext = customInputsFromFilters(context.filters);
+      const next: Record<string, SplitValues> = {};
 
-  const applyFilters = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (loading) {
-      return;
-    }
-
-    setModified(false);
-    setContext((prev) => {
-      const next = {
-        ...prev,
-        filters: {
-          ...prev.filters,
-          splits: new Map<number, [Comparator, number]>(),
-          tob: emptyTobFilters(),
-        },
-        pagination: {},
-      };
-
-      for (const [id, { ticks, comparator }] of Object.entries(customInputs)) {
-        if (ticks === null) {
+      for (const [id, input] of Object.entries(prev)) {
+        if (FILTER_DEFS[id] === undefined) {
           continue;
         }
-        const filterDef = FILTER_DEFS[id];
-        if (filterDef !== undefined) {
-          setFilterValue(next.filters, filterDef, [comparator, ticks]);
+        if (id in fromContext) {
+          next[id] = fromContext[id];
+        } else if (input.ticks === null) {
+          next[id] = input;
+        }
+      }
+
+      // Any context entries that weren't already in prev (e.g. loaded from URL
+      // on initial mount) go at the end in FILTER_DEFS order.
+      for (const [id, input] of Object.entries(fromContext)) {
+        if (!(id in next)) {
+          next[id] = input;
         }
       }
 
       return next;
     });
-  };
+  }, [context.filters, customInputsFromFilters]);
 
-  return (
-    <form
-      className={`${styles.filterGroup} ${styles.custom}`}
-      onSubmit={applyFilters}
-    >
-      <div className={styles.customHeading}>
-        <label>Custom filters</label>
-        <div className={styles.actions}>
-          <Button
-            id="filters-add-custom"
-            className={styles.action}
-            onClick={() => {
-              setTimeout(() => setMenuOpen(true), 25);
-            }}
-            simple
-          >
-            <i className="fas fa-plus-circle" />
-            Add filter
-          </Button>
-          <Button
-            className={styles.action}
-            disabled={loading || !modified}
-            simple
-            type="submit"
-          >
-            Apply
-          </Button>
-          {display.isFull() ? (
-            <Menu
-              onClose={() => setMenuOpen(false)}
-              onSelection={addInput}
-              open={menuOpen}
-              items={CUSTOM_FILTERS_ITEMS}
-              targetId="filters-add-custom"
-              width="auto"
-            />
-          ) : (
-            <CustomFiltersModal
-              onClose={() => setMenuOpen(false)}
-              onSelection={addInput}
-              open={menuOpen}
-            />
-          )}
-        </div>
-      </div>
-      <div className={styles.inputs}>
-        {Object.keys(customInputs).map((id) => {
-          const filterDef = FILTER_DEFS[id];
-          if (filterDef === undefined) {
-            return null;
+  // After a filter is added (or re-selected), scroll it into view and focus
+  // its input so the user can start typing immediately.
+  useEffect(() => {
+    const key = pendingScrollRef.current;
+    if (key === null) {
+      return;
+    }
+    pendingScrollRef.current = null;
+    const raf = requestAnimationFrame(() => {
+      const id = customFilterId(key);
+      const field = document.querySelector<HTMLElement>(
+        `[data-field-id="${id}"]`,
+      );
+      field?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      const input = document.getElementById(id);
+      input?.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [customInputs]);
+
+  const commitAll = useCallback(
+    (inputs: Record<string, SplitValues>) => {
+      setContext((prev) => {
+        const filters = cloneFiltersForCustomEdit(prev.filters);
+        for (const [id, filterDef] of Object.entries(FILTER_DEFS)) {
+          const input = inputs[id];
+          // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+          if (input === undefined || input.ticks === null) {
+            setFilterValue(filters, filterDef, null);
+          } else {
+            setFilterValue(filters, filterDef, [input.comparator, input.ticks]);
           }
-
-          const input = customInputs[id];
-          const removeFilter = () => {
-            setModified(true);
-            setCustomInputs((prev) => {
-              const next = { ...prev };
-              delete next[id];
-              return next;
-            });
-          };
-          const onChange = (value: number | null, cmp?: Comparator) => {
-            setModified(true);
-            setCustomInputs((prev) => ({
-              ...prev,
-              [id]: { ticks: value, comparator: cmp ?? Comparator.EQUAL },
-            }));
-          };
-
-          return (
-            <div key={id} className={styles.customInput}>
-              {filterDef.inputKind === 'number' ? (
-                <div className={styles.comparable}>
-                  <ComparableInput
-                    id={`filters-custom-${id}`}
-                    label={filterDef.label}
-                    labelBg="var(--blert-surface-dark)"
-                    type="number"
-                    comparator={input.comparator}
-                    onComparatorChange={(c) => onChange(input.ticks, c)}
-                    value={input.ticks?.toString() ?? ''}
-                    onChange={(e) => {
-                      const v = parseInt(e.target.value);
-                      onChange(isNaN(v) ? null : v, input.comparator);
-                    }}
-                  />
-                </div>
-              ) : (
-                <TickInput
-                  comparator
-                  label={filterDef.label}
-                  id={`filters-custom-${id}`}
-                  initialComparator={input.comparator}
-                  initialTicks={input.ticks ?? undefined}
-                  inputMode={
-                    filterDef.inputKind === 'ticks' ? 'ticks' : undefined
-                  }
-                  labelBg="var(--blert-surface-dark)"
-                  onChange={onChange}
-                  round={filterDef.round}
-                />
-              )}
-              <button
-                className={styles.remove}
-                onClick={removeFilter}
-                type="button"
-              >
-                <i className="fas fa-times" />
-                <label className="sr-only">
-                  Remove filter {filterDef.label}
-                </label>
-              </button>
-            </div>
-          );
-        })}
-      </div>
-    </form>
+        }
+        if (customFiltersEqual(prev.filters, filters)) {
+          return prev;
+        }
+        return { ...prev, filters, pagination: {} };
+      });
+    },
+    [setContext],
   );
-}
 
-function CollapsibleList({
-  items,
-  onSelection,
-  searchTerm = '',
-  level = 0,
-}: {
-  items: MenuItem[];
-  onSelection: (split: number) => void;
-  searchTerm?: string;
-  level?: number;
-}) {
-  const [open, setOpen] = useState<Record<string, boolean>>({});
-
-  const itemMatchesSearch = (item: MenuItem, term: string): boolean => {
-    if (term === '') {
-      return true;
-    }
-
-    if (item.label.toLowerCase().includes(term.toLowerCase())) {
-      return true;
-    }
-
-    if (item.subMenu) {
-      return item.subMenu.some((subItem) => itemMatchesSearch(subItem, term));
-    }
-
-    return false;
+  const stageInputChange = (id: string) => {
+    return (ticks: number | null, cmp?: Comparator) => {
+      const prevComparator = customInputs[id]?.comparator ?? Comparator.EQUAL;
+      const comparator = cmp ?? prevComparator;
+      const next = { ...customInputs, [id]: { ticks, comparator } };
+      setCustomInputs(next);
+      // Only a genuine comparator change is discrete; TickInput re-emits its
+      // current comparator on every keystroke.
+      if (cmp !== undefined && cmp !== prevComparator) {
+        commitAll(next);
+      }
+    };
   };
 
-  const filteredItems = items
-    .map((item) => {
-      if (!itemMatchesSearch(item, searchTerm)) {
-        return null;
-      }
+  const commitInput = (id: string) => {
+    return (ticks: number | null, cmp?: Comparator) => {
+      const comparator =
+        cmp ?? customInputs[id]?.comparator ?? Comparator.EQUAL;
+      const next = { ...customInputs, [id]: { ticks, comparator } };
+      setCustomInputs(next);
+      commitAll(next);
+    };
+  };
 
-      if (!item.subMenu) {
-        return item;
-      }
+  const handleAdd = (id: string | number) => {
+    const key = String(id);
+    pendingScrollRef.current = key;
+    if (customInputs[key] !== undefined) {
+      // Already exists; force an effect run so we still scroll to it.
+      setCustomInputs({ ...customInputs });
+      return;
+    }
+    setCustomInputs({
+      ...customInputs,
+      [key]: { ticks: null, comparator: Comparator.EQUAL },
+    });
+  };
 
-      const itemDirectlyMatches = item.label
-        .toLowerCase()
-        .includes(searchTerm.toLowerCase());
+  const handleRemove = (id: string) => {
+    const next = { ...customInputs };
+    delete next[id];
+    setCustomInputs(next);
+    commitAll(next);
+  };
 
-      if (itemDirectlyMatches) {
-        return item;
-      }
-
-      const filteredSubMenu = item.subMenu
-        .map((subItem) => {
-          if (!itemMatchesSearch(subItem, searchTerm)) {
-            return null;
-          }
-
-          if (!subItem.subMenu) {
-            return subItem;
-          }
-
-          // If subItem directly matches, show all its children.
-          const subItemDirectlyMatches = subItem.label
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase());
-
-          if (subItemDirectlyMatches) {
-            return subItem;
-          }
-
-          const filteredSubSubMenu = subItem.subMenu.filter((subSubItem) =>
-            itemMatchesSearch(subSubItem, searchTerm),
-          );
-
-          return filteredSubSubMenu.length > 0
-            ? { ...subItem, subMenu: filteredSubSubMenu }
-            : null;
-        })
-        .filter(Boolean) as MenuItem[];
-
-      return filteredSubMenu.length > 0
-        ? { ...item, subMenu: filteredSubMenu }
-        : null;
-    })
-    .filter(Boolean) as MenuItem[];
-
-  const shouldExpand = searchTerm.length > 0;
+  const addButton = (
+    <>
+      <button
+        id="filters-add-custom"
+        className={styles.addFilter}
+        onClick={() => setTimeout(() => setMenuOpen(true), 25)}
+        type="button"
+        disabled={loading}
+      >
+        <i className="fas fa-plus" aria-hidden />
+        <span>Add</span>
+      </button>
+      <Menu
+        onClose={() => setMenuOpen(false)}
+        onSelection={handleAdd}
+        open={menuOpen}
+        items={CUSTOM_FILTERS_ITEMS}
+        targetId="filters-add-custom"
+        width="auto"
+        cascadeDirection="left"
+      />
+    </>
+  );
 
   return (
-    <ul
-      className={`${styles.customFiltersList} ${styles[`level${level}`] || ''}`}
-    >
-      {filteredItems.map((item) => {
-        const itemKey = `${level}-${item.label}`;
-        const isExpanded = shouldExpand || open[itemKey] || false;
+    <FilterSection title="Custom filters" action={addButton}>
+      {Object.keys(customInputs).map((id) => {
+        const filterDef = FILTER_DEFS[id];
+        if (filterDef === undefined) {
+          return null;
+        }
 
-        const element = item.subMenu ? (
-          <button
-            className={styles.collapsible}
-            onClick={() =>
-              setOpen((prev) => ({
-                ...prev,
-                [itemKey]: !prev[itemKey],
-              }))
-            }
-          >
-            <i className={`fas fa-folder${isExpanded ? '-open' : ''}`} />
-            {item.label}
-            <i className={`fas fa-chevron-${isExpanded ? 'up' : 'down'}`} />
-          </button>
-        ) : (
-          <button
-            className={styles.filterItem}
-            onClick={() => onSelection(item.value! as number)}
-          >
-            <i className="fas fa-plus" />
-            {item.label}
-          </button>
-        );
+        const input = customInputs[id];
+        const stage = stageInputChange(id);
+        const commit = commitInput(id);
+
+        const fieldId = customFilterId(id);
 
         return (
-          <li key={item.label}>
-            {element}
-            {item.subMenu && isExpanded && (
-              <CollapsibleList
-                items={item.subMenu}
-                onSelection={onSelection}
-                searchTerm={
-                  item.label.toLowerCase().includes(searchTerm.toLowerCase())
-                    ? '' // Don't filter children if parent directly matched.
-                    : searchTerm
+          <FilterField
+            key={id}
+            label={filterDef.label}
+            htmlFor={fieldId}
+            fieldId={fieldId}
+            onRemove={() => handleRemove(id)}
+          >
+            {filterDef.inputKind === 'number' ? (
+              <ComparableInput
+                id={fieldId}
+                label={filterDef.label}
+                labelBg="var(--blert-filter-surface)"
+                type="number"
+                comparator={input.comparator}
+                onComparatorChange={(c) => commit(input.ticks, c)}
+                value={input.ticks?.toString() ?? ''}
+                min={filterDef.min}
+                max={filterDef.max}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value);
+                  stage(isNaN(v) ? null : v);
+                }}
+                onBlur={() => commitAll(customInputs)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    commitAll(customInputs);
+                  }
+                }}
+              />
+            ) : (
+              <TickInput
+                comparator
+                label={filterDef.label}
+                id={fieldId}
+                initialComparator={input.comparator}
+                initialTicks={input.ticks ?? undefined}
+                inputMode={
+                  filterDef.inputKind === 'ticks' ? 'ticks' : undefined
                 }
-                level={level + 1}
+                labelBg="var(--blert-filter-surface)"
+                onChange={stage}
+                onBlur={commit}
+                onConfirm={commit}
+                round={filterDef.round}
               />
             )}
-          </li>
+          </FilterField>
         );
       })}
-    </ul>
-  );
-}
-
-function CustomFiltersModal({
-  open,
-  onClose,
-  onSelection,
-}: {
-  open: boolean;
-  onClose: () => void;
-  onSelection: (split: number) => void;
-}) {
-  const [searchTerm, setSearchTerm] = useState('');
-
-  React.useEffect(() => {
-    if (open) {
-      setSearchTerm('');
-    }
-  }, [open]);
-
-  return (
-    <Modal className={styles.customFiltersModal} onClose={onClose} open={open}>
-      <div className={styles.modalHeader}>
-        <h2>Add Custom Filter</h2>
-        <button className={styles.closeButton} onClick={onClose} type="button">
-          <i className="fas fa-times" />
-          <span className="sr-only">Close</span>
-        </button>
-      </div>
-
-      <div className={styles.searchWrapper}>
-        <div className={styles.searchInput}>
-          <i className="fas fa-search" />
-          <input
-            type="text"
-            placeholder="Search filters..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            autoFocus
-          />
-          {searchTerm && (
-            <button
-              className={styles.clearSearch}
-              onClick={() => setSearchTerm('')}
-              type="button"
-            >
-              <i className="fas fa-times" />
-            </button>
-          )}
-        </div>
-      </div>
-
-      <div className={styles.customFiltersContent}>
-        {searchTerm && (
-          <div className={styles.searchInfo}>
-            Showing filters matching &quot;{searchTerm}&quot;
-          </div>
-        )}
-        <CollapsibleList
-          items={CUSTOM_FILTERS_ITEMS}
-          searchTerm={searchTerm}
-          onSelection={(value) => {
-            onSelection(value);
-            onClose();
-          }}
-        />
-      </div>
-
-      <div className={styles.modalFooter}>
-        <Button simple onClick={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </Modal>
+    </FilterSection>
   );
 }

--- a/web/app/search/challenges/search.tsx
+++ b/web/app/search/challenges/search.tsx
@@ -2,24 +2,27 @@
 
 import { SplitType } from '@blert/common';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   BasicSortableFields,
   ChallengeOverview,
   SortableFields,
 } from '@/actions/challenge';
-import Card from '@/components/card';
 import { getLocalSetting } from '@/utils/user-settings';
 import { UrlParams, queryString } from '@/utils/url';
 
 import {
   SearchContext,
   contextFromUrlParams,
+  countActiveFilters,
   extraFieldsToUrlParam,
   filtersToUrlParams,
+  isDefaultSearchFilters,
 } from './context';
-import Filters from './filters';
+import Filters, { resetChallengeFilters } from './filters';
+import FilterPanel from '../filter-panel';
+import { useFilterPanel } from '../filter-panel-context';
 import Table, {
   extraFieldsForColumns,
   DEFAULT_SELECTED_COLUMNS,
@@ -161,6 +164,12 @@ export default function Search({
   const [challenges, setChallenges] =
     useState<ChallengeOverview[]>(initialChallenges);
   const [stats, setStats] = useState<FilteredStats>(initialStats);
+  const lastLoadedQuery = useRef<string | null>(null);
+
+  const { setActiveCount } = useFilterPanel();
+  useEffect(() => {
+    setActiveCount(countActiveFilters(context.filters));
+  }, [context.filters, setActiveCount]);
 
   const resultsPerPage = 25; // TODO(frolv): Make this configurable.
 
@@ -199,6 +208,12 @@ export default function Search({
 
     paginationParams.limit = resultsPerPage + 1;
     paginationParams.extraFields = extraFieldsToUrlParam(ctx.extraFields);
+
+    const queryKey = queryString(paginationParams);
+    if (queryKey === lastLoadedQuery.current) {
+      return;
+    }
+    lastLoadedQuery.current = queryKey;
 
     setLoading(true);
     setLoadError(null);
@@ -273,6 +288,7 @@ export default function Search({
       setChallenges(newChallenges);
       setStats({ count: totalCount });
     } catch (error) {
+      lastLoadedQuery.current = null;
       if (error instanceof LoadChallengeError) {
         setLoadError(errorForStatus(error.status));
         return;
@@ -282,7 +298,6 @@ export default function Search({
         message: 'Unable to load challenges right now.',
         details: 'Please try again later.',
       });
-      return;
     } finally {
       setLoading(false);
     }
@@ -340,14 +355,6 @@ export default function Search({
 
   return (
     <>
-      <Card
-        header={{
-          title: 'Filters',
-        }}
-        fixed
-      >
-        <Filters context={context} setContext={setContext} loading={loading} />
-      </Card>
       <div className={styles.challenges}>
         <Table
           challenges={challenges}
@@ -377,6 +384,12 @@ export default function Search({
           </div>
         </div>
       </div>
+      <FilterPanel
+        onReset={() => setContext(resetChallengeFilters)}
+        canReset={!isDefaultSearchFilters(context.filters)}
+      >
+        <Filters context={context} setContext={setContext} loading={loading} />
+      </FilterPanel>
     </>
   );
 }

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -23,6 +23,8 @@
 }
 
 .challenges {
+  flex: 1;
+  min-width: 0;
   max-width: min(100%, 2000px);
   position: relative;
 
@@ -234,52 +236,6 @@
     }
   }
 
-  .contextMenu {
-    position: fixed;
-    z-index: 1000;
-    background-color: var(--blert-panel-background-color);
-    border: 1px solid rgba(var(--blert-purple-base), 0.2);
-    border-radius: 8px;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-
-    .entry {
-      height: 36px;
-      padding: 8px 16px;
-      text-align: left;
-      font-size: 1rem;
-      display: flex;
-      align-items: center;
-      transition: all 0.2s ease;
-
-      &:disabled,
-      &.inactive {
-        opacity: 0.5;
-      }
-
-      &.info {
-        height: auto;
-        pointer-events: none;
-        color: var(--blert-font-color-secondary);
-      }
-
-      &:not(.inactive):hover {
-        background: rgba(var(--blert-purple-base), 0.1);
-        cursor: pointer;
-        color: var(--blert-font-color-primary);
-      }
-    }
-
-    .divider {
-      width: calc(100% - 16px);
-      height: 1px;
-      margin: 0 auto;
-      background-color: rgba(var(--blert-purple-base), 0.1);
-    }
-  }
-
   .id {
     font-family: var(--font-roboto-mono), monospace;
     font-size: 14px;
@@ -336,7 +292,7 @@
 
         i {
           position: relative;
-          top: 2px;
+          top: 1px;
         }
       }
 
@@ -351,78 +307,62 @@
   }
 }
 
+.addFilter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--blert-purple);
+  background: rgba(var(--blert-purple-base), 0.1);
+  border: 1px solid rgba(var(--blert-purple-base), 0.25);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  i {
+    font-size: 0.75em;
+  }
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-purple-base), 0.2);
+    border-color: rgba(var(--blert-purple-base), 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
 .filters {
-  padding: 1rem;
-  background: var(--blert-surface-dark);
-  border: 1px solid var(--blert-surface-light);
   display: flex;
   flex-direction: column;
-  max-width: 1250px;
-  border-radius: 8px;
-
-  .label {
-    display: flex;
-    width: 100%;
-    font-weight: 500;
-    font-size: 1.1rem;
-    margin-bottom: 0.5em;
-
-    .action {
-      margin-left: auto;
-      font-size: 0.8em;
-      color: var(--blert-purple);
-      transition: opacity 0.2s ease;
-
-      &:hover {
-        cursor: pointer;
-        opacity: 0.8;
-      }
-    }
-  }
-
-  .filterGroup {
-    display: flex;
-    gap: 36px;
-
-    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
-      flex-wrap: wrap;
-      justify-content: space-between;
-    }
-
-    .item {
-      margin: 8px 0;
-    }
-  }
-
-  .checkGroup {
-    display: flex;
-    flex-direction: column;
-    width: 140px;
-
-    .checkbox {
-      padding: 4px 0;
-    }
-  }
+  gap: 1.25rem;
 
   .stageFilter {
     display: flex;
-    flex-direction: column;
-    align-items: center;
+    align-items: stretch;
     gap: 6px;
 
     button {
-      min-width: 150px;
+      flex: 1;
+      min-width: 0;
       text-align: left;
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 8px 12px;
+      padding: 8px 10px;
       border-radius: 6px;
       cursor: pointer;
       color: var(--blert-font-color-primary);
-      font-size: 16px;
+      font-size: 0.9rem;
       border: 1px solid rgba(var(--blert-purple-base), 0.1);
       transition: all 0.2s ease;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
 
       &:disabled {
         opacity: 0.5;
@@ -433,384 +373,6 @@
         background: rgba(var(--blert-purple-base), 0.1);
         border-color: rgba(var(--blert-purple-base), 0.2);
       }
-    }
-  }
-
-  .dateWrapper {
-    display: flex;
-    flex-direction: column;
-    padding-top: 10px;
-
-    .date {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 12px;
-    }
-
-    .dateRangeCheckbox {
-      padding: 4px 0;
-    }
-  }
-
-  .divider {
-    width: min(600px, 90%);
-    height: 1px;
-    margin: 1.5em auto;
-    background: linear-gradient(
-      90deg,
-      transparent,
-      rgba(var(--blert-purple-base), 0.2),
-      transparent
-    );
-  }
-
-  .custom {
-    flex-direction: column;
-    width: 100%;
-    gap: 12px;
-
-    .customHeading {
-      padding: 0 12px;
-
-      & > label {
-        font-size: 1.2rem;
-        font-weight: 500;
-      }
-
-      .actions {
-        margin: 16px 0;
-        display: flex;
-        gap: 12px;
-
-        .action {
-          padding: 8px 16px;
-          border-radius: 6px;
-          background: rgba(var(--blert-purple-base), 0.1);
-          border: 1px solid rgba(var(--blert-purple-base), 0.2);
-          color: var(--blert-purple);
-          font-weight: 500;
-          transition: all 0.2s ease;
-
-          i {
-            margin-right: 8px;
-          }
-
-          &:not(:disabled):hover {
-            background: rgba(var(--blert-purple-base), 0.2);
-          }
-        }
-      }
-    }
-
-    .inputs {
-      display: flex;
-      flex-flow: row wrap;
-      gap: 12px;
-
-      .customInput {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 4px 12px;
-
-        .comparable {
-          margin-top: -10px;
-        }
-
-        button.remove {
-          cursor: pointer;
-          margin: -12px 0 0 12px;
-          font-size: 18px;
-          width: 26px;
-          height: 26px;
-          color: rgba(var(--blert-red-base), 0.5);
-          background: rgba(var(--blert-red-base), 0.1);
-          border: 1px solid rgba(var(--blert-red-base), 0.2);
-          border-radius: 6px;
-          padding: 0;
-          transition: all 0.2s ease;
-
-          i {
-            position: relative;
-            top: -1px;
-          }
-
-          &:hover {
-            color: var(--blert-red);
-            border-color: rgba(var(--blert-red-base), 0.5);
-          }
-        }
-      }
-    }
-  }
-}
-
-.customFiltersModal {
-  @include panel;
-  width: min(90vw, 500px);
-  max-height: 85vh;
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-
-  .modalHeader {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 20px 24px;
-    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
-    background: linear-gradient(
-      135deg,
-      rgba(var(--blert-purple-base), 0.08) 0%,
-      rgba(var(--blert-purple-base), 0.03) 100%
-    );
-
-    h2 {
-      margin: 0;
-      color: var(--blert-font-color-primary);
-      font-weight: 600;
-      font-size: 1.3em;
-    }
-
-    .closeButton {
-      width: 32px;
-      height: 32px;
-      border-radius: 6px;
-      background: rgba(var(--blert-purple-base), 0.1);
-      border: 1px solid rgba(var(--blert-purple-base), 0.2);
-      color: var(--blert-font-color-secondary);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      transition: all 0.2s ease;
-
-      &:hover {
-        background: rgba(var(--blert-purple-base), 0.2);
-        color: var(--blert-font-color-primary);
-        transform: scale(1.05);
-      }
-    }
-  }
-
-  .searchWrapper {
-    padding: 16px 24px;
-    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
-
-    .searchInput {
-      position: relative;
-      display: flex;
-      align-items: center;
-
-      & > i:first-child {
-        position: absolute;
-        left: 12px;
-        color: var(--blert-font-color-secondary);
-        font-size: 0.9em;
-        z-index: 1;
-      }
-
-      input {
-        width: 100%;
-        padding: 12px 16px 12px 40px;
-        border: 1px solid rgba(var(--blert-purple-base), 0.2);
-        border-radius: 8px;
-        background: rgba(var(--blert-surface-dark-base), 0.3);
-        color: var(--blert-font-color-primary);
-        font-size: 1rem;
-        transition: all 0.2s ease;
-
-        &:focus {
-          outline: none;
-          border-color: var(--blert-purple);
-          background: rgba(var(--blert-surface-dark-base), 0.5);
-          box-shadow: 0 0 0 3px rgba(var(--blert-purple-base), 0.1);
-        }
-
-        &::placeholder {
-          color: var(--blert-font-color-secondary);
-        }
-      }
-
-      .clearSearch {
-        position: absolute;
-        right: 8px;
-        width: 24px;
-        height: 24px;
-        border-radius: 4px;
-        background: rgba(var(--blert-purple-base), 0.1);
-        border: none;
-        color: var(--blert-font-color-secondary);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: all 0.2s ease;
-
-        &:hover {
-          background: rgba(var(--blert-purple-base), 0.2);
-          color: var(--blert-font-color-primary);
-        }
-      }
-    }
-  }
-
-  .searchInfo {
-    padding: 12px 24px;
-    font-size: 0.9em;
-    color: var(--blert-font-color-secondary);
-    background: rgba(var(--blert-purple-base), 0.05);
-    border-bottom: 1px solid rgba(var(--blert-purple-base), 0.1);
-  }
-
-  .customFiltersContent {
-    flex: 1;
-    overflow-y: auto;
-    padding: 8px 0;
-    @include styledScrollbar;
-  }
-
-  .customFiltersList {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-
-    // Base level (Splits)
-    &.level0 {
-      li {
-        .collapsible {
-          padding-left: 24px;
-          font-size: 1rem;
-          font-weight: 600;
-        }
-      }
-    }
-
-    // Second level (ToB, Colosseum)
-    &.level1 {
-      background: rgba(var(--blert-surface-dark-base), 0.1);
-
-      li {
-        .collapsible {
-          padding-left: 40px;
-          font-size: 0.95rem;
-          font-weight: 500;
-        }
-
-        .filterItem {
-          padding-left: 64px;
-          font-size: 0.9rem;
-        }
-      }
-    }
-
-    // Third level (Maiden, Nylocas, Challenge time, Overall time, etc.)
-    &.level2 {
-      background: rgba(var(--blert-surface-dark-base), 0.2);
-
-      li {
-        .collapsible {
-          padding-left: 56px;
-          font-size: 0.9rem;
-          font-weight: 500;
-        }
-
-        .filterItem {
-          padding-left: 56px;
-          font-size: 0.85rem;
-        }
-      }
-    }
-
-    // Fourth level (Room time, 70s spawn, etc.)
-    &.level3 {
-      background: rgba(var(--blert-surface-dark-base), 0.3);
-
-      li {
-        .filterItem {
-          padding-left: 80px;
-          font-size: 0.8rem;
-        }
-      }
-    }
-
-    li {
-      .collapsible {
-        width: 100%;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        padding: 12px 24px;
-        font-size: 1rem;
-        font-weight: 500;
-        color: var(--blert-font-color-primary);
-        background: none;
-        border: none;
-        text-align: left;
-        transition: all 0.2s ease;
-        position: relative;
-
-        &:hover {
-          background: rgba(var(--blert-purple-base), 0.08);
-          color: var(--blert-purple);
-        }
-
-        i:first-child {
-          color: var(--blert-purple);
-          font-size: 0.9em;
-          width: 16px;
-          flex-shrink: 0;
-        }
-
-        i:last-child {
-          margin-left: auto;
-          font-size: 0.8em;
-          color: var(--blert-font-color-secondary);
-          flex-shrink: 0;
-        }
-      }
-
-      .filterItem {
-        width: 100%;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        padding: 10px 24px 10px 52px;
-        font-size: 0.95rem;
-        color: var(--blert-font-color-secondary);
-        background: none;
-        border: none;
-        text-align: left;
-        transition: all 0.2s ease;
-        border-left: 3px solid transparent;
-
-        &:hover {
-          background: rgba(var(--blert-purple-base), 0.1);
-          color: var(--blert-font-color-primary);
-          border-left-color: var(--blert-purple);
-          transform: translateX(2px);
-        }
-
-        i {
-          color: var(--blert-purple);
-          font-size: 0.8em;
-          width: 12px;
-          flex-shrink: 0;
-        }
-      }
-    }
-  }
-
-  .modalFooter {
-    padding: 16px 24px;
-    border-top: 1px solid rgba(var(--blert-purple-base), 0.1);
-    background: rgba(var(--blert-surface-dark-base), 0.2);
-    display: flex;
-    justify-content: flex-end;
-
-    button {
-      min-width: 80px;
     }
   }
 }

--- a/web/app/search/entity-selector.module.scss
+++ b/web/app/search/entity-selector.module.scss
@@ -1,0 +1,46 @@
+@use '@/mixins.scss' as *;
+
+.selector {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.entity {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--blert-font-color-secondary);
+  text-decoration: none;
+  transition: all 0.15s ease;
+  border: 1px solid transparent;
+
+  i {
+    font-size: 0.9em;
+  }
+
+  &:hover:not(.active) {
+    color: var(--blert-font-color-primary);
+    background: rgba(var(--blert-purple-base), 0.08);
+  }
+
+  &.active {
+    color: var(--blert-font-color-primary);
+    background: rgba(var(--blert-purple-base), 0.15);
+    border-color: rgba(var(--blert-purple-base), 0.3);
+
+    i {
+      color: var(--blert-purple);
+    }
+  }
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    padding: 6px 10px;
+    gap: 8px;
+    font-size: 0.85rem;
+  }
+}

--- a/web/app/search/entity-selector.tsx
+++ b/web/app/search/entity-selector.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { buildEntityHref } from './shared-filters';
+
+import styles from './entity-selector.module.scss';
+
+type Entity = {
+  label: string;
+  path: string;
+  icon: string;
+};
+
+const ENTITIES: Entity[] = [
+  { label: 'Challenges', path: '/search/challenges', icon: 'fas fa-list' },
+  { label: 'Sessions', path: '/search/sessions', icon: 'fas fa-layer-group' },
+];
+
+export default function EntitySelector() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  return (
+    <nav className={styles.selector}>
+      {ENTITIES.map((entity) => {
+        const active = pathname === entity.path;
+        const href = active
+          ? entity.path
+          : buildEntityHref(entity.path, searchParams);
+        return (
+          <Link
+            key={entity.path}
+            href={href}
+            className={`${styles.entity} ${active ? styles.active : ''}`}
+            aria-current={active ? 'page' : undefined}
+          >
+            <i className={entity.icon} />
+            <span>{entity.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/app/search/filter-controls.module.scss
+++ b/web/app/search/filter-controls.module.scss
@@ -1,0 +1,110 @@
+@use '@/mixins.scss' as *;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--blert-font-color-secondary);
+}
+
+.sectionAction {
+  display: flex;
+  align-items: center;
+}
+
+.sectionBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.fieldLabelRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.fieldLabel {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+}
+
+.fieldRemove {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--blert-font-color-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: rgba(var(--blert-red-base), 0.15);
+    color: var(--blert-red);
+  }
+}
+
+.fieldBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  > * {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.checkboxList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.partyInput {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dateRange {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/web/app/search/filter-controls.tsx
+++ b/web/app/search/filter-controls.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+import { ChallengeMode, ChallengeType } from '@blert/common';
+
+import Checkbox from '@/components/checkbox';
+import DatePicker from '@/components/date-picker';
+import PlayerSearch from '@/components/player-search';
+import TagList from '@/components/tag-list';
+import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
+
+import styles from './filter-controls.module.scss';
+
+const DATE_INPUT_WIDTH = 132;
+const MAX_PARTY_SIZE = 5;
+
+const NO_MODE_CHALLENGE_TYPES = new Set<ChallengeType>([
+  ChallengeType.COLOSSEUM,
+  ChallengeType.INFERNO,
+  ChallengeType.MOKHAIOTL,
+]);
+
+function isTobMode(mode: ChallengeMode): boolean {
+  return mode >= ChallengeMode.TOB_ENTRY && mode <= ChallengeMode.TOB_HARD;
+}
+
+type FilterSectionProps = {
+  title?: string;
+  /** Optional action rendered in the section header. */
+  action?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+/**
+ * Logical grouping of one or more filters.
+ * Renders an optional heading above its children.
+ */
+export function FilterSection({ title, action, children }: FilterSectionProps) {
+  const hasHeader = title !== undefined || action !== undefined;
+  return (
+    <section className={styles.section}>
+      {hasHeader && (
+        <div className={styles.sectionHeader}>
+          {title !== undefined && (
+            <h4 className={styles.sectionTitle}>{title}</h4>
+          )}
+          {action !== undefined && (
+            <div className={styles.sectionAction}>{action}</div>
+          )}
+        </div>
+      )}
+      <div className={styles.sectionBody}>{children}</div>
+    </section>
+  );
+}
+
+type FilterFieldProps = {
+  label: string;
+  htmlFor?: string;
+  /** Identifier mirrored as a `data-field-id` attribute on the wrapper. */
+  fieldId?: string;
+  onRemove?: () => void;
+  children: React.ReactNode;
+};
+
+/**
+ * A single labeled filter. Used inside a {@link FilterSection} (or standalone).
+ */
+export function FilterField({
+  label,
+  htmlFor,
+  fieldId,
+  onRemove,
+  children,
+}: FilterFieldProps) {
+  return (
+    <div className={styles.field} data-field-id={fieldId}>
+      <div className={styles.fieldLabelRow}>
+        <label className={styles.fieldLabel} htmlFor={htmlFor}>
+          {label}
+        </label>
+        {onRemove !== undefined && (
+          <button
+            className={styles.fieldRemove}
+            onClick={onRemove}
+            type="button"
+            aria-label={`Remove filter ${label}`}
+          >
+            <i className="fas fa-times" aria-hidden />
+          </button>
+        )}
+      </div>
+      <div className={styles.fieldBody}>{children}</div>
+    </div>
+  );
+}
+
+/** Horizontal grouping of fields. */
+export function FilterRow({ children }: { children: React.ReactNode }) {
+  return <div className={styles.row}>{children}</div>;
+}
+
+type PartyFilterProps = {
+  party: string[];
+  onChange: (party: string[]) => void;
+  disabled?: boolean;
+};
+
+export function PartyFilter({
+  party,
+  onChange,
+  disabled = false,
+}: PartyFilterProps) {
+  return (
+    <FilterField label="Party" htmlFor="filters-player">
+      <div className={styles.partyInput}>
+        <PlayerSearch
+          disabled={disabled || party.length >= MAX_PARTY_SIZE}
+          label="Enter username"
+          labelBg="var(--blert-filter-surface)"
+          id="filters-player"
+          onSelection={(username) => {
+            if (!party.includes(username)) {
+              onChange([...party, username]);
+            }
+          }}
+        />
+        <TagList
+          onRemove={(username) => onChange(party.filter((u) => u !== username))}
+          tags={party}
+        />
+      </div>
+    </FilterField>
+  );
+}
+
+type DateRangeFilterProps = {
+  startDate: Date | null;
+  endDate: Date | null;
+  onChange: (startDate: Date | null, endDate: Date | null) => void;
+  disabled?: boolean;
+};
+
+export function DateRangeFilter({
+  startDate,
+  endDate,
+  onChange,
+  disabled = false,
+}: DateRangeFilterProps) {
+  return (
+    <FilterField label="Date">
+      <div className={styles.dateRange}>
+        <DatePicker
+          disabled={disabled}
+          icon="fas fa-calendar-alt"
+          isClearable
+          maxDate={endDate ?? new Date()}
+          placeholderText="From"
+          popperPlacement="bottom"
+          selected={startDate}
+          onChange={(date) => onChange(date, endDate)}
+          showIcon
+          width={DATE_INPUT_WIDTH}
+        />
+        <DatePicker
+          disabled={disabled}
+          icon="fas fa-calendar-alt"
+          isClearable
+          maxDate={new Date()}
+          minDate={startDate ?? undefined}
+          placeholderText="To"
+          popperPlacement="bottom"
+          selected={endDate}
+          onChange={(date) => onChange(startDate, date)}
+          showIcon
+          width={DATE_INPUT_WIDTH}
+        />
+      </div>
+    </FilterField>
+  );
+}
+
+type TypeFilterProps = {
+  type: ChallengeType[];
+  mode: ChallengeMode[];
+  onChange: (type: ChallengeType[], mode: ChallengeMode[]) => void;
+  disabled?: boolean;
+  disabledTypes?: ChallengeType[];
+  disabledTypesMessage?: string;
+};
+
+export function toggleTobMode(
+  type: ChallengeType[],
+  mode: ChallengeMode[],
+  targetMode: ChallengeMode,
+): { type: ChallengeType[]; mode: ChallengeMode[] } {
+  const remove = mode.includes(targetMode);
+  if (remove) {
+    const tobModes = mode.filter(isTobMode).length;
+    return {
+      mode: mode.filter((v) => v !== targetMode),
+      type: tobModes === 1 ? type.filter((v) => v !== ChallengeType.TOB) : type,
+    };
+  }
+  return {
+    mode: [...mode, targetMode],
+    type: type.includes(ChallengeType.TOB)
+      ? type
+      : [...type, ChallengeType.TOB],
+  };
+}
+
+export function toggleNoModeType(
+  type: ChallengeType[],
+  mode: ChallengeMode[],
+  targetType: ChallengeType,
+): { type: ChallengeType[]; mode: ChallengeMode[] } {
+  const remove = type.includes(targetType);
+  if (remove) {
+    const keepNoMode = type.some(
+      (t) => t !== targetType && NO_MODE_CHALLENGE_TYPES.has(t),
+    );
+    return {
+      type: type.filter((t) => t !== targetType),
+      mode: keepNoMode ? mode : mode.filter((m) => m !== ChallengeMode.NO_MODE),
+    };
+  }
+  const hasNoMode = mode.includes(ChallengeMode.NO_MODE);
+  return {
+    type: [...type, targetType],
+    mode: hasNoMode ? mode : [...mode, ChallengeMode.NO_MODE],
+  };
+}
+
+export function TypeFilter({
+  type,
+  mode,
+  onChange,
+  disabled = false,
+  disabledTypes = [],
+  disabledTypesMessage,
+}: TypeFilterProps) {
+  const tobRegularChecked =
+    type.includes(ChallengeType.TOB) &&
+    mode.includes(ChallengeMode.TOB_REGULAR);
+  const tobHardChecked =
+    type.includes(ChallengeType.TOB) && mode.includes(ChallengeMode.TOB_HARD);
+
+  function maybeWrapDisabled(checkboxEl: React.ReactNode, isDisabled: boolean) {
+    if (!isDisabled || disabledTypesMessage === undefined) {
+      return checkboxEl;
+    }
+    return (
+      <div
+        data-tooltip-id={GLOBAL_TOOLTIP_ID}
+        data-tooltip-content={disabledTypesMessage}
+      >
+        {checkboxEl}
+      </div>
+    );
+  }
+
+  const tobDisabled =
+    disabledTypes.includes(ChallengeType.TOB) &&
+    !type.includes(ChallengeType.TOB);
+
+  function tobModeCheckbox(
+    target: ChallengeMode,
+    label: string,
+    checked: boolean,
+  ) {
+    return maybeWrapDisabled(
+      <Checkbox
+        checked={checked}
+        disabled={disabled || (tobDisabled && !checked)}
+        onChange={() => {
+          const next = toggleTobMode(type, mode, target);
+          onChange(next.type, next.mode);
+        }}
+        label={label}
+        simple
+      />,
+      tobDisabled && !checked,
+    );
+  }
+
+  function noModeCheckbox(target: ChallengeType, label: string) {
+    const checked = type.includes(target);
+    const isDisabled = disabledTypes.includes(target) && !checked;
+    return maybeWrapDisabled(
+      <Checkbox
+        checked={checked}
+        disabled={disabled || isDisabled}
+        onChange={() => {
+          const next = toggleNoModeType(type, mode, target);
+          onChange(next.type, next.mode);
+        }}
+        label={label}
+        simple
+      />,
+      isDisabled,
+    );
+  }
+
+  return (
+    <FilterField label="Type">
+      <div className={styles.checkboxList}>
+        {tobModeCheckbox(
+          ChallengeMode.TOB_REGULAR,
+          'ToB Regular',
+          tobRegularChecked,
+        )}
+        {tobModeCheckbox(ChallengeMode.TOB_HARD, 'ToB Hard', tobHardChecked)}
+        {noModeCheckbox(ChallengeType.INFERNO, 'Inferno')}
+        {noModeCheckbox(ChallengeType.COLOSSEUM, 'Colosseum')}
+        {noModeCheckbox(ChallengeType.MOKHAIOTL, 'Mokhaiotl')}
+      </div>
+    </FilterField>
+  );
+}
+
+type ScaleFilterProps = {
+  scale: number[];
+  type: ChallengeType[];
+  onChange: (scale: number[]) => void;
+  disabled?: boolean;
+};
+
+export function ScaleFilter({
+  scale,
+  type,
+  onChange,
+  disabled = false,
+}: ScaleFilterProps) {
+  const hasTeamChallenges =
+    type.length === 0 || type.includes(ChallengeType.TOB);
+
+  function toggle(value: number) {
+    if (scale.includes(value)) {
+      onChange(scale.filter((v) => v !== value));
+    } else {
+      onChange([...scale, value]);
+    }
+  }
+
+  function checkbox(value: number, label: string, teamOnly: boolean = false) {
+    const checked = scale.includes(value);
+    const isDisabled = teamOnly && !hasTeamChallenges && !checked;
+    const checkboxEl = (
+      <Checkbox
+        checked={checked}
+        disabled={disabled || isDisabled}
+        onChange={() => toggle(value)}
+        label={label}
+        simple
+      />
+    );
+    if (!isDisabled) {
+      return checkboxEl;
+    }
+    return (
+      <div
+        data-tooltip-id={GLOBAL_TOOLTIP_ID}
+        data-tooltip-content="Only available for team challenge types"
+      >
+        {checkboxEl}
+      </div>
+    );
+  }
+
+  return (
+    <FilterField label="Scale">
+      <div className={styles.checkboxList}>
+        {checkbox(1, 'Solo')}
+        {checkbox(2, 'Duo', true)}
+        {checkbox(3, 'Trio', true)}
+        {checkbox(4, '4s', true)}
+        {checkbox(5, '5s', true)}
+      </div>
+    </FilterField>
+  );
+}
+
+type StatusOption<T extends number> = {
+  value: T;
+  label: string;
+};
+
+type StatusFilterProps<T extends number> = {
+  status: T[];
+  options: StatusOption<T>[];
+  onChange: (status: T[]) => void;
+  disabled?: boolean;
+};
+
+export function StatusFilter<T extends number>({
+  status,
+  options,
+  onChange,
+  disabled = false,
+}: StatusFilterProps<T>) {
+  function toggle(value: T) {
+    if (status.includes(value)) {
+      onChange(status.filter((v) => v !== value));
+    } else {
+      onChange([...status, value]);
+    }
+  }
+
+  return (
+    <FilterField label="Status">
+      <div className={styles.checkboxList}>
+        {options.map((option) => (
+          <Checkbox
+            key={option.value}
+            checked={status.includes(option.value)}
+            disabled={disabled}
+            onChange={() => toggle(option.value)}
+            label={option.label}
+            simple
+          />
+        ))}
+      </div>
+    </FilterField>
+  );
+}

--- a/web/app/search/filter-panel-context.tsx
+++ b/web/app/search/filter-panel-context.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+import { useDisplay } from '@/display';
+import { useSetting } from '@/utils/user-settings';
+
+type FilterPanelState = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  activeCount: number;
+  setActiveCount: (n: number) => void;
+};
+
+const FilterPanelContext = createContext<FilterPanelState | null>(null);
+
+export function FilterPanelProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const display = useDisplay();
+  const [desktopOpen, setDesktopOpen] = useSetting<boolean>({
+    key: 'search-filter-panel-open',
+    defaultValue: true,
+  });
+  const [compactOpen, setCompactOpen] = useState(false);
+  const [activeCount, setActiveCount] = useState(0);
+
+  const isCompact = display.isCompact();
+  const open = isCompact ? compactOpen : desktopOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isCompact) {
+        setCompactOpen(next);
+      } else {
+        setDesktopOpen(next);
+      }
+    },
+    [isCompact, setDesktopOpen],
+  );
+  const toggle = useCallback(() => setOpen(!open), [open, setOpen]);
+
+  const value = useMemo(
+    () => ({ open, setOpen, toggle, activeCount, setActiveCount }),
+    [open, setOpen, toggle, activeCount],
+  );
+
+  return (
+    <FilterPanelContext.Provider value={value}>
+      {children}
+    </FilterPanelContext.Provider>
+  );
+}
+
+export function useFilterPanel(): FilterPanelState {
+  const ctx = useContext(FilterPanelContext);
+  if (ctx === null) {
+    throw new Error('useFilterPanel must be used within a FilterPanelProvider');
+  }
+  return ctx;
+}

--- a/web/app/search/filter-panel.module.scss
+++ b/web/app/search/filter-panel.module.scss
@@ -1,0 +1,133 @@
+@use '@/mixins.scss' as *;
+
+$PANEL_WIDTH: 320px;
+
+.panel {
+  flex-shrink: 0;
+  width: $PANEL_WIDTH;
+  max-height: calc(100vh - 120px);
+  position: sticky;
+  top: 16px;
+  overflow: hidden;
+  transition:
+    width 0.2s ease,
+    opacity 0.2s ease;
+  border-radius: 6px;
+
+  &.closed {
+    width: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.panelInner {
+  @include panel;
+  flex-direction: column;
+  width: $PANEL_WIDTH;
+  max-height: inherit;
+  overflow: hidden;
+
+  // Surface color behind filter inputs so floating labels can cover their
+  // input border cleanly.
+  --blert-filter-surface: var(--blert-panel-background-color);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(var(--blert-surface-light-base), 0.4);
+  background: rgba(var(--blert-surface-dark-base), 0.6);
+  flex-shrink: 0;
+
+  h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--blert-font-color-primary);
+  }
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.reset {
+  font-size: 0.85rem;
+  color: var(--blert-purple);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: all 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(var(--blert-purple-base), 0.1);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(var(--blert-red-base), 0.1);
+  border-radius: 6px;
+  background: rgba(var(--blert-red-base), 0.05);
+  color: var(--blert-red);
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:active {
+    background: rgba(var(--blert-red-base), 0.1);
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      background: rgba(var(--blert-red-base), 0.1);
+      border-color: rgba(var(--blert-red-base), 0.2);
+    }
+  }
+}
+
+.content {
+  @include styledScrollbar;
+
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal {
+  width: 100%;
+  max-width: min(420px, 92vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+
+  // Override to match the Modal component's surface-dark background.
+  --blert-filter-surface: var(--blert-surface-dark);
+}
+
+.modalContent {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1rem 1rem 2rem;
+  overflow-y: auto;
+}

--- a/web/app/search/filter-panel.tsx
+++ b/web/app/search/filter-panel.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useContext } from 'react';
+
+import Modal from '@/components/modal';
+import { DisplayContext } from '@/display';
+
+import { useFilterPanel } from './filter-panel-context';
+
+import styles from './filter-panel.module.scss';
+
+type FilterPanelProps = {
+  children: React.ReactNode;
+  onReset?: () => void;
+  canReset?: boolean;
+};
+
+export default function FilterPanel({
+  children,
+  onReset,
+  canReset = true,
+}: FilterPanelProps) {
+  const display = useContext(DisplayContext);
+  const { open, setOpen } = useFilterPanel();
+
+  const resetButton = onReset !== undefined && (
+    <button
+      className={styles.reset}
+      disabled={!canReset}
+      onClick={onReset}
+      type="button"
+    >
+      Reset
+    </button>
+  );
+
+  const isCompact = display.isCompact();
+  const header = (
+    <div className={styles.header}>
+      <h3>Filters</h3>
+      <div className={styles.headerActions}>
+        {resetButton}
+        {isCompact && (
+          <button
+            className={styles.close}
+            onClick={() => setOpen(false)}
+            type="button"
+            aria-label="Close filters"
+          >
+            <i className="fas fa-times" aria-hidden />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  if (isCompact) {
+    return (
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        className={styles.modal}
+      >
+        {header}
+        <div className={styles.modalContent}>{children}</div>
+      </Modal>
+    );
+  }
+
+  return (
+    <aside className={`${styles.panel} ${open ? '' : styles.closed}`}>
+      <div className={styles.panelInner}>
+        {header}
+        <div className={styles.content}>{children}</div>
+      </div>
+    </aside>
+  );
+}

--- a/web/app/search/filter-toggle.module.scss
+++ b/web/app/search/filter-toggle.module.scss
@@ -1,0 +1,56 @@
+@use '@/mixins.scss' as *;
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  i {
+    font-size: 0.85em;
+  }
+
+  &:hover {
+    color: var(--blert-font-color-primary);
+    background: rgba(var(--blert-purple-base), 0.08);
+  }
+
+  &.active {
+    color: var(--blert-font-color-primary);
+    background: rgba(var(--blert-purple-base), 0.12);
+    border-color: rgba(var(--blert-purple-base), 0.2);
+
+    i {
+      color: var(--blert-purple);
+    }
+  }
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    padding: 6px 10px;
+    gap: 6px;
+    font-size: 0.85rem;
+  }
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--blert-purple);
+  line-height: 1;
+}

--- a/web/app/search/filter-toggle.tsx
+++ b/web/app/search/filter-toggle.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useFilterPanel } from './filter-panel-context';
+
+import styles from './filter-toggle.module.scss';
+
+export default function FilterToggle() {
+  const { open, toggle, activeCount } = useFilterPanel();
+
+  return (
+    <button
+      className={`${styles.toggle} ${open ? styles.active : ''}`}
+      onClick={toggle}
+      aria-pressed={open}
+      aria-label={
+        open
+          ? `Hide filters${activeCount > 0 ? ` (${activeCount} active)` : ''}`
+          : `Show filters${activeCount > 0 ? ` (${activeCount} active)` : ''}`
+      }
+      type="button"
+    >
+      <i className="fas fa-filter" aria-hidden />
+      <span>Filters</span>
+      {activeCount > 0 && (
+        <span className={styles.badge} aria-hidden>
+          {activeCount}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/web/app/search/layout.module.scss
+++ b/web/app/search/layout.module.scss
@@ -3,63 +3,55 @@
 .searchLayout {
   display: flex;
   flex-direction: column;
-  align-items: center;
   width: 100%;
+  padding: 12px 16px 24px;
+  gap: 16px;
+  box-sizing: border-box;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    padding: 8px 0;
+    gap: 12px;
+  }
 }
 
-.header {
-  margin: 1em 0;
+.topbar {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  text-align: center;
+  gap: 12px;
+  padding: 6px 12px;
+  background: rgba(var(--blert-surface-dark-base), 0.5);
+  border: 1px solid rgba(var(--blert-purple-base), 0.08);
+  border-radius: 10px;
+  width: 100%;
+  box-sizing: border-box;
 
-  h1 {
-    font-size: 1.5em;
-    margin: 0;
-  }
-
-  p {
-    margin: 0.5em 0 1em;
-    color: var(--blert-font-color-secondary);
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    gap: 8px;
+    padding: 4px 8px;
   }
 }
 
-.tabs {
-  display: flex;
-  gap: 4px;
-  padding: 4px;
-  background: var(--blert-surface-dark);
-  border-radius: 8px;
-  border: 1px solid rgba(var(--blert-purple-base), 0.1);
-}
-
-.tab {
+.topbarActions {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 20px;
-  border-radius: 6px;
-  font-weight: 500;
-  color: var(--blert-font-color-secondary);
-  text-decoration: none;
-  transition: all 0.2s ease;
+  margin-left: auto;
+}
 
-  i {
-    font-size: 0.9em;
-  }
+// Empty placeholder while EntitySelector hydrates. Matches the active button's
+// height so the topbar doesn't jump on first paint.
+.selectorFallback {
+  height: 40px;
+}
 
-  &:hover:not(.active) {
-    color: var(--blert-font-color-primary);
-    background: rgba(var(--blert-purple-base), 0.08);
-  }
+.body {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+  align-items: flex-start;
 
-  &.active {
-    color: var(--blert-font-color-primary);
-    background: rgba(var(--blert-purple-base), 0.15);
-
-    i {
-      color: var(--blert-purple);
-    }
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-direction: column;
+    gap: 12px;
   }
 }

--- a/web/app/search/layout.tsx
+++ b/web/app/search/layout.tsx
@@ -1,9 +1,8 @@
-'use client';
+import { Suspense } from 'react';
 
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-
-import Card from '@/components/card';
+import EntitySelector from './entity-selector';
+import { FilterPanelProvider } from './filter-panel-context';
+import FilterToggle from './filter-toggle';
 
 import styles from './layout.module.scss';
 
@@ -12,37 +11,19 @@ export default function SearchLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-
-  const isChallenge = pathname === '/search/challenges';
-  const isSession = pathname === '/search/sessions';
-
   return (
-    <div className={styles.searchLayout}>
-      <Card className={styles.header} fixed primary>
-        <h1>Search</h1>
-        <p>
-          Find recorded challenges and sessions by player, date, and other
-          criteria.
-        </p>
-        <nav className={styles.tabs}>
-          <Link
-            href="/search/challenges"
-            className={`${styles.tab} ${isChallenge ? styles.active : ''}`}
-          >
-            <i className="fas fa-list" />
-            Challenges
-          </Link>
-          <Link
-            href="/search/sessions"
-            className={`${styles.tab} ${isSession ? styles.active : ''}`}
-          >
-            <i className="fas fa-layer-group" />
-            Sessions
-          </Link>
-        </nav>
-      </Card>
-      {children}
-    </div>
+    <FilterPanelProvider>
+      <div className={styles.searchLayout}>
+        <div className={styles.topbar}>
+          <Suspense fallback={<div className={styles.selectorFallback} />}>
+            <EntitySelector />
+          </Suspense>
+          <div className={styles.topbarActions}>
+            <FilterToggle />
+          </div>
+        </div>
+        <div className={styles.body}>{children}</div>
+      </div>
+    </FilterPanelProvider>
   );
 }

--- a/web/app/search/sessions/__tests__/context.test.ts
+++ b/web/app/search/sessions/__tests__/context.test.ts
@@ -1,0 +1,129 @@
+import { ChallengeMode, ChallengeType, SessionStatus } from '@blert/common';
+
+import { NextSearchParams, queryString } from '@/utils/url';
+
+import {
+  SessionSearchFilters,
+  contextFromUrlParams,
+  countActiveFilters,
+  emptyFilters,
+  filtersToUrlParams,
+} from '../context';
+
+function queryToParams(qs: string): NextSearchParams {
+  const params: NextSearchParams = {};
+  const search = new URLSearchParams(qs);
+  for (const key of Array.from(new Set(search.keys()))) {
+    const values = search.getAll(key);
+    params[key] = values.length > 1 ? values : values[0];
+  }
+  return params;
+}
+
+function roundTrip(filters: SessionSearchFilters): SessionSearchFilters {
+  const url = queryString(filtersToUrlParams(filters));
+  const ctx = contextFromUrlParams(queryToParams(url));
+  return ctx.filters;
+}
+
+describe('sessions filter URL round-trip', () => {
+  it('preserves all shared fields', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      party: ['WWWWWWWWWWQQ', 'otter pet'],
+      type: [ChallengeType.COLOSSEUM],
+      mode: [ChallengeMode.NO_MODE],
+      scale: [1, 2],
+      startDate: new Date('2026-02-01T00:00:00Z'),
+    };
+    const result = roundTrip(filters);
+    expect(result.party).toEqual(['WWWWWWWWWWQQ', 'otter pet']);
+    expect(result.type).toEqual([ChallengeType.COLOSSEUM]);
+    expect(result.mode).toEqual([ChallengeMode.NO_MODE]);
+    expect(result.scale).toEqual([1, 2]);
+    expect(result.startDate?.getTime()).toBe(filters.startDate!.getTime());
+  });
+
+  it('preserves status', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      status: [SessionStatus.COMPLETED, SessionStatus.ACTIVE],
+    };
+    const result = roundTrip(filters);
+    expect(result.status).toEqual([
+      SessionStatus.COMPLETED,
+      SessionStatus.ACTIVE,
+    ]);
+  });
+
+  it('preserves challenge-count range', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      minChallengeCount: 5,
+      maxChallengeCount: 20,
+    };
+    const result = roundTrip(filters);
+    expect(result.minChallengeCount).toBe(5);
+    expect(result.maxChallengeCount).toBe(20);
+  });
+
+  it('preserves a min-only challenge-count range', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      minChallengeCount: 3,
+    };
+    const result = roundTrip(filters);
+    expect(result.minChallengeCount).toBe(3);
+    expect(result.maxChallengeCount).toBeNull();
+  });
+
+  it('preserves duration range in minutes (scale=60)', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      minDurationMinutes: 30,
+      maxDurationMinutes: 120,
+    };
+    const result = roundTrip(filters);
+    expect(result.minDurationMinutes).toBe(30);
+    expect(result.maxDurationMinutes).toBe(120);
+  });
+
+  it('produces an empty query string for empty filters', () => {
+    expect(queryString(filtersToUrlParams(emptyFilters()))).toBe('');
+  });
+});
+
+describe('countActiveFilters', () => {
+  it('returns 0 for empty filters', () => {
+    expect(countActiveFilters(emptyFilters())).toBe(0);
+  });
+
+  it('counts status, challenge-count range, and duration range each as one', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      status: [SessionStatus.ACTIVE],
+      minChallengeCount: 5,
+      minDurationMinutes: 30,
+    };
+    expect(countActiveFilters(filters)).toBe(3);
+  });
+
+  it('counts a range with only a max bound', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      maxChallengeCount: 10,
+    };
+    expect(countActiveFilters(filters)).toBe(1);
+  });
+
+  it('includes shared filter counts', () => {
+    const filters: SessionSearchFilters = {
+      ...emptyFilters(),
+      party: ['WWWWWWWWWWQQ'],
+      type: [ChallengeType.TOB],
+      mode: [ChallengeMode.TOB_REGULAR],
+      status: [SessionStatus.COMPLETED],
+    };
+    expect(countActiveFilters(filters)).toBe(3);
+  });
+});

--- a/web/app/search/sessions/context.ts
+++ b/web/app/search/sessions/context.ts
@@ -1,19 +1,22 @@
-import { ChallengeMode, ChallengeType, SessionStatus } from '@blert/common';
+import { SessionStatus } from '@blert/common';
 
 import { NextSearchParams, UrlParams } from '@/utils/url';
 
-export type SessionSearchFilters = {
-  type: ChallengeType[];
-  mode: ChallengeMode[];
-  scale: number[];
+import {
+  SharedFilters,
+  applySharedFilterParam,
+  countSharedFilters,
+  emptySharedFilters,
+  numericList,
+  sharedFiltersToUrlParams,
+} from '../shared-filters';
+
+export type SessionSearchFilters = SharedFilters & {
   status: SessionStatus[];
-  party: string[];
   minChallengeCount: number | null;
   maxChallengeCount: number | null;
   minDurationMinutes: number | null;
   maxDurationMinutes: number | null;
-  startDate: Date | null;
-  endDate: Date | null;
 };
 
 export type SessionSearchContext = {
@@ -26,22 +29,29 @@ export type SessionSearchContext = {
 
 export function emptyFilters(): SessionSearchFilters {
   return {
-    type: [],
-    mode: [],
-    scale: [],
+    ...emptySharedFilters(),
     status: [],
-    party: [],
     minChallengeCount: null,
     maxChallengeCount: null,
     minDurationMinutes: null,
     maxDurationMinutes: null,
-    startDate: null,
-    endDate: null,
   };
 }
 
-export function emptyContext(): SessionSearchContext {
+/**
+ * Whether every filter is at its default value.
+ */
+export function isDefaultSessionFilters(
+  filters: SessionSearchFilters,
+): boolean {
+  return countActiveFilters(filters) === 0;
+}
+
+export function resetSessionFilters(
+  prev: SessionSearchContext,
+): SessionSearchContext {
   return {
+    ...prev,
     filters: emptyFilters(),
     pagination: {},
   };
@@ -90,26 +100,9 @@ function urlParamToRange(
  * URL query string.
  */
 export function filtersToUrlParams(filters: SessionSearchFilters): UrlParams {
-  let startTime;
-  if (filters.startDate !== null && filters.endDate !== null) {
-    const endDate = new Date(filters.endDate);
-    endDate.setDate(endDate.getDate() + 1);
-    startTime = `${filters.startDate.getTime()}..${endDate.getTime()}`;
-  } else if (filters.startDate !== null) {
-    startTime = `>=${filters.startDate.getTime()}`;
-  } else if (filters.endDate !== null) {
-    const endDate = new Date(filters.endDate);
-    endDate.setDate(endDate.getDate() + 1);
-    startTime = `<${endDate.getTime()}`;
-  }
-
   return {
-    party: filters.party,
-    scale: filters.scale,
+    ...sharedFiltersToUrlParams(filters),
     status: filters.status,
-    mode: filters.mode,
-    type: filters.type,
-    startTime,
     challengeCount: rangeToUrlParam(
       filters.minChallengeCount,
       filters.maxChallengeCount,
@@ -120,13 +113,6 @@ export function filtersToUrlParams(filters: SessionSearchFilters): UrlParams {
       { scale: 60, upperBoundStep: 1 },
     ),
   };
-}
-
-function numericList<T = number>(value: string): T[] {
-  return value
-    .split(',')
-    .map((n) => parseInt(n))
-    .filter((n) => !isNaN(n)) as T[];
 }
 
 /**
@@ -143,37 +129,13 @@ export function contextFromUrlParams(
   for (const [key, v] of Object.entries(params)) {
     const value = v as string;
 
+    if (applySharedFilterParam(context.filters, key, value)) {
+      continue;
+    }
+
     switch (key) {
-      case 'party':
-        context.filters.party = value.split(',').map((p) => p.trim());
-        break;
-
-      case 'mode':
-        context.filters.mode = numericList<ChallengeMode>(value);
-        break;
-
-      case 'scale':
-        context.filters.scale = numericList(value);
-        break;
-
       case 'status':
         context.filters.status = numericList<SessionStatus>(value);
-        break;
-
-      case 'type':
-        context.filters.type = numericList<ChallengeType>(value);
-        break;
-
-      case 'startTime':
-        if (value.startsWith('>=')) {
-          context.filters.startDate = new Date(parseInt(value.slice(2)));
-        } else if (value.startsWith('<')) {
-          context.filters.endDate = new Date(parseInt(value.slice(1)));
-        } else {
-          const [start, end] = value.split('..').map((time) => parseInt(time));
-          context.filters.startDate = new Date(start);
-          context.filters.endDate = new Date(end);
-        }
         break;
 
       case 'challengeCount': {
@@ -201,4 +163,24 @@ export function contextFromUrlParams(
   }
 
   return context;
+}
+
+export function countActiveFilters(filters: SessionSearchFilters): number {
+  let count = countSharedFilters(filters);
+  if (filters.status.length > 0) {
+    count++;
+  }
+  if (
+    filters.minChallengeCount !== null ||
+    filters.maxChallengeCount !== null
+  ) {
+    count++;
+  }
+  if (
+    filters.minDurationMinutes !== null ||
+    filters.maxDurationMinutes !== null
+  ) {
+    count++;
+  }
+  return count;
 }

--- a/web/app/search/sessions/filters.tsx
+++ b/web/app/search/sessions/filters.tsx
@@ -1,17 +1,22 @@
-import { ChallengeMode, ChallengeType, SessionStatus } from '@blert/common';
+import { SessionStatus } from '@blert/common';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
-import Checkbox from '@/components/checkbox';
-import DatePicker from '@/components/date-picker';
 import Input from '@/components/input';
-import PlayerSearch from '@/components/player-search';
-import TagList from '@/components/tag-list';
+
+import {
+  DateRangeFilter,
+  FilterField,
+  FilterRow,
+  FilterSection,
+  PartyFilter,
+  ScaleFilter,
+  StatusFilter,
+  TypeFilter,
+} from '../filter-controls';
 
 import { SessionSearchContext, SessionSearchFilters } from './context';
 
 import styles from './style.module.scss';
-
-const DATE_INPUT_WIDTH = 150;
 
 type FiltersProps = {
   context: SessionSearchContext;
@@ -19,46 +24,10 @@ type FiltersProps = {
   loading: boolean;
 };
 
-type ArrayFields<T> = Pick<
-  T,
-  { [K in keyof T]: T[K] extends any[] ? K : never }[keyof T]
->;
-
-function isTobMode(mode: ChallengeMode) {
-  return mode >= ChallengeMode.TOB_ENTRY && mode <= ChallengeMode.TOB_HARD;
-}
-
-function toggleTobMode(
-  filters: SessionSearchFilters,
-  mode: ChallengeMode,
-): SessionSearchFilters {
-  const remove = filters.mode.includes(mode);
-  if (remove) {
-    const tobModes = filters.mode.filter(isTobMode).length;
-    return {
-      ...filters,
-      mode: filters.mode.filter((v) => v !== mode),
-      type:
-        tobModes === 1
-          ? filters.type.filter((v) => v !== ChallengeType.TOB)
-          : filters.type,
-    };
-  }
-
-  return {
-    ...filters,
-    mode: [...filters.mode, mode],
-    type: filters.type.includes(ChallengeType.TOB)
-      ? filters.type
-      : [...filters.type, ChallengeType.TOB],
-  };
-}
-
-const NO_MODE_CHALLENGE_TYPES = new Set([
-  ChallengeType.COLOSSEUM,
-  ChallengeType.INFERNO,
-  ChallengeType.MOKHAIOTL,
-]);
+const STATUS_OPTIONS = [
+  { value: SessionStatus.COMPLETED, label: 'Completed' },
+  { value: SessionStatus.ACTIVE, label: 'Active' },
+];
 
 type RangeFilterProps = {
   label: string;
@@ -110,22 +79,19 @@ function RangeFilter({
     text: string,
   ) {
     if (e.key === 'Enter') {
+      e.preventDefault();
       commit(field, text);
-      (e.target as HTMLInputElement).blur();
     }
   }
 
   return (
-    <div className={styles.filterGroup}>
-      <div className={styles.filterLabel}>
-        <label>{label}</label>
-      </div>
+    <FilterField label={label}>
       <div className={styles.rangeContainer}>
         <Input
           disabled={loading}
           id={`filters-min-${id}`}
           label="Min"
-          labelBg="var(--blert-surface-dark)"
+          labelBg="var(--blert-filter-surface)"
           type="number"
           value={minText}
           width={inputWidth}
@@ -138,7 +104,7 @@ function RangeFilter({
           disabled={loading}
           id={`filters-max-${id}`}
           label="Max"
-          labelBg="var(--blert-surface-dark)"
+          labelBg="var(--blert-filter-surface)"
           type="number"
           value={maxText}
           width={inputWidth}
@@ -147,7 +113,7 @@ function RangeFilter({
           onKeyDown={(e) => handleKeyDown(e, maxField, maxText)}
         />
       </div>
-    </div>
+    </FilterField>
   );
 }
 
@@ -156,297 +122,73 @@ export default function Filters({
   setContext,
   loading,
 }: FiltersProps) {
-  function toggle<
-    K extends keyof ArrayFields<SessionSearchFilters>,
-    V = SessionSearchFilters[K][number],
-  >(key: K, value: V) {
+  function updateFilters(update: Partial<SessionSearchFilters>) {
     setContext((prev) => ({
       ...prev,
-      filters: {
-        ...prev.filters,
-        [key]: (prev.filters[key] as V[]).includes(value)
-          ? prev.filters[key].filter((v) => v !== value)
-          : [...prev.filters[key], value],
-      },
+      filters: { ...prev.filters, ...update },
       pagination: {},
     }));
   }
 
-  function checkbox<
-    K extends keyof ArrayFields<SessionSearchFilters>,
-    V = SessionSearchFilters[K][number],
-  >(key: K, value: V, label: string, disabled: boolean = false) {
-    const checked = (context.filters[key] as V[]).includes(value);
-    const isDisabled = disabled && !checked;
-
-    return (
-      <Checkbox
-        checked={checked}
-        className={styles.checkbox}
-        disabled={loading || isDisabled}
-        onChange={() => toggle(key, value)}
-        label={label}
-        simple
-      />
-    );
-  }
-
-  function toggleNoMode(challengeType: ChallengeType) {
-    return setContext((prev) => {
-      const remove = prev.filters.type.includes(challengeType);
-      if (remove) {
-        const keepNoMode = prev.filters.type.some(
-          (t) => t !== challengeType && NO_MODE_CHALLENGE_TYPES.has(t),
-        );
-        return {
-          ...prev,
-          filters: {
-            ...prev.filters,
-            type: prev.filters.type.filter((t) => t !== challengeType),
-            mode: keepNoMode
-              ? prev.filters.mode
-              : prev.filters.mode.filter((m) => m !== ChallengeMode.NO_MODE),
-          },
-          pagination: {},
-        };
-      }
-
-      const hasNoMode = prev.filters.mode.includes(ChallengeMode.NO_MODE);
-      return {
-        ...prev,
-        filters: {
-          ...prev.filters,
-          type: [...prev.filters.type, challengeType],
-          mode: hasNoMode
-            ? prev.filters.mode
-            : [...prev.filters.mode, ChallengeMode.NO_MODE],
-        },
-        pagination: {},
-      };
-    });
-  }
-
-  function noModeChallengeCheckbox(
-    challengeType: ChallengeType,
-    label: string,
-  ) {
-    return (
-      <Checkbox
-        checked={context.filters.type.includes(challengeType)}
-        className={styles.checkbox}
-        disabled={loading}
-        onChange={() => toggleNoMode(challengeType)}
-        label={label}
-        simple
-      />
-    );
-  }
-  const hasTeamChallenges =
-    context.filters.type.length === 0 ||
-    context.filters.type.includes(ChallengeType.TOB);
-
   return (
-    <div className={styles.filtersContainer}>
-      <div className={styles.filterSection}>
-        <div className={styles.filterRow}>
-          {/* Type filter */}
-          <div className={styles.filterGroup}>
-            <div className={styles.filterLabel}>
-              <label>Type</label>
-            </div>
-            <div className={styles.checkboxList}>
-              <Checkbox
-                checked={
-                  context.filters.type.includes(ChallengeType.TOB) &&
-                  context.filters.mode.includes(ChallengeMode.TOB_REGULAR)
-                }
-                className={styles.checkbox}
-                disabled={loading}
-                onChange={() =>
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: toggleTobMode(
-                      prev.filters,
-                      ChallengeMode.TOB_REGULAR,
-                    ),
-                    pagination: {},
-                  }))
-                }
-                label="ToB Regular"
-                simple
-              />
-              <Checkbox
-                checked={
-                  context.filters.type.includes(ChallengeType.TOB) &&
-                  context.filters.mode.includes(ChallengeMode.TOB_HARD)
-                }
-                className={styles.checkbox}
-                disabled={loading}
-                onChange={() =>
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: toggleTobMode(
-                      prev.filters,
-                      ChallengeMode.TOB_HARD,
-                    ),
-                    pagination: {},
-                  }))
-                }
-                label="ToB Hard"
-                simple
-              />
-              {noModeChallengeCheckbox(ChallengeType.INFERNO, 'Inferno')}
-              {noModeChallengeCheckbox(ChallengeType.COLOSSEUM, 'Colosseum')}
-              {noModeChallengeCheckbox(ChallengeType.MOKHAIOTL, 'Mokhaiotl')}
-            </div>
-          </div>
+    <div className={styles.filters}>
+      <FilterRow>
+        <TypeFilter
+          type={context.filters.type}
+          mode={context.filters.mode}
+          onChange={(type, mode) => updateFilters({ type, mode })}
+          disabled={loading}
+        />
+        <ScaleFilter
+          scale={context.filters.scale}
+          type={context.filters.type}
+          onChange={(scale) => updateFilters({ scale })}
+          disabled={loading}
+        />
+      </FilterRow>
 
-          {/* Status filter */}
-          <div className={styles.filterGroup}>
-            <div className={styles.filterLabel}>
-              <label>Status</label>
-            </div>
-            <div className={styles.checkboxList}>
-              {checkbox('status', SessionStatus.COMPLETED, 'Completed')}
-              {checkbox('status', SessionStatus.ACTIVE, 'Active')}
-            </div>
-          </div>
+      <StatusFilter
+        status={context.filters.status}
+        options={STATUS_OPTIONS}
+        onChange={(status) => updateFilters({ status })}
+        disabled={loading}
+      />
 
-          {/* Scale filter */}
-          <div className={styles.filterGroup}>
-            <div className={styles.filterLabel}>
-              <label>Scale</label>
-            </div>
-            <div className={styles.checkboxList}>
-              {checkbox('scale', 1, 'Solo')}
-              {checkbox('scale', 2, 'Duo', !hasTeamChallenges)}
-              {checkbox('scale', 3, 'Trio', !hasTeamChallenges)}
-              {checkbox('scale', 4, '4s', !hasTeamChallenges)}
-              {checkbox('scale', 5, '5s', !hasTeamChallenges)}
-            </div>
-          </div>
+      <DateRangeFilter
+        startDate={context.filters.startDate}
+        endDate={context.filters.endDate}
+        onChange={(startDate, endDate) => updateFilters({ startDate, endDate })}
+        disabled={loading}
+      />
 
-          <RangeFilter
-            label="Challenges"
-            id="challenge-count"
-            minValue={context.filters.minChallengeCount}
-            maxValue={context.filters.maxChallengeCount}
-            minField="minChallengeCount"
-            maxField="maxChallengeCount"
-            setContext={setContext}
-            loading={loading}
-          />
-        </div>
+      <PartyFilter
+        party={context.filters.party}
+        onChange={(party) => updateFilters({ party })}
+        disabled={loading}
+      />
 
-        <div className={styles.filterRow}>
-          {/* Party filter */}
-          <div className={styles.filterGroup}>
-            <div className={styles.filterLabel}>
-              <label>Party</label>
-            </div>
-            <div className={styles.playerSearchContainer}>
-              <PlayerSearch
-                disabled={loading || context.filters.party.length >= 5}
-                label="Enter username"
-                labelBg="var(--blert-surface-dark)"
-                id="filters-player"
-                onSelection={(username) =>
-                  setContext((prev) => {
-                    if (prev.filters.party.includes(username)) {
-                      return prev;
-                    }
-                    return {
-                      ...prev,
-                      filters: {
-                        ...prev.filters,
-                        party: [...prev.filters.party, username],
-                      },
-                      pagination: {},
-                    };
-                  })
-                }
-              />
-              <TagList
-                onRemove={(username) =>
-                  setContext((prev) => ({
-                    ...prev,
-                    filters: {
-                      ...prev.filters,
-                      party: prev.filters.party.filter((u) => u !== username),
-                    },
-                    pagination: {},
-                  }))
-                }
-                tags={context.filters.party}
-                width={260}
-              />
-            </div>
-          </div>
-
-          {/* Date filter */}
-          <div className={styles.filterGroup}>
-            <div className={styles.filterLabel}>
-              <label>Date</label>
-            </div>
-            <div className={styles.dateContainer}>
-              <div className={styles.dateField}>
-                <span className={styles.dateFieldLabel}>From</span>
-                <DatePicker
-                  disabled={loading}
-                  icon="fas fa-calendar-alt"
-                  isClearable
-                  maxDate={context.filters.endDate ?? new Date()}
-                  placeholderText="Any"
-                  popperPlacement="bottom"
-                  selected={context.filters.startDate}
-                  onChange={(date) =>
-                    setContext((prev) => ({
-                      ...prev,
-                      filters: { ...prev.filters, startDate: date },
-                      pagination: {},
-                    }))
-                  }
-                  showIcon
-                  width={DATE_INPUT_WIDTH}
-                />
-              </div>
-              <span className={styles.dateFieldLabel}>&ndash;</span>
-              <div className={styles.dateField}>
-                <DatePicker
-                  disabled={loading}
-                  icon="fas fa-calendar-alt"
-                  isClearable
-                  maxDate={new Date()}
-                  minDate={context.filters.startDate ?? undefined}
-                  placeholderText="Any"
-                  popperPlacement="bottom"
-                  selected={context.filters.endDate}
-                  onChange={(date) =>
-                    setContext((prev) => ({
-                      ...prev,
-                      filters: { ...prev.filters, endDate: date },
-                      pagination: {},
-                    }))
-                  }
-                  showIcon
-                  width={DATE_INPUT_WIDTH}
-                />
-              </div>
-            </div>
-          </div>
-
-          <RangeFilter
-            label="Duration (mins)"
-            id="duration"
-            minValue={context.filters.minDurationMinutes}
-            maxValue={context.filters.maxDurationMinutes}
-            minField="minDurationMinutes"
-            maxField="maxDurationMinutes"
-            setContext={setContext}
-            loading={loading}
-          />
-        </div>
-      </div>
+      <FilterSection title="Session metrics">
+        <RangeFilter
+          label="Challenge count"
+          id="challenge-count"
+          minValue={context.filters.minChallengeCount}
+          maxValue={context.filters.maxChallengeCount}
+          minField="minChallengeCount"
+          maxField="maxChallengeCount"
+          setContext={setContext}
+          loading={loading}
+        />
+        <RangeFilter
+          label="Duration (mins)"
+          id="duration"
+          minValue={context.filters.minDurationMinutes}
+          maxValue={context.filters.maxDurationMinutes}
+          minField="minDurationMinutes"
+          maxField="maxDurationMinutes"
+          setContext={setContext}
+          loading={loading}
+        />
+      </FilterSection>
     </div>
   );
 }

--- a/web/app/search/sessions/session-search.tsx
+++ b/web/app/search/sessions/session-search.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { SessionWithChallenges } from '@/actions/challenge';
 import Card from '@/components/card';
@@ -11,10 +11,14 @@ import { queryString } from '@/utils/url';
 import {
   SessionSearchContext,
   contextFromUrlParams,
-  emptyContext,
+  countActiveFilters,
   filtersToUrlParams,
+  isDefaultSessionFilters,
+  resetSessionFilters,
 } from './context';
 import Filters from './filters';
+import FilterPanel from '../filter-panel';
+import { useFilterPanel } from '../filter-panel-context';
 
 import styles from './style.module.scss';
 
@@ -108,23 +112,16 @@ export default function SessionSearch({
   );
   const [stats, setStats] = useState<FilteredStats>(initialStats);
   const [remaining, setRemaining] = useState(initialRemaining);
+  const lastLoadedQuery = useRef<string | null>(null);
+
+  const { setActiveCount } = useFilterPanel();
+  useEffect(() => {
+    setActiveCount(countActiveFilters(context.filters));
+  }, [context.filters, setActiveCount]);
 
   const offset = stats.count - remaining;
   const page = Math.ceil(offset / RESULTS_PER_PAGE);
   const totalPages = Math.ceil(stats.count / RESULTS_PER_PAGE);
-
-  const filtersEmpty =
-    context.filters.type.length === 0 &&
-    context.filters.mode.length === 0 &&
-    context.filters.scale.length === 0 &&
-    context.filters.status.length === 0 &&
-    context.filters.party.length === 0 &&
-    context.filters.minChallengeCount === null &&
-    context.filters.maxChallengeCount === null &&
-    context.filters.minDurationMinutes === null &&
-    context.filters.maxDurationMinutes === null &&
-    context.filters.startDate === null &&
-    context.filters.endDate === null;
 
   const errorForStatus = (status?: number): LoadErrorState => {
     if (status === 429) {
@@ -149,6 +146,11 @@ export default function SessionSearch({
 
     const updatedUrl = `/search/sessions?${queryParams}`;
     window.history.replaceState(null, '', updatedUrl);
+
+    if (queryParams === lastLoadedQuery.current) {
+      return;
+    }
+    lastLoadedQuery.current = queryParams;
 
     setLoading(true);
     setLoadError(null);
@@ -193,6 +195,7 @@ export default function SessionSearch({
       setSessions(parsed);
       setStats({ count: totalCount });
     } catch (error) {
+      lastLoadedQuery.current = null;
       if (error instanceof LoadSessionError) {
         setLoadError(errorForStatus(error.status));
         return;
@@ -202,7 +205,6 @@ export default function SessionSearch({
         message: 'Unable to load sessions right now.',
         details: 'Please try again later.',
       });
-      return;
     } finally {
       setLoading(false);
     }
@@ -254,25 +256,7 @@ export default function SessionSearch({
   }, [context, sessions, loading, loadError, page, totalPages]);
 
   return (
-    <div className={styles.sessionSearch}>
-      <Card
-        className={styles.filtersCard}
-        fixed
-        header={{
-          title: <span className={styles.filtersTitle}>Filters</span>,
-          action: (
-            <button
-              className={styles.clearAllButton}
-              disabled={loading || filtersEmpty}
-              onClick={() => setContext(emptyContext())}
-            >
-              Clear all
-            </button>
-          ),
-        }}
-      >
-        <Filters context={context} setContext={setContext} loading={loading} />
-      </Card>
+    <>
       <Card
         className={styles.resultsCard}
         fixed
@@ -343,6 +327,12 @@ export default function SessionSearch({
           </div>
         )}
       </Card>
-    </div>
+      <FilterPanel
+        onReset={() => setContext(resetSessionFilters)}
+        canReset={!isDefaultSessionFilters(context.filters)}
+      >
+        <Filters context={context} setContext={setContext} loading={loading} />
+      </FilterPanel>
+    </>
   );
 }

--- a/web/app/search/sessions/style.module.scss
+++ b/web/app/search/sessions/style.module.scss
@@ -1,139 +1,9 @@
 @use '@/mixins.scss' as *;
 
-.sessionSearch {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  gap: 16px;
-}
-
-.header {
-  margin: 0.5em 0;
-  text-align: center;
-  max-width: 600px;
-
-  h1 {
-    font-size: 1.5em;
-    margin: 0;
-  }
-
-  p {
-    margin-bottom: 0;
-    color: var(--blert-font-color-secondary);
-  }
-}
-
-.filtersCard {
-  width: 100%;
-  max-width: 1200px;
-
-  .filtersTitle {
-    font-size: 1.2rem;
-    font-weight: 500;
-  }
-}
-
-.clearAllButton {
-  font-size: 0.85rem;
-  color: var(--blert-purple);
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  transition: all 0.2s ease;
-
-  &:hover:not(:disabled) {
-    background: rgba(var(--blert-purple-base), 0.1);
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
-.filtersContainer {
+.filters {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-}
-
-.filterSection {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
-  background: var(--blert-surface-dark);
-  border-radius: 8px;
-  border: 1px solid var(--blert-surface-light);
-}
-
-.filterRow {
-  display: flex;
-  justify-content: space-between;
-  gap: 1.5rem 2rem;
-
-  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
-    flex-wrap: wrap;
-    gap: 1.25rem 2rem;
-  }
-}
-
-.filterGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.filterLabel {
-  label {
-    font-size: 0.85rem;
-    font-weight: 600;
-    color: var(--blert-font-color-primary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-}
-
-.checkboxList {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-
-  .checkbox {
-    padding: 0.2rem 0;
-  }
-}
-
-.playerSearchContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  min-width: 260px;
-
-  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
-    min-width: 100%;
-  }
-}
-
-.dateContainer {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding-top: 10px;
-}
-
-.dateField {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.dateFieldLabel {
-  font-size: 0.8rem;
-  color: var(--blert-font-color-secondary);
 }
 
 .rangeContainer {
@@ -158,8 +28,9 @@
 }
 
 .resultsCard {
+  flex: 1;
+  min-width: 0;
   width: 100%;
-  max-width: 1200px;
 
   .resultsTitle {
     display: flex;

--- a/web/app/search/shared-filters.ts
+++ b/web/app/search/shared-filters.ts
@@ -1,0 +1,130 @@
+import { ChallengeMode, ChallengeType } from '@blert/common';
+
+import { UrlParams } from '@/utils/url';
+
+export type SharedFilters = {
+  party: string[];
+  mode: ChallengeMode[];
+  scale: number[];
+  type: ChallengeType[];
+  startDate: Date | null;
+  endDate: Date | null;
+};
+
+export const SHARED_FILTER_PARAMS = [
+  'party',
+  'mode',
+  'scale',
+  'type',
+  'startTime',
+] as const;
+
+export function emptySharedFilters(): SharedFilters {
+  return {
+    party: [],
+    mode: [],
+    scale: [],
+    type: [],
+    startDate: null,
+    endDate: null,
+  };
+}
+
+export function numericList<T = number>(value: string): T[] {
+  return value
+    .split(',')
+    .map((n) => parseInt(n))
+    .filter((n) => !isNaN(n)) as T[];
+}
+
+/** Count the number of non-empty shared filter categories. */
+export function countSharedFilters(filters: SharedFilters): number {
+  let count = 0;
+  if (filters.party.length > 0) {
+    count++;
+  }
+  if (filters.type.length > 0 || filters.mode.length > 0) {
+    count++;
+  }
+  if (filters.scale.length > 0) {
+    count++;
+  }
+  if (filters.startDate !== null || filters.endDate !== null) {
+    count++;
+  }
+  return count;
+}
+
+export function sharedFiltersToUrlParams(filters: SharedFilters): UrlParams {
+  let startTime: string | undefined;
+  if (filters.startDate !== null && filters.endDate !== null) {
+    const endDate = new Date(filters.endDate);
+    endDate.setDate(endDate.getDate() + 1);
+    startTime = `${filters.startDate.getTime()}..${endDate.getTime()}`;
+  } else if (filters.startDate !== null) {
+    startTime = `>=${filters.startDate.getTime()}`;
+  } else if (filters.endDate !== null) {
+    const endDate = new Date(filters.endDate);
+    endDate.setDate(endDate.getDate() + 1);
+    startTime = `<${endDate.getTime()}`;
+  }
+
+  return {
+    party: filters.party,
+    scale: filters.scale,
+    mode: filters.mode,
+    type: filters.type,
+    startTime,
+  };
+}
+
+export function applySharedFilterParam(
+  filters: SharedFilters,
+  key: string,
+  value: string,
+): boolean {
+  switch (key) {
+    case 'party':
+      filters.party = value.split(',').map((p) => p.trim());
+      return true;
+    case 'mode':
+      filters.mode = numericList<ChallengeMode>(value);
+      return true;
+    case 'scale':
+      filters.scale = numericList(value);
+      return true;
+    case 'type':
+      filters.type = numericList<ChallengeType>(value);
+      return true;
+    case 'startTime':
+      if (value.startsWith('>=')) {
+        filters.startDate = new Date(parseInt(value.slice(2)));
+      } else if (value.startsWith('<')) {
+        filters.endDate = new Date(parseInt(value.slice(1)));
+      } else {
+        const [start, end] = value.split('..').map((time) => parseInt(time));
+        filters.startDate = new Date(start);
+        filters.endDate = new Date(end);
+      }
+      return true;
+  }
+  return false;
+}
+
+export function buildEntityHref(
+  targetPath: string,
+  currentParams: URLSearchParams | null,
+): string {
+  if (currentParams === null) {
+    return targetPath;
+  }
+  const sharedParams = new URLSearchParams();
+  for (const key of SHARED_FILTER_PARAMS) {
+    const values = currentParams.getAll(key);
+    for (const v of values) {
+      sharedParams.append(key, v);
+    }
+  }
+  const queryString = sharedParams.toString();
+  return queryString ? `${targetPath}?${queryString}` : targetPath;
+}


### PR DESCRIPTION
Rebuilds the search UI for both challenges and sessions into a shared layout with a slim topbar to select what to search, and a collapsible filters sidebar which becomes a modal on mobile. A subset of filters is shared between the two pages and persisted when navigating from one to the other.

This reclaims a lot of screen space for the search results, which were previously pushed down the page below the headers and filters sections, while also unifying code, simplifying future additions.