### PR TITLE
web: Allow optional players in gear setups

### DIFF
--- a/web/app/actions/setup.ts
+++ b/web/app/actions/setup.ts
@@ -9,7 +9,7 @@ import {
 import { randomBytes } from 'crypto';
 import postgres from 'postgres';
 
-import { GearSetup } from '@/setups/setup';
+import { GearSetup, setupScale } from '@/setups/setup';
 
 import logger from '@/utils/log';
 import { withServerAction } from '@/utils/metrics';
@@ -127,7 +127,7 @@ export async function newGearSetup(
     }
     name = overrideName ?? `Copy of ${template.title}`;
     challengeType = template.challenge;
-    scale = template.players.length;
+    scale = setupScale(template);
     hasDraft = true;
 
     template = {
@@ -137,7 +137,7 @@ export async function newGearSetup(
   } else if (template !== undefined) {
     name = overrideName ?? template.title;
     challengeType = template.challenge;
-    scale = template.players.length;
+    scale = setupScale(template);
     hasDraft = true;
   }
 
@@ -442,7 +442,7 @@ export async function saveSetupDraft(
       // If the setup has not yet been published, change its name and scale to
       // match the latest draft.
       updates.name = setup.title;
-      updates.scale = setup.players.length;
+      updates.scale = setupScale(setup);
     }
 
     await sql`
@@ -528,7 +528,7 @@ export async function publishSetupRevision(
         SET
           name = ${setup.title},
           challenge_type = ${setup.challenge},
-          scale = ${setup.players.length},
+          scale = ${setupScale(setup)},
           latest_revision_id = ${revision.id},
           state = ${targetState},
           has_draft = FALSE,

--- a/web/app/components/markdown-renderer/markdown-renderer.tsx
+++ b/web/app/components/markdown-renderer/markdown-renderer.tsx
@@ -5,7 +5,14 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
-import { ComponentPropsWithoutRef, useState, useEffect } from 'react';
+import {
+  Children,
+  ComponentPropsWithoutRef,
+  Fragment,
+  isValidElement,
+  useState,
+  useEffect,
+} from 'react';
 import { createPortal } from 'react-dom';
 
 import 'katex/dist/katex.min.css';
@@ -325,6 +332,19 @@ export default function MarkdownRenderer({
                 return <input type="checkbox" disabled {...props} />;
               }
               return <input type={type} {...props} />;
+            },
+            p: ({ children, node: _node, ...props }) => {
+              const meaningful = Children.toArray(children).filter(
+                (c) => !(typeof c === 'string' && c.trim() === ''),
+              );
+              if (
+                meaningful.length === 1 &&
+                isValidElement(meaningful[0]) &&
+                meaningful[0].type === VideoEmbedComponent
+              ) {
+                return <Fragment>{meaningful[0]}</Fragment>;
+              }
+              return <p {...props}>{children}</p>;
             },
             h1: ({ children, node: _node, ...props }) => (
               <h3 {...props}>{children}</h3>

--- a/web/app/setups/[id]/edit/setup-creator.tsx
+++ b/web/app/setups/[id]/edit/setup-creator.tsx
@@ -35,7 +35,12 @@ import ItemCounts from '../../item-counts';
 import { setupLocalStorage } from '../../local-storage';
 import { ItemSelector } from './item-selector';
 import PlayerList from '../../player-list';
-import { GearSetup, hasAllItems, newGearSetupPlayer } from '../../setup';
+import {
+  GearSetup,
+  hasAllItems,
+  newGearSetupPlayer,
+  setupScale,
+} from '../../setup';
 
 import setupStyles from '../../style.module.scss';
 import styles from './style.module.scss';
@@ -845,6 +850,29 @@ function PublishModal({
               </div>
             </>
           )}
+        </div>
+
+        <div className={styles.setupPreview}>
+          <div className={styles.previewLabel}>Setup to be published:</div>
+          <div className={styles.previewCard}>
+            <div className={styles.previewIcon}>
+              <i className="fas fa-shield" />
+            </div>
+            <div className={styles.previewInfo}>
+              <span className={styles.previewName}>{gearSetup.title}</span>
+              <div className={styles.previewMeta}>
+                <span>
+                  <i className="fas fa-shield" />
+                  {challengeName(gearSetup.challenge)}
+                </span>
+                <span>
+                  <i className="fas fa-users" />
+                  {setupScale(gearSetup)} player
+                  {setupScale(gearSetup) !== 1 ? 's' : ''}
+                </span>
+              </div>
+            </div>
+          </div>
         </div>
 
         {publishIssues.length > 0 && (

--- a/web/app/setups/item-counts.tsx
+++ b/web/app/setups/item-counts.tsx
@@ -22,6 +22,9 @@ export default function ItemCounts({ setup, selectedItemId }: ItemCountsProps) {
   const counts = new Map<number, number>();
 
   for (const player of setup.players) {
+    if (player.optional) {
+      continue;
+    }
     for (const container of [
       Container.INVENTORY,
       Container.EQUIPMENT,

--- a/web/app/setups/local-storage.ts
+++ b/web/app/setups/local-storage.ts
@@ -1,6 +1,6 @@
 import { SetupListItem, SetupMetadata } from '@/actions/setup';
 
-import { GearSetup } from './setup';
+import { GearSetup, setupScale } from './setup';
 
 class SetupLocalStorage {
   private static readonly PREFIX = 'blert:setup';
@@ -37,7 +37,7 @@ class SetupLocalStorage {
       publicId: id,
       name: setup.title,
       challengeType: setup.challenge,
-      scale: setup.players.length,
+      scale: setupScale(setup),
       authorId: 0,
       author: '',
       state: 'draft',

--- a/web/app/setups/player.tsx
+++ b/web/app/setups/player.tsx
@@ -7,6 +7,7 @@ import { useCallback, useContext, useRef, useState } from 'react';
 import EditableTextField from '@/components/editable-text-field';
 import Menu, { MenuItem } from '@/components/menu';
 import { useToast } from '@/components/toast';
+import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
 
 import { EditingContext, SetupEditingContext } from './editing-context';
 import { getSlotMetadata, SLOT_SIZE_PX } from './container-grid';
@@ -20,6 +21,7 @@ import {
   QUIVER_SLOT_INDEX,
   Spellbook,
   newGearSetupPlayer,
+  setupScale,
   spellbookName,
 } from './setup';
 import { Slot } from './slot';
@@ -79,7 +81,19 @@ export function Player({ index, player }: PlayerProps) {
   };
 
   const isHighlighted = highlightedPlayerIndex === index;
-  const className = `${styles.player}${isHighlighted ? ` ${styles.highlighted}` : ''}`;
+  const isOptional = player.optional === true;
+  const isLastRequired =
+    !isOptional &&
+    editingContext !== null &&
+    setupScale(editingContext.setup) <= 1;
+  const classNames = [styles.player];
+  if (isHighlighted) {
+    classNames.push(styles.highlighted);
+  }
+  if (isOptional) {
+    classNames.push(styles.optional);
+  }
+  const className = classNames.join(' ');
 
   const handleExport = useCallback(
     (format: ExportFormat) => {
@@ -109,7 +123,10 @@ export function Player({ index, player }: PlayerProps) {
     try {
       const text = await clipboard.readText();
       const setup = importSetup(text);
-      editingContext.updatePlayer(index, (_) => setup);
+      editingContext.updatePlayer(index, (prev) => ({
+        ...setup,
+        optional: prev.optional,
+      }));
     } catch (error: unknown) {
       if (error instanceof TranslateError) {
         sendToast(
@@ -143,7 +160,7 @@ export function Player({ index, player }: PlayerProps) {
           />
         ) : (
           <h2 className={styles.name}>
-            {player.name}
+            <span className={styles.nameText}>{player.name}</span>
             <div className={styles.playerActions}>
               <button
                 className={styles.shareButton}
@@ -273,6 +290,16 @@ export function Player({ index, player }: PlayerProps) {
           readonly={editingContext === null}
         />
       </div>
+      {isOptional && editingContext === null && (
+        <span
+          className={styles.optionalIndicator}
+          data-tooltip-id={GLOBAL_TOOLTIP_ID}
+          data-tooltip-content="Situational setup"
+        >
+          <i className="fas fa-user-slash" />
+          Optional
+        </span>
+      )}
       {editingContext !== null && (
         <div className={styles.editActions}>
           <button className={styles.import} onClick={() => void handleImport()}>
@@ -280,7 +307,37 @@ export function Player({ index, player }: PlayerProps) {
             Import from clipboard
           </button>
           <button
+            type="button"
+            className={`${styles.optionalToggle} ${isOptional ? styles.active : ''}`}
+            disabled={isLastRequired}
+            onClick={() =>
+              editingContext.updatePlayer(index, (prev) => ({
+                ...prev,
+                optional: prev.optional ? undefined : true,
+              }))
+            }
+            aria-pressed={isOptional}
+            data-tooltip-id={GLOBAL_TOOLTIP_ID}
+            data-tooltip-content={
+              isLastRequired
+                ? 'Add another player before marking this one as optional'
+                : isOptional
+                  ? 'Include this setup in the required items summary'
+                  : 'Mark as a situational setup. Its items will be excluded from the required items summary.'
+            }
+          >
+            <i className="fas fa-user-slash" />
+            <span>{isOptional ? 'Mark required' : 'Mark optional'}</span>
+          </button>
+          <button
             className={styles.remove}
+            disabled={isLastRequired}
+            data-tooltip-id={isLastRequired ? GLOBAL_TOOLTIP_ID : undefined}
+            data-tooltip-content={
+              isLastRequired
+                ? 'Add another player before removing the last required one'
+                : undefined
+            }
             onClick={() =>
               editingContext.update((prev) => {
                 let newPlayers;

--- a/web/app/setups/setup.ts
+++ b/web/app/setups/setup.ts
@@ -19,6 +19,7 @@ export type GearSetupPlayer = {
   equipment: PlayerEquipment;
   pouch: PlayerPouch;
   spellbook: Spellbook;
+  optional?: boolean;
 };
 
 export type SlotContainer = {
@@ -80,6 +81,10 @@ export function getContainer(
     case Container.POUCH:
       return player.pouch.slots;
   }
+}
+
+export function setupScale(setup: GearSetup): number {
+  return setup.players.filter((p) => !p.optional).length;
 }
 
 export const NEW_GEAR_SETUP: GearSetup = {

--- a/web/app/setups/style.module.scss
+++ b/web/app/setups/style.module.scss
@@ -123,12 +123,34 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 
   .header {
     display: flex;
     align-items: center;
     gap: 8px;
     margin-bottom: 0.5em;
+    max-width: 100%;
+  }
+
+  .optionalIndicator {
+    position: absolute;
+    left: 6px;
+    bottom: 6px;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    color: rgba(var(--blert-blue-base), 0.7);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    pointer-events: auto;
+    cursor: help;
+
+    i {
+      font-size: 11px;
+    }
   }
 
   .name {
@@ -138,6 +160,15 @@
     font-size: 18px;
     margin: 0;
     position: relative;
+    min-width: 0;
+    max-width: 100%;
+
+    .nameText {
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
     .playerActions {
       position: absolute;
@@ -209,13 +240,19 @@
         margin-right: 8px;
       }
 
-      &:hover {
+      &:not(:disabled):hover {
         cursor: pointer;
         filter: brightness(1.4);
 
         i {
           transform: scale(1.1);
         }
+      }
+
+      &:disabled {
+        color: var(--blert-font-color-secondary);
+        opacity: 0.6;
+        cursor: not-allowed;
       }
     }
 
@@ -225,6 +262,37 @@
 
     .remove {
       color: var(--blert-red);
+    }
+
+    .optionalToggle {
+      display: inline-flex;
+      align-items: center;
+      color: var(--blert-purple);
+      border-radius: 4px;
+
+      &.active {
+        color: var(--blert-blue);
+        background: rgba(var(--blert-blue-base), 0.12);
+      }
+    }
+  }
+
+  &.optional {
+    background: rgba(var(--blert-blue-base), 0.03);
+    border-radius: 8px;
+    opacity: 0.8;
+
+    .slotContainer {
+      opacity: 0.8;
+    }
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border: 2px dashed rgba(var(--blert-blue-base), 0.4);
+      border-radius: 8px;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
Allows marking a setup player as optional/situational to showcase alternative setups. Their items don't get counted in the total.

Closes #252.