### PR TITLE
web: Optimize unique player count query

### DIFF
--- a/common/migrations/20260419055959-add-challenge-players-player-challenge-index.ts
+++ b/common/migrations/20260419055959-add-challenge-players-player-challenge-index.ts
@@ -1,0 +1,11 @@
+import { Sql } from 'postgres';
+
+export async function migrate(sql: Sql) {
+  await sql`
+    CREATE INDEX idx_challenge_players_player_id_challenge_id
+      ON challenge_players (player_id, challenge_id)
+  `;
+  await sql`
+    DROP INDEX idx_challenge_players_player_id
+  `;
+}

--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -992,43 +992,83 @@ describe('challenges', () => {
   });
 
   describe('countUniquePlayers', () => {
-    it('should count all distinct players across non-abandoned challenges', async () => {
-      const count = await countUniquePlayers({});
-      expect(count).toBe(3);
+    describe('loose index scan', () => {
+      it('should count all distinct players across non-abandoned challenges', async () => {
+        const count = await countUniquePlayers({});
+        expect(count).toBe(3);
+      });
+
+      it('should filter by challenge type', async () => {
+        const tobCount = await countUniquePlayers({
+          type: ['==', ChallengeType.TOB],
+        });
+        expect(tobCount).toBe(3);
+
+        const coloCount = await countUniquePlayers({
+          type: ['==', ChallengeType.COLOSSEUM],
+        });
+        expect(coloCount).toBe(1);
+      });
+
+      it('should count all participants in a party-filtered query', async () => {
+        // PlayerA appears in challenges with B and C.
+        const count = await countUniquePlayers({ party: ['PlayerA'] });
+        expect(count).toBe(3);
+      });
+
+      it('should combine party and type filters', async () => {
+        // PlayerC only has TOB challenges.
+        const count = await countUniquePlayers({
+          party: ['PlayerC'],
+          type: ['==', ChallengeType.COLOSSEUM],
+        });
+        expect(count).toBe(0);
+      });
+
+      it('should return 0 for no matching challenges', async () => {
+        const count = await countUniquePlayers({
+          type: ['==', ChallengeType.INFERNO],
+        });
+        expect(count).toBe(0);
+      });
     });
 
-    it('should filter by challenge type', async () => {
-      const tobCount = await countUniquePlayers({
-        type: ['==', ChallengeType.TOB],
+    // Multi-player party filters rewrite baseTable into a subquery and fall
+    // back to the hash-DISTINCT form.
+    describe('subquery fallback', () => {
+      it('should count distinct players for a multi-player matchAll party', async () => {
+        // Challenges 0 and 1 both include PlayerA and PlayerB; challenge 1
+        // additionally includes PlayerC.
+        const count = await countUniquePlayers({
+          party: ['PlayerA', 'PlayerB'],
+        });
+        expect(count).toBe(3);
       });
-      expect(tobCount).toBe(3);
 
-      const coloCount = await countUniquePlayers({
-        type: ['==', ChallengeType.COLOSSEUM],
+      it('should count distinct players for a multi-player matchAny party', async () => {
+        const count = await countUniquePlayers({
+          party: ['PlayerA', 'PlayerC'],
+          partyMatch: 'any',
+        });
+        expect(count).toBe(3);
       });
-      expect(coloCount).toBe(1);
-    });
 
-    it('should count all participants in a party-filtered query', async () => {
-      // PlayerA appears in challenges with B and C.
-      const count = await countUniquePlayers({ party: ['PlayerA'] });
-      expect(count).toBe(3);
-    });
-
-    it('should combine party and type filters', async () => {
-      // PlayerC only has TOB challenges.
-      const count = await countUniquePlayers({
-        party: ['PlayerC'],
-        type: ['==', ChallengeType.COLOSSEUM],
+      it('should combine a multi-player matchAny party with a type filter', async () => {
+        const count = await countUniquePlayers({
+          party: ['PlayerA', 'PlayerB'],
+          partyMatch: 'any',
+          type: ['==', ChallengeType.COLOSSEUM],
+        });
+        expect(count).toBe(1);
       });
-      expect(count).toBe(0);
-    });
 
-    it('should return 0 for no matching challenges', async () => {
-      const count = await countUniquePlayers({
-        type: ['==', ChallengeType.INFERNO],
+      it('should return 0 when no challenge satisfies matchAll', async () => {
+        const count = await countUniquePlayers({
+          party: ['PlayerA', 'PlayerB'],
+          type: ['==', ChallengeType.COLOSSEUM],
+        });
+        expect(count).toBe(0);
       });
-      expect(count).toBe(0);
     });
   });
 });

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -599,6 +599,12 @@ function order(
 
 type QueryComponents = {
   baseTable: postgres.Fragment;
+  /**
+   * Whether `baseTable` is a derived subquery rather than the `challenges`
+   * table directly. Some callers need to know this to avoid embedding the
+   * subquery in a context that would re-execute it per row.
+   */
+  baseTableIsSubquery: boolean;
   queryTable: postgres.Helper<string>;
   joins: Join[];
   conditions: postgres.Fragment[];
@@ -724,6 +730,7 @@ function applyFilters(
   fullRecordings?: boolean,
 ): QueryComponents | null {
   let baseTable = sql`challenges`;
+  let baseTableIsSubquery = false;
   const joins: Join[] = defaultJoins;
   const conditions = [];
 
@@ -780,6 +787,7 @@ function applyFilters(
           WHERE players.normalized_username = ANY(${query.party.map(normalizeRsn)})
         ) challenges`;
       }
+      baseTableIsSubquery = true;
     }
   }
 
@@ -890,6 +898,7 @@ function applyFilters(
 
   return {
     baseTable,
+    baseTableIsSubquery,
     queryTable: sqlChallenges,
     joins,
     conditions,
@@ -1508,24 +1517,67 @@ export async function countUniquePlayers(
     return 0;
   }
 
-  const { baseTable, joins, conditions } = components;
+  const { baseTable, baseTableIsSubquery, joins, conditions } = components;
 
-  // Use a dedicated alias so the count isn't restricted by a party filter's
-  // challenge_players join.
-  const allJoins: Join[] = [
-    ...joins,
-    {
-      table: sql`challenge_players cp_count`,
-      on: sql`challenges.id = cp_count.challenge_id`,
-      tableName: 'cp_count',
-    },
-  ];
+  if (baseTableIsSubquery) {
+    // The loose index scan below could re-execute the baseTable subquery
+    // once per candidate player; fall back to the hash-DISTINCT form.
+    const allJoins: Join[] = [
+      ...joins,
+      {
+        table: sql`challenge_players cp_count`,
+        on: sql`challenges.id = cp_count.challenge_id`,
+        tableName: 'cp_count',
+      },
+    ];
+
+    const [row] = await sql<[{ count: string }]>`
+      SELECT COUNT(DISTINCT cp_count.player_id) AS count
+      FROM ${baseTable}
+      ${join(allJoins)}
+      ${where(conditions)}
+    `;
+
+    return parseInt(row.count);
+  }
+
+  // Loose index scan over challenge_players.player_id: hop from one
+  // distinct player_id to the next, stopping at the first matching challenge
+  // per player.
+  // Work scales with distinct players rather than the fully-joined row count.
+  const matchesChallenge = sql`
+    EXISTS (
+      SELECT 1
+      FROM ${baseTable}
+      ${join(joins)}
+      ${where([...conditions, sql`challenges.id = cp.challenge_id`])}
+    )
+  `;
 
   const [row] = await sql<[{ count: string }]>`
-    SELECT COUNT(DISTINCT cp_count.player_id) AS count
-    FROM ${baseTable}
-    ${join(allJoins)}
-    ${where(conditions)}
+    WITH RECURSIVE distinct_players AS (
+      (
+        SELECT cp.player_id
+        FROM challenge_players cp
+        WHERE ${matchesChallenge}
+        ORDER BY cp.player_id
+        LIMIT 1
+      )
+      UNION ALL
+      SELECT (
+        SELECT cp.player_id
+        FROM challenge_players cp
+        WHERE cp.player_id > dp.player_id
+          AND ${matchesChallenge}
+        ORDER BY cp.player_id
+        LIMIT 1
+      )
+      FROM distinct_players dp
+      WHERE dp.player_id IS NOT NULL
+    )
+    SELECT COUNT(*) AS count
+    FROM distinct_players
+    WHERE player_id IS NOT NULL
   `;
 
   return parseInt(row.count);


### PR DESCRIPTION
Adds an index on challenge_players(player_id, challenge_id) and rewrites the countUniquePlayers query to scale with ditinct player count rather than challenge_players count.