### PR TITLE
challenge: Fix reconnection logic

### DIFF
--- a/challenge-server/api.ts
+++ b/challenge-server/api.ts
@@ -169,6 +169,7 @@ async function challengeApiHandler(
 type NewChallengeRequest = {
   userId: number;
   clientId: number;
+  sessionToken: string;
   type: ChallengeType;
   mode: ChallengeMode;
   stage: Stage;
@@ -183,11 +184,17 @@ async function newChallenge(req: Request, res: Response): Promise<void> {
     req,
     res,
     '/challenges/new',
-    { userId: request.userId, clientId: request.clientId, action: 'new' },
+    {
+      userId: request.userId,
+      clientId: request.clientId,
+      sessionToken: request.sessionToken,
+      action: 'new',
+    },
     async () => {
       const result = await res.locals.challengeManager.createOrJoin(
         request.userId,
         request.clientId,
+        request.sessionToken,
         request.type,
         request.mode,
         request.stage,
@@ -202,6 +209,7 @@ async function newChallenge(req: Request, res: Response): Promise<void> {
 type UpdateChallengeRequest = {
   userId: number;
   clientId: number;
+  sessionToken: string;
   update: ChallengeUpdate;
 };
 
@@ -217,9 +225,12 @@ async function updateChallenge(req: Request, res: Response): Promise<void> {
       challengeUuid: challengeId,
       userId: request.userId,
       clientId: request.clientId,
+      sessionToken: request.sessionToken,
       action: 'update',
     },
     async () => {
+      // The session token is not needed here as challenge state is a property
+      // of OSRS, not Blert's system.
       const result = await res.locals.challengeManager.update(
         challengeId,
         request.userId,
@@ -238,6 +249,7 @@ async function updateChallenge(req: Request, res: Response): Promise<void> {
 type FinishChallengeRequest = {
   userId: number;
   clientId: number;
+  sessionToken: string;
   times: ReportedTimes | null;
   soft: boolean;
 };
@@ -254,9 +266,12 @@ async function finishChallenge(req: Request, res: Response): Promise<void> {
       challengeUuid: challengeId,
       userId: request.userId,
       clientId: request.clientId,
+      sessionToken: request.sessionToken,
       action: 'finish',
     },
     async () => {
+      // The session token is not needed here as challenge state is a property
+      // of OSRS, not Blert's system.
       await res.locals.challengeManager.finish(
         challengeId,
         request.userId,
@@ -272,6 +287,7 @@ async function finishChallenge(req: Request, res: Response): Promise<void> {
 type JoinChallengeRequest = {
   userId: number;
   clientId: number;
+  sessionToken: string;
   recordingType: RecordingType;
 };
 
@@ -287,6 +303,7 @@ async function joinChallenge(req: Request, res: Response): Promise<void> {
       challengeUuid: challengeId,
       userId: request.userId,
       clientId: request.clientId,
+      sessionToken: request.sessionToken,
       action: 'join',
     },
     async () => {
@@ -294,6 +311,7 @@ async function joinChallenge(req: Request, res: Response): Promise<void> {
         challengeId,
         request.userId,
         request.clientId,
+        request.sessionToken,
         request.recordingType,
       );
       res.json(status);

--- a/challenge-server/challenge-manager.ts
+++ b/challenge-server/challenge-manager.ts
@@ -69,6 +69,7 @@ import {
   LifecycleState,
   RedisClient,
   TimeoutState,
+  TransactionClient,
 } from './redis-client';
 import { timeOperation } from './time';
 import { DiscordClient, RecordsHandler, WebhookService } from './webhooks';
@@ -177,16 +178,33 @@ type StartActionDecision =
       response: ChallengeStatusResponse;
     };
 
-function createChallengeClient(
+async function createChallengeClient(
+  txn: TransactionClient,
+  challengeUuid: string,
   userId: number,
   clientId: number,
+  sessionToken: string,
   recordingType: RecordingType,
   stage: Stage,
   stageAttempt: number | null = null,
-): ChallengeClient {
+): Promise<ChallengeClient> {
+  const existing = await txn.getChallengeClient(challengeUuid, clientId);
+  if (existing !== null) {
+    // If rejoining, maintain the last completed stage.
+    return {
+      ...existing,
+      stage,
+      stageAttempt,
+      stageStatus: StageStatus.ENTERED,
+      sessionToken,
+      active: true,
+    };
+  }
+
   return {
     userId,
     clientId,
+    sessionToken,
     type: recordingType,
     active: true,
     stage,
@@ -281,6 +299,7 @@ export default class ChallengeManager {
    *
    * @param userId ID of the user.
    * @param clientId ID of the client.
+   * @param sessionToken Unique identifier for the client's session.
    * @param type Type of challenge.
    * @param mode Mode of challenge.
    * @param stage Stage of challenge.
@@ -292,6 +311,7 @@ export default class ChallengeManager {
   public async createOrJoin(
     userId: number,
     clientId: number,
+    sessionToken: string,
     type: ChallengeType,
     mode: ChallengeMode,
     stage: Stage,
@@ -315,6 +335,7 @@ export default class ChallengeManager {
       const decision = await this.determineStartAction(
         userId,
         clientId,
+        sessionToken,
         type,
         recordingType,
         stage,
@@ -331,6 +352,7 @@ export default class ChallengeManager {
             decision.sessionId,
             userId,
             clientId,
+            sessionToken,
             recordingType,
             type,
             mode,
@@ -346,6 +368,7 @@ export default class ChallengeManager {
             decision.uuid,
             userId,
             clientId,
+            sessionToken,
             recordingType,
           );
           requestDecision = 'deferred';
@@ -382,6 +405,7 @@ export default class ChallengeManager {
   private async determineStartAction(
     userId: number,
     clientId: number,
+    sessionToken: string,
     type: ChallengeType,
     recordingType: RecordingType,
     stage: Stage,
@@ -495,9 +519,12 @@ export default class ChallengeManager {
               },
             };
 
-            const challengeClient = createChallengeClient(
+            const challengeClient = await createChallengeClient(
+              txn,
+              lastChallengeForParty,
               userId,
               clientId,
+              sessionToken,
               recordingType,
               startDecision.response.stage,
               startDecision.response.stageAttempt,
@@ -570,6 +597,7 @@ export default class ChallengeManager {
     sessionId: number | null,
     userId: number,
     clientId: number,
+    sessionToken: string,
     recordingType: RecordingType,
     type: ChallengeType,
     mode: ChallengeMode,
@@ -619,23 +647,25 @@ export default class ChallengeManager {
       );
     }
 
-    const challengeClient = createChallengeClient(
-      userId,
-      clientId,
-      recordingType,
-      stage,
-    );
-
-    await this.redisClient.pipeline((pipeline) => {
-      pipeline.setChallengeFields(uuid, {
+    await this.redisClient.transaction(async (txn) => {
+      const challengeClient = await createChallengeClient(
+        txn,
+        uuid,
+        userId,
+        clientId,
+        sessionToken,
+        recordingType,
+        stage,
+      );
+      txn.setChallengeFields(uuid, {
         ...processor.getState(),
         state: LifecycleState.ACTIVE,
       });
-      pipeline.setChallengeClient(uuid, clientId, challengeClient);
-      pipeline.setSessionChallenge(processor.getSessionId(), type, party);
+      txn.setChallengeClient(uuid, clientId, challengeClient);
+      txn.setSessionChallenge(processor.getSessionId(), type, party);
 
       for (const player of party) {
-        pipeline.setPlayerActiveChallenge(player, uuid);
+        txn.setPlayerActiveChallenge(player, uuid);
       }
     });
 
@@ -662,6 +692,7 @@ export default class ChallengeManager {
     uuid: string,
     userId: number,
     clientId: number,
+    sessionToken: string,
     recordingType: RecordingType,
   ): Promise<ChallengeStatusResponse> {
     // Another client is simultaneously creating the challenge. Wait until
@@ -711,9 +742,12 @@ export default class ChallengeManager {
           stageAttempt,
         };
 
-        const challengeClient = createChallengeClient(
+        const challengeClient = await createChallengeClient(
+          txn,
+          uuid,
           userId,
           clientId,
+          sessionToken,
           recordingType,
           statusResponse.stage,
           statusResponse.stageAttempt,
@@ -1153,6 +1187,7 @@ export default class ChallengeManager {
    * @param challengeId ID of the challenge to join.
    * @param userId ID of the user.
    * @param clientId ID of the client.
+   * @param sessionToken Unique identifier for the client's session.
    * @param recordingType Type of client recording.
    * @returns The current status of the joined challenge.
    * @throws ChallengeError if the join fails.
@@ -1161,6 +1196,7 @@ export default class ChallengeManager {
     challengeId: string,
     userId: number,
     clientId: number,
+    sessionToken: string,
     recordingType: RecordingType,
   ): Promise<ChallengeStatusResponse> {
     let metricDecision: ChallengeRequestDecision = 'error';
@@ -1168,7 +1204,7 @@ export default class ChallengeManager {
     try {
       const currentChallenge =
         await this.redisClient.getActiveChallengeForClient(clientId);
-      if (currentChallenge !== null) {
+      if (currentChallenge !== null && currentChallenge !== challengeId) {
         logger.warn('challenge_join_rejected', {
           userId,
           clientId,
@@ -1204,9 +1240,12 @@ export default class ChallengeManager {
           return;
         }
 
-        const clientInfo = createChallengeClient(
+        const clientInfo = await createChallengeClient(
+          txn,
+          challengeId,
           userId,
           clientId,
+          sessionToken,
           recordingType,
           challenge.stage,
           challenge.stageAttempt ?? null,
@@ -1275,8 +1314,14 @@ export default class ChallengeManager {
   private async removeClient(
     clientId: number,
     challengeId: string,
+    sessionToken: string,
   ): Promise<void> {
     await this.redisClient.transaction(async (txn) => {
+      const existing = await txn.getChallengeClient(challengeId, clientId);
+      if (existing?.sessionToken !== sessionToken) {
+        return;
+      }
+
       txn.removeChallengeClient(challengeId, clientId);
 
       const [{ state: lifecycleState }, clients] = await Promise.all([
@@ -1327,6 +1372,7 @@ export default class ChallengeManager {
   private async setClientActive(
     clientId: number,
     challengeId: string,
+    sessionToken: string,
   ): Promise<void> {
     await this.redisClient.transaction(async (txn) => {
       const [activeChallenge, challenge, us] = await Promise.all([
@@ -1334,6 +1380,10 @@ export default class ChallengeManager {
         txn.getChallenge(challengeId),
         txn.getChallengeClient(challengeId, clientId),
       ]);
+
+      if (us?.sessionToken !== sessionToken) {
+        return;
+      }
 
       if (activeChallenge !== challengeId || challenge === null) {
         txn.removeChallengeClient(challengeId, clientId);
@@ -1373,6 +1423,7 @@ export default class ChallengeManager {
   private async setClientInactive(
     clientId: number,
     challengeId: string,
+    sessionToken: string,
   ): Promise<void> {
     await this.redisClient.transaction(async (txn) => {
       const [activeChallenge, challenge, clients] = await Promise.all([
@@ -1381,11 +1432,6 @@ export default class ChallengeManager {
         txn.getChallengeClients(challengeId),
       ]);
 
-      if (activeChallenge !== challengeId || challenge === null) {
-        txn.removeChallengeClient(challengeId, clientId);
-        return;
-      }
-
       const us = clients.find((c) => c.clientId === clientId);
       if (us === undefined) {
         logger.warn('client_not_in_challenge', {
@@ -1393,6 +1439,15 @@ export default class ChallengeManager {
           challengeUuid: challengeId,
           operation: 'set_client_inactive',
         });
+        txn.removeChallengeClient(challengeId, clientId);
+        return;
+      }
+
+      if (us.sessionToken !== sessionToken) {
+        return;
+      }
+
+      if (activeChallenge !== challengeId || challenge === null) {
         txn.removeChallengeClient(challengeId, clientId);
         return;
       }
@@ -1457,15 +1512,27 @@ export default class ChallengeManager {
         let statusLabel: ClientEventStatusLabel | null = null;
         switch (statusEvent.status) {
           case ClientStatus.ACTIVE:
-            await this.setClientActive(event.clientId, clientChallenge);
+            await this.setClientActive(
+              event.clientId,
+              clientChallenge,
+              event.sessionToken,
+            );
             statusLabel = 'active';
             break;
           case ClientStatus.IDLE:
-            await this.setClientInactive(event.clientId, clientChallenge);
+            await this.setClientInactive(
+              event.clientId,
+              clientChallenge,
+              event.sessionToken,
+            );
             statusLabel = 'idle';
             break;
           case ClientStatus.DISCONNECTED:
-            await this.removeClient(event.clientId, clientChallenge);
+            await this.removeClient(
+              event.clientId,
+              clientChallenge,
+              event.sessionToken,
+            );
             statusLabel = 'disconnected';
             break;
         }

--- a/challenge-server/redis-client.ts
+++ b/challenge-server/redis-client.ts
@@ -77,6 +77,7 @@ type RedisChallengeState = {
 export type ChallengeClient = {
   userId: number;
   clientId: number;
+  sessionToken: string;
   type: RecordingType;
   active: boolean;
   stage: Stage;
@@ -728,7 +729,15 @@ class ChallengeWriter implements ChallengeWriteOperations {
 
   removeChallengeClient(uuid: string, clientId: number): void {
     this.multi.hDel(challengeClientsKey(uuid), clientId.toString());
-    this.multi.del(clientChallengesKey(clientId));
+    this.multi.eval(
+      `
+        if redis.call('GET', KEYS[1]) == ARGV[1] then
+          return redis.call('DEL', KEYS[1])
+        end
+        return 0
+      `,
+      { keys: [clientChallengesKey(clientId)], arguments: [uuid] },
+    );
     this.queuedOperations += 2;
   }
 

--- a/common/db/redis.ts
+++ b/common/db/redis.ts
@@ -147,6 +147,7 @@ export type ClientEvent = {
   type: ClientEventType;
   userId: number;
   clientId: number;
+  sessionToken: string;
 };
 
 export type ClientStatusEvent = ClientEvent & {

--- a/socket-server/app.ts
+++ b/socket-server/app.ts
@@ -427,6 +427,7 @@ async function main(): Promise<void> {
       userId: client.getUserId(),
       username: client.getUsername(),
       sessionId: client.getSessionId(),
+      sessionToken: client.getSessionToken(),
       pluginVersion: pluginVersions.getVersion(),
       pluginRevision: pluginVersions.getRevision(),
       runeLiteVersion: pluginVersions.getRuneLiteVersion(),

--- a/socket-server/client.ts
+++ b/socket-server/client.ts
@@ -61,6 +61,11 @@ type ActiveChallengeInfo = {
   stages: Map<Stage, number | null>;
 };
 
+export type Session = {
+  id: number;
+  token: string;
+};
+
 export default class Client {
   private static readonly HEARTBEAT_INTERVAL_MS = 5000;
   private static readonly HEARTBEAT_DISCONNECT_THRESHOLD = 10;
@@ -77,7 +82,7 @@ export default class Client {
   private user: BasicUser;
   private pluginVersions: PluginVersions;
   private messageFormat: MessageFormat;
-  private sessionId: number;
+  private session: Session | null;
   private socket: WebSocket;
   private messageHandler: MessageHandler;
   private activeChallenge: ActiveChallengeInfo | null;
@@ -110,7 +115,7 @@ export default class Client {
     this.user = user;
     this.pluginVersions = pluginVersions;
     this.messageFormat = messageFormat;
-    this.sessionId = -1;
+    this.session = null;
     this.socket = socket;
     this.messageHandler = eventHandler;
     this.activeChallenge = null;
@@ -181,8 +186,8 @@ export default class Client {
       }
     });
 
-    void this.withLogContext(() => this.processMessageLoop());
-    void this.withLogContext(() => this.heartbeatLoop());
+    void this.processMessageLoop();
+    void this.heartbeatLoop();
   }
 
   /**
@@ -190,11 +195,18 @@ export default class Client {
    * @returns The session ID.
    */
   public getSessionId(): number {
-    return this.sessionId;
+    return this.session?.id ?? -1;
   }
 
-  public setSessionId(sessionId: number): void {
-    this.sessionId = sessionId;
+  /**
+   * @returns The client's session token.
+   */
+  public getSessionToken(): string {
+    return this.session?.token ?? '';
+  }
+
+  public setSession(session: Session): void {
+    this.session = session;
   }
 
   /**
@@ -422,7 +434,7 @@ export default class Client {
   }
 
   public toString(): string {
-    return `Client#${this.sessionId}[${this.user.username}]`;
+    return `Client#${this.getSessionId()}[${this.user.username}]`;
   }
 
   private withLogContext<T>(
@@ -437,7 +449,8 @@ export default class Client {
       userId: this.user.id,
       clientId: this.getClientId(),
       username: this.user.username,
-      sessionId: this.sessionId,
+      sessionId: this.session?.id ?? undefined,
+      sessionToken: this.session?.token ?? undefined,
       loggedInRsn: this.loggedInRsn ?? undefined,
       validated: this.validated,
       pluginVersion: this.pluginVersions.getVersion(),
@@ -522,7 +535,9 @@ export default class Client {
           this.missedHeartbeats = 0;
         } else {
           try {
-            await this.messageHandler.handleMessage(this, message);
+            await this.withLogContext(() =>
+              this.messageHandler.handleMessage(this, message),
+            );
           } catch (e) {
             logger.error(
               'client_message_handler_error',
@@ -590,7 +605,7 @@ export default class Client {
     });
 
     this.messageHandler.closeClient(this);
-    this.sessionId = -1;
+    this.session = null;
     this.closeCallbacks = [];
     this.activeChallenge = null;
   }

--- a/socket-server/connection-manager.ts
+++ b/socket-server/connection-manager.ts
@@ -7,7 +7,7 @@ import { ServerMessage } from '@blert/common/generated/server_message_pb';
 import { RedisClientType } from 'redis';
 
 import { ActionDefinitionsRepository } from './action-definitions';
-import Client from './client';
+import Client, { Session } from './client';
 import logger from './log';
 import { recordActiveClients, recordClientRegistration } from './metrics';
 import { BasicUser, Users } from './users';
@@ -106,11 +106,11 @@ export default class ConnectionManager {
    * @param client The connected client.
    */
   public addClient(client: Client) {
-    const sessionId = this.newSessionId();
-    client.setSessionId(sessionId);
+    const session = this.newSession();
+    client.setSession(session);
     client.onClose(() => this.removeClient(client));
 
-    this.activeClients.set(sessionId, client);
+    this.activeClients.set(session.id, client);
 
     const pluginInfo = client.getPluginVersions();
     recordClientRegistration({
@@ -157,8 +157,11 @@ export default class ConnectionManager {
     return Array.from(this.activeClients.values());
   }
 
-  private newSessionId(): number {
-    // 2**53 session IDs ought to be enough for anybody.
-    return this.nextSessionId++;
+  private newSession(): Session {
+    return {
+      // 2**53 session IDs ought to be enough for anybody.
+      id: this.nextSessionId++,
+      token: crypto.randomUUID(),
+    };
   }
 }

--- a/socket-server/remote-challenge-manager.ts
+++ b/socket-server/remote-challenge-manager.ts
@@ -84,6 +84,7 @@ export class RemoteChallengeManager extends ChallengeManager {
       body: JSON.stringify({
         userId: client.getUserId(),
         clientId: client.getClientId(),
+        sessionToken: client.getSessionToken(),
         type: challengeType,
         mode,
         party,
@@ -131,6 +132,7 @@ export class RemoteChallengeManager extends ChallengeManager {
           body: JSON.stringify({
             userId: client.getUserId(),
             clientId: client.getClientId(),
+            sessionToken: client.getSessionToken(),
             times,
             soft,
           }),
@@ -201,6 +203,7 @@ export class RemoteChallengeManager extends ChallengeManager {
         body: JSON.stringify({
           userId: client.getUserId(),
           clientId: client.getClientId(),
+          sessionToken: client.getSessionToken(),
           update,
         }),
       });
@@ -368,6 +371,7 @@ export class RemoteChallengeManager extends ChallengeManager {
           body: JSON.stringify({
             userId: client.getUserId(),
             clientId: client.getClientId(),
+            sessionToken: client.getSessionToken(),
             recordingType,
           }),
         },
@@ -397,6 +401,7 @@ export class RemoteChallengeManager extends ChallengeManager {
       type: ClientEventType.STATUS,
       userId: client.getUserId(),
       clientId: client.getClientId(),
+      sessionToken: client.getSessionToken(),
       status,
     };
 


### PR DESCRIPTION
The reconnection flow previously assumed that a client would cleanly disconnect before rejoining. However, due to network issues, a stale socket could still be timing out at the time the new one connects. If this happened, the challenge server would see that the client is already in a challenge (the same challenge) and reject their join. This corrects that check to allow rejoining the same challenge. The overlapping connections issue could also send stale lifecycle events when the old socket times out, so this preemptively guards against those via unique per session tokens.