### PR TITLE
web: Allow author to load a old setup revision

### DIFF
--- a/web/app/setups/[id]/page.tsx
+++ b/web/app/setups/[id]/page.tsx
@@ -18,6 +18,7 @@ import { getRequestIp } from '@/utils/headers';
 import SetupActions from './actions';
 import CollapsibleDescription from './collapsible-description';
 import Panels from './panels';
+import { RevertButton } from './revert-button';
 import { SlotTooltipRenderer } from '../slot';
 import { SetupViewingContextProvider } from '../viewing-context';
 import { VisibilityToggleButton } from './visibility-actions';
@@ -95,6 +96,13 @@ export default async function GearSetupPage({
                       View latest version
                     </Link>
                   </span>
+                  {isAuthor && (
+                    <RevertButton
+                      publicId={setup.publicId}
+                      gearSetup={gearSetup}
+                      currentRevision={targetRevision}
+                    />
+                  )}
                 </div>
               )}
               {isAuthor && setup.state === 'unlisted' && (

--- a/web/app/setups/[id]/revert-button.tsx
+++ b/web/app/setups/[id]/revert-button.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useState } from 'react';
+
+import { saveSetupDraft } from '@/actions/setup';
+import ConfirmationModal from '@/components/confirmation-modal';
+import { useToast } from '@/components/toast';
+
+import { GearSetup } from '../setup';
+
+import styles from './style.module.scss';
+
+type Props = {
+  publicId: string;
+  gearSetup: GearSetup;
+  currentRevision: number;
+};
+
+export function RevertButton({ publicId, gearSetup, currentRevision }: Props) {
+  const router = useRouter();
+  const showToast = useToast();
+  const [loading, setLoading] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const confirm = useCallback(async () => {
+    setLoading(true);
+    try {
+      await saveSetupDraft(publicId, gearSetup);
+      router.push(`/setups/${publicId}/edit`);
+    } catch {
+      showToast('Failed to revert setup', 'error');
+      setLoading(false);
+    }
+  }, [gearSetup, publicId, router, showToast]);
+
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.revisionBannerAction}
+        onClick={() => setConfirmOpen(true)}
+        disabled={loading}
+      >
+        <i className="fas fa-undo" />
+        Revert to this revision
+      </button>
+      <ConfirmationModal
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => void confirm()}
+        title={`Revert to v${currentRevision}?`}
+        message={
+          <>
+            This will load v{currentRevision} into the editor as a new draft,
+            replacing any in-progress draft you have. You&apos;ll need to
+            publish to create a new revision.
+          </>
+        }
+        confirmText="Revert"
+        loading={loading}
+      />
+    </>
+  );
+}

--- a/web/app/setups/[id]/style.module.scss
+++ b/web/app/setups/[id]/style.module.scss
@@ -67,9 +67,13 @@
     font-size: 0.9rem;
     line-height: 1.4;
 
-    i {
+    > i {
       color: var(--blert-purple);
       font-size: 1em;
+    }
+
+    > span {
+      flex: 1;
     }
 
     a {
@@ -83,6 +87,7 @@
     }
 
     @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      flex-wrap: wrap;
       text-align: center;
       justify-content: center;
     }
@@ -123,9 +128,11 @@
   }
 }
 
-.unlistedBannerAction {
+.unlistedBannerAction,
+.revisionBannerAction {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   padding: 6px 12px;
   background: var(--blert-surface-dark);
@@ -150,6 +157,10 @@
   &:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    flex-basis: 100%;
   }
 }
 

--- a/web/app/setups/__tests__/setup.test.ts
+++ b/web/app/setups/__tests__/setup.test.ts
@@ -1,0 +1,61 @@
+import { ChallengeType } from '@blert/common';
+
+import { GearSetup, setupScale, Spellbook } from '../setup';
+
+describe('setupScale', () => {
+  const baseSetup: GearSetup = {
+    title: 'Test Setup',
+    description: '',
+    challenge: ChallengeType.TOB,
+    players: [],
+  };
+
+  function emptyPlayer(name: string, optional: boolean = false) {
+    return {
+      name,
+      spellbook: Spellbook.STANDARD,
+      inventory: { slots: [] },
+      equipment: { slots: [] },
+      pouch: { slots: [] },
+      optional,
+    };
+  }
+
+  it('handles setups without optional players', () => {
+    expect(setupScale(baseSetup)).toBe(0);
+
+    const setup = {
+      ...baseSetup,
+      players: [
+        emptyPlayer('Player 1'),
+        emptyPlayer('Player 2'),
+        emptyPlayer('Player 3'),
+      ],
+    };
+    expect(setupScale(setup)).toBe(3);
+  });
+
+  it('handles setups with optional players', () => {
+    const setup = {
+      ...baseSetup,
+      players: [
+        emptyPlayer('Player 1'),
+        emptyPlayer('Player 2', true),
+        emptyPlayer('Player 3', true),
+        emptyPlayer('Player 4'),
+      ],
+    };
+    expect(setupScale(setup)).toBe(2);
+
+    const allOptionalSetup = {
+      ...baseSetup,
+      players: [
+        emptyPlayer('Player 1', true),
+        emptyPlayer('Player 2', true),
+        emptyPlayer('Player 3', true),
+        emptyPlayer('Player 4', true),
+      ],
+    };
+    expect(setupScale(allOptionalSetup)).toBe(0);
+  });
+});


### PR DESCRIPTION
When an author is viewing an old revision of their gear setup, adds a button which loads that revision as their working draft.