### PR TITLE
web: Expose Xarpus healing in API and search

### DIFF
--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -9,6 +9,7 @@ import {
 } from '@blert/common';
 
 import {
+  aggregateChallenges,
   aggregateSessions,
   countUniquePlayers,
   findChallenges,
@@ -857,6 +858,136 @@ describe('challenges', () => {
         expect(challenges).toHaveLength(1);
         expect(challenges[0].uuid).toBe('cccccccc-cccc-cccc-cccc-cccccccccccc');
       });
+    });
+
+    describe('xarpus healing filter', () => {
+      beforeEach(async () => {
+        await sql`
+          INSERT INTO tob_challenge_stats ${sql([
+            { challenge_id: challengeIds[0], xarpus_healing: 50 },
+            { challenge_id: challengeIds[1], xarpus_healing: 200 },
+          ])}
+        `;
+      });
+
+      it('matches challenges above a threshold', async () => {
+        const [challenges] = await findChallenges(10, {
+          tob: { xarpusHealing: ['>', 100] },
+        });
+
+        expect(challenges.map((c) => c.uuid)).toEqual([
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        ]);
+      });
+
+      it('matches challenges below a threshold', async () => {
+        const [challenges] = await findChallenges(10, {
+          tob: { xarpusHealing: ['<=', 50] },
+        });
+
+        expect(challenges.map((c) => c.uuid)).toEqual([
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        ]);
+      });
+
+      it('excludes challenges without a tob_challenge_stats row', async () => {
+        // dddd is Colosseum and has no row; it should never match a tob filter.
+        const [challenges] = await findChallenges(10, {
+          tob: { xarpusHealing: ['>=', 0] },
+        });
+
+        expect(challenges.map((c) => c.uuid).sort()).toEqual([
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+        ]);
+      });
+    });
+
+    describe('sort by tob:xarpusHealing', () => {
+      beforeEach(async () => {
+        await sql`
+          INSERT INTO tob_challenge_stats ${sql([
+            { challenge_id: challengeIds[0], xarpus_healing: 200 },
+            { challenge_id: challengeIds[1], xarpus_healing: 50 },
+          ])}
+        `;
+      });
+
+      it('sorts descending with non-tob challenges coming last (null)', async () => {
+        const [challenges] = await findChallenges(10, {
+          sort: '-tob:xarpusHealing#nl',
+        });
+
+        // bbbb (200), cccc (50), then dddd (Colosseum, null) last.
+        expect(challenges.map((c) => c.uuid)).toEqual([
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        ]);
+      });
+
+      it('sorts ascending with nulls last', async () => {
+        const [challenges] = await findChallenges(10, {
+          sort: '+tob:xarpusHealing#nl',
+        });
+
+        expect(challenges.map((c) => c.uuid)).toEqual([
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        ]);
+      });
+    });
+  });
+
+  describe('aggregateChallenges', () => {
+    beforeEach(async () => {
+      await sql`
+        INSERT INTO tob_challenge_stats ${sql([
+          { challenge_id: challengeIds[0], xarpus_healing: 50 },
+          { challenge_id: challengeIds[1], xarpus_healing: 200 },
+        ])}
+      `;
+    });
+
+    it('aggregates tob:xarpusHealing across all operations', async () => {
+      const result = await aggregateChallenges(
+        {},
+        { 'tob:xarpusHealing': ['avg', 'count', 'sum', 'min', 'max'] },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!['tob:xarpusHealing'].count).toBe(2);
+      expect(result!['tob:xarpusHealing'].sum).toBe(250);
+      expect(result!['tob:xarpusHealing'].avg).toBe(125);
+      expect(result!['tob:xarpusHealing'].min).toBe(50);
+      expect(result!['tob:xarpusHealing'].max).toBe(200);
+    });
+
+    it('does not drop challenges without a tob_challenge_stats row', async () => {
+      // Colosseum challenge (dddd) has no tob stats; the LEFT JOIN should
+      // still include it in the total count while its healing is null.
+      const result = await aggregateChallenges(
+        {},
+        { '*': 'count', 'tob:xarpusHealing': 'count' },
+      );
+
+      expect(result!['*'].count).toBe(3);
+      expect(result!['tob:xarpusHealing'].count).toBe(2);
+    });
+
+    it('groups tob:xarpusHealing by scale', async () => {
+      const result = await aggregateChallenges(
+        { type: ['==', ChallengeType.TOB] },
+        { 'tob:xarpusHealing': ['avg', 'count'] },
+        {},
+        'scale',
+      );
+
+      expect(result).not.toBeNull();
+      // Both ToB challenges are scale 2.
+      expect(result!['2']['tob:xarpusHealing'].count).toBe(2);
+      expect(result!['2']['tob:xarpusHealing'].avg).toBe(125);
     });
   });
 

--- a/web/__tests__/api/challenge-query.test.ts
+++ b/web/__tests__/api/challenge-query.test.ts
@@ -84,6 +84,27 @@ describe('parseChallengeQuery', () => {
         parse({ sort: '-startTime', before: '100', after: '200' }),
       ).toBeNull();
     });
+
+    it('builds an after cursor for a tob:xarpusHealing sort', () => {
+      const query = parse({ sort: '-tob:xarpusHealing', after: '100' });
+      expect(query!.sort).toEqual(['-tob:xarpusHealing#nl']);
+      expect(query!.customConditions).toEqual([
+        [
+          ['tob:xarpusHealing', '<', 100],
+          '||',
+          ['tob:xarpusHealing', 'is', null],
+        ],
+      ]);
+    });
+
+    it('builds a before cursor for a tob:xarpusHealing sort', () => {
+      const query = parse({ sort: '-tob:xarpusHealing', before: '200' });
+      // before reverses the direction so nulls come first.
+      expect(query!.sort).toEqual(['+tob:xarpusHealing#nf']);
+      expect(query!.customConditions).toEqual([
+        ['tob:xarpusHealing', '>', 200],
+      ]);
+    });
   });
 
   describe('comparator params', () => {
@@ -203,6 +224,11 @@ describe('parseChallengeQuery', () => {
       expect(query!.tob!.nylocasPostCapStalls).toEqual(['<=', 2]);
     });
 
+    it('should parse xarpus healing', () => {
+      const query = parse({ 'tob.xarpusHealing': 'gt100' });
+      expect(query!.tob!.xarpusHealing).toEqual(['>', 100]);
+    });
+
     it('should parse verzik reds count', () => {
       const query = parse({ 'tob.verzikRedsCount': 'ge2' });
       expect(query!.tob!.verzikRedsCount).toEqual(['>=', 2]);
@@ -212,10 +238,12 @@ describe('parseChallengeQuery', () => {
       const query = parse({
         'tob.bloatDownCount': 'eq3',
         'tob.nylocasPreCapStalls': 'eq0',
+        'tob.xarpusHealing': 'lt50',
         'tob.verzikRedsCount': 'ge2',
       });
       expect(query!.tob!.bloatDownCount).toEqual(['==', 3]);
       expect(query!.tob!.nylocasPreCapStalls).toEqual(['==', 0]);
+      expect(query!.tob!.xarpusHealing).toEqual(['<', 50]);
       expect(query!.tob!.verzikRedsCount).toEqual(['>=', 2]);
     });
 

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -402,11 +402,14 @@ export type BasicSortableFields = keyof Omit<
   'party' | 'finishTime'
 >;
 export type SplitSortableFields = `splits:${SplitType}`;
+export type TobSortableFields =
+  `tob:${keyof Pick<TobChallengeStats, 'xarpusHealing'>}`;
 export type MokhaiotlSortableFields =
   `mok:${keyof Pick<MokhaiotlChallengeStats, 'maxCompletedDelve'>}`;
 export type SortableFields =
   | BasicSortableFields
   | SplitSortableFields
+  | TobSortableFields
   | MokhaiotlSortableFields;
 
 export type SingleOrArray<T> = T | T[];
@@ -416,6 +419,7 @@ export type TobQuery = {
   bloatDownCount?: Comparator<number>;
   nylocasPreCapStalls?: Comparator<number>;
   nylocasPostCapStalls?: Comparator<number>;
+  xarpusHealing?: Comparator<number>;
   verzikRedsCount?: Comparator<number>;
 };
 
@@ -466,6 +470,11 @@ function shorthandToFullField(field: string): [string, string] {
   if (field.startsWith('splits:')) {
     const split = field.slice(7);
     return ['ticks', splitsTableName(parseInt(split))];
+  }
+
+  if (field.startsWith('tob:')) {
+    const tobField = field.slice(4);
+    return [tobField, 'tob_challenge_stats'];
   }
 
   if (field.startsWith('mok:')) {
@@ -626,6 +635,7 @@ function applyTobFilters(
     bloatDownCount: 'bloat_down_count',
     nylocasPreCapStalls: 'nylocas_pre_cap_stalls',
     nylocasPostCapStalls: 'nylocas_post_cap_stalls',
+    xarpusHealing: 'xarpus_healing',
     verzikRedsCount: 'verzik_reds_count',
   };
 
@@ -810,6 +820,15 @@ function applyFilters(
       if (sortKey.startsWith('splits:')) {
         const split = parseInt(sortKey.slice(7)) as SplitType;
         addSplitsTable(split, sqlChallenges, joins, conditions, accurateSplits);
+      }
+
+      if (sortKey.startsWith('tob:')) {
+        joins.push({
+          table: sql`tob_challenge_stats`,
+          on: sql`${sqlChallenges}.id = tob_challenge_stats.challenge_id`,
+          type: 'left',
+          tableName: 'tob_challenge_stats',
+        });
       }
 
       if (sortKey.startsWith('mok:')) {
@@ -1320,6 +1339,16 @@ export async function aggregateChallenges<
         conditions,
         options.accurateSplits,
       );
+    } else if (
+      table !== 'challenges' &&
+      joins.find((j) => j.tableName === table) === undefined
+    ) {
+      joins.push({
+        table: sqlTable,
+        on: sql`${queryTable}.id = ${sqlTable}.challenge_id`,
+        type: 'left',
+        tableName: table,
+      });
     }
 
     return aggs.map((agg) => {

--- a/web/app/api/v1/challenges/query.ts
+++ b/web/app/api/v1/challenges/query.ts
@@ -154,6 +154,7 @@ export function parseChallengeQuery(
       'bloatDownCount',
       'nylocasPreCapStalls',
       'nylocasPostCapStalls',
+      'xarpusHealing',
       'verzikRedsCount',
     ] as const;
     for (const field of tobScalarParams) {

--- a/web/app/api/v1/challenges/route.ts
+++ b/web/app/api/v1/challenges/route.ts
@@ -91,6 +91,9 @@ export const GET = withApiRoute(
         }
         splits.add(split);
       }
+      if (sortField.startsWith('tob:')) {
+        loadStats = true;
+      }
     }
 
     const findOptions: Required<FindChallengesOptions> = {

--- a/web/app/search/challenges/__tests__/context.test.ts
+++ b/web/app/search/challenges/__tests__/context.test.ts
@@ -107,6 +107,7 @@ describe('challenges filter URL round-trip', () => {
         bloatDownCount: [Comparator.GREATER_THAN_OR_EQUAL, 3],
         nylocasPreCapStalls: [Comparator.EQUAL, 2],
         nylocasPostCapStalls: null,
+        xarpusHealing: [Comparator.GREATER_THAN, 100],
         verzikRedsCount: [Comparator.LESS_THAN, 5],
       },
     };
@@ -122,6 +123,7 @@ describe('challenges filter URL round-trip', () => {
     ]);
     expect(result.tob.nylocasPreCapStalls).toEqual([Comparator.EQUAL, 2]);
     expect(result.tob.nylocasPostCapStalls).toBeNull();
+    expect(result.tob.xarpusHealing).toEqual([Comparator.GREATER_THAN, 100]);
     expect(result.tob.verzikRedsCount).toEqual([Comparator.LESS_THAN, 5]);
   });
 

--- a/web/app/search/challenges/context.ts
+++ b/web/app/search/challenges/context.ts
@@ -64,6 +64,7 @@ export type TobFilters = {
   bloatDownCount: [Comparator, number] | null;
   nylocasPreCapStalls: [Comparator, number] | null;
   nylocasPostCapStalls: [Comparator, number] | null;
+  xarpusHealing: [Comparator, number] | null;
   verzikRedsCount: [Comparator, number] | null;
 };
 
@@ -87,6 +88,7 @@ function parseTobParam(tob: TobFilters, key: string, value: string): void {
     'bloatDownCount',
     'nylocasPreCapStalls',
     'nylocasPostCapStalls',
+    'xarpusHealing',
     'verzikRedsCount',
   ];
   const field = scalarFields.find((f) => f === key);
@@ -119,6 +121,7 @@ export function emptyTobFilters(): TobFilters {
     bloatDownCount: null,
     nylocasPreCapStalls: null,
     nylocasPostCapStalls: null,
+    xarpusHealing: null,
     verzikRedsCount: null,
   };
 }
@@ -140,6 +143,9 @@ function countTobFilters(tob: TobFilters): number {
     count++;
   }
   if (tob.nylocasPostCapStalls !== null) {
+    count++;
+  }
+  if (tob.xarpusHealing !== null) {
     count++;
   }
   if (tob.verzikRedsCount !== null) {
@@ -263,6 +269,7 @@ export function filtersToUrlParams(filters: SearchFilters): UrlParams {
     'bloatDownCount',
     'nylocasPreCapStalls',
     'nylocasPostCapStalls',
+    'xarpusHealing',
     'verzikRedsCount',
   ];
   for (const field of tobScalarFields) {

--- a/web/app/search/challenges/filters.tsx
+++ b/web/app/search/challenges/filters.tsx
@@ -511,6 +511,19 @@ const CUSTOM_FILTERS_ITEMS: MenuItem[] = [
         ],
       },
       {
+        label: 'Xarpus',
+        subMenu: [
+          {
+            label: 'Healing',
+            value: def('Xarpus healing', {
+              path: 'tob.xarpusHealing',
+              inputKind: 'number',
+              min: 0,
+            }).id,
+          },
+        ],
+      },
+      {
         label: 'Verzik',
         subMenu: [
           {

--- a/web/app/search/challenges/search.tsx
+++ b/web/app/search/challenges/search.tsx
@@ -68,6 +68,13 @@ function getSortKeyValue(challenge: ChallengeOverview, key: SortableFields) {
     return challenge.splits?.[split]?.ticks ?? null;
   }
 
+  if (key.startsWith('tob:')) {
+    const field = key.slice(4) as keyof NonNullable<
+      ChallengeOverview['tobStats']
+    >;
+    return (challenge.tobStats?.[field] as number | null | undefined) ?? null;
+  }
+
   const k = key as BasicSortableFields;
   return challenge[k] ?? null;
 }

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -54,7 +54,8 @@
   }
 
   .wrapper {
-    width: 100%;
+    width: fit-content;
+    max-width: 100%;
     overflow-x: auto;
     border-radius: 8px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);

--- a/web/app/search/challenges/table.tsx
+++ b/web/app/search/challenges/table.tsx
@@ -174,6 +174,7 @@ const COLUMN_GROUPS: ColumnGroup[] = [
       Column.TOB_BLOAT_DOWN_COUNT,
       Column.TOB_NYLOCAS_PRE_CAP_STALLS,
       Column.TOB_NYLOCAS_POST_CAP_STALLS,
+      Column.TOB_XARPUS_HEALING,
       Column.TOB_VERZIK_REDS_COUNT,
     ],
   },
@@ -616,6 +617,14 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Verzik reds spawns',
     align: 'right',
     renderer: (challenge) => challenge.tobStats?.verzikRedsCount ?? '-',
+    toggleFields: includeStats,
+  },
+  [Column.TOB_XARPUS_HEALING]: {
+    name: 'Xarpus heal',
+    fullName: 'Xarpus healing',
+    align: 'right',
+    renderer: (challenge) => challenge.tobStats?.xarpusHealing ?? '-',
+    sortKey: 'tob:xarpusHealing',
     toggleFields: includeStats,
   },
 
@@ -1359,8 +1368,6 @@ function ColumnsModal({
           { column: dragging },
           ...columns.slice(newIndex),
         ];
-
-        return [];
       });
     }
 

--- a/web/app/search/challenges/types.ts
+++ b/web/app/search/challenges/types.ts
@@ -68,6 +68,7 @@ export const enum Column {
   TOB_NYLOCAS_PRE_CAP_STALLS,
   TOB_NYLOCAS_POST_CAP_STALLS,
   TOB_VERZIK_REDS_COUNT,
+  TOB_XARPUS_HEALING,
 }
 
 export type SelectedColumn = {


### PR DESCRIPTION
Makes the Xarpus healing stat filterable, sortable, and aggregateable in the API. Adds it as a custom filter and column in the search table.

Closes #257.