### PR TITLE
web: Pause live auto scroll when user scrolls away

### DIFF
--- a/web/app/(challenges)/challenges/colosseum/[id]/waves/[number]/page.tsx
+++ b/web/app/(challenges)/challenges/colosseum/[id]/waves/[number]/page.tsx
@@ -387,6 +387,7 @@ export default function ColosseumWavePage({ params }: ColosseumWavePageProps) {
           bcf={bcf}
           customStates={customStates}
           smallLegend={display.isCompact()}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/challenges/inferno/[id]/waves/[number]/page.tsx
+++ b/web/app/(challenges)/challenges/inferno/[id]/waves/[number]/page.tsx
@@ -249,6 +249,7 @@ export default function InfernoWavePage({ params }: InfernoWavePageProps) {
           bcf={bcf}
           smallLegend={display.isCompact()}
           splits={splits}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/challenges/mokhaiotl/[id]/delves/[number]/page.tsx
+++ b/web/app/(challenges)/challenges/mokhaiotl/[id]/delves/[number]/page.tsx
@@ -404,6 +404,7 @@ export default function DelvePage({ params }: DelvePageProps) {
           bcf={bcf}
           smallLegend={display.isCompact()}
           customRows={[orbsRow]}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/bloat/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/bloat/page.tsx
@@ -377,6 +377,7 @@ export default function BloatPage() {
           bcf={bcf}
           splits={splits}
           backgroundColors={backgroundColors}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/maiden/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/maiden/page.tsx
@@ -433,6 +433,7 @@ export default function Maiden() {
           splits={splits}
           npcs={npcState}
           smallLegend={display.isCompact()}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/nylocas/page.tsx
@@ -878,6 +878,7 @@ export default function NylocasPage() {
           bcf={bcf}
           npcs={npcState}
           smallLegend={display.isCompact()}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/sotetseg/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/sotetseg/page.tsx
@@ -361,6 +361,7 @@ export default function SotetsegPage() {
           npcs={npcState}
           bcf={bcf}
           smallLegend={display.isCompact()}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/verzik/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/verzik/page.tsx
@@ -585,6 +585,7 @@ export default function VerzikPage() {
           backgroundColors={backgroundColors}
           smallLegend={display.isCompact()}
           customStates={customStates}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/(challenges)/raids/tob/[id]/(bosses)/xarpus/page.tsx
+++ b/web/app/(challenges)/raids/tob/[id]/(bosses)/xarpus/page.tsx
@@ -371,6 +371,7 @@ export default function XarpusPage() {
           npcs={npcState}
           bcf={bcf}
           smallLegend={display.isCompact()}
+          liveFollowing={following}
         />
       </div>
 

--- a/web/app/components/attack-timeline/bcf-renderer.module.scss
+++ b/web/app/components/attack-timeline/bcf-renderer.module.scss
@@ -409,3 +409,52 @@ button.legendParticipant {
   transition: transform 0.25s ease-out;
   will-change: transform;
 }
+
+.returnToLiveButton {
+  position: absolute;
+  bottom: 14px;
+  right: 14px;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 10px;
+  background: rgba(var(--blert-red-base), 0.2);
+  border: 1px solid transparent;
+  color: var(--blert-red);
+  font-size: 0.85em;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  transition: border-color 0.2s ease;
+
+  &:hover {
+    border-color: rgba(var(--blert-red-base), 0.5);
+  }
+
+  i {
+    font-size: 0.8em;
+  }
+}
+
+.returnToLiveDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--blert-red);
+  animation: return-to-live-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes return-to-live-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(0.85);
+  }
+}

--- a/web/app/components/attack-timeline/bcf-renderer.tsx
+++ b/web/app/components/attack-timeline/bcf-renderer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { BCFResolver, BlertChartFormat } from '@blert/bcf';
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import HorizontalScrollable from '@/components/horizontal-scrollable';
 
@@ -80,6 +80,12 @@ export type BcfRendererProps = {
 
   /** Use the canvas-based renderer instead of DOM cells. Default: false. */
   useCanvas?: boolean;
+
+  /**
+   * Whether the timeline is auto-following a live challenge. When true, the
+   * timeline detects manual horizontal scrolling and pauses auto-follow.
+   */
+  liveFollowing?: boolean;
 };
 
 export function BcfRenderer({
@@ -100,6 +106,7 @@ export function BcfRenderer({
   onActorSelect,
   onTickSelect,
   useCanvas = false,
+  liveFollowing = false,
 }: BcfRendererProps) {
   const resolver = useMemo(() => new BCFResolver(bcf), [bcf]);
 
@@ -133,6 +140,8 @@ export function BcfRenderer({
   }, [resolver, customRowsMap]);
 
   const scrollableRef = useRef<HTMLDivElement | null>(null);
+  const liveScrollTargetRef = useRef<number | null>(null);
+  const [scrolledAwayFromLive, setScrolledAwayFromLive] = useState(false);
 
   const totalColumnWidth = cellSize + CELL_GAP;
   const shouldScroll = wrapWidth === undefined;
@@ -154,37 +163,110 @@ export function BcfRenderer({
 
   const maxTick = resolver.totalTicks - 1;
 
+  const computeScrollTarget = useCallback(
+    (tick: number) => {
+      const el = scrollableRef.current;
+      if (el === null) {
+        return null;
+      }
+      const tickOffset = tick - resolver.startTick;
+      const scrollThreshold = scrollMinColumns * totalColumnWidth;
+      const scrollOffset = scrollVisibleColumns * totalColumnWidth + cellSize;
+      if (tickOffset * totalColumnWidth < scrollThreshold) {
+        return 0;
+      }
+      if (tick === maxTick) {
+        return el.scrollWidth - el.clientWidth;
+      }
+      return tickOffset * totalColumnWidth - scrollOffset;
+    },
+    [
+      resolver.startTick,
+      scrollMinColumns,
+      scrollVisibleColumns,
+      totalColumnWidth,
+      cellSize,
+      maxTick,
+    ],
+  );
+
   // Auto-scroll to current tick when playing.
   useEffect(() => {
     if (!shouldScroll || currentTick === undefined) {
+      liveScrollTargetRef.current = null;
       return;
     }
 
-    if (scrollableRef.current !== null) {
-      const tickOffset = currentTick - resolver.startTick;
-      const scrollThreshold = scrollMinColumns * totalColumnWidth;
-      const scrollOffset = scrollVisibleColumns * totalColumnWidth + cellSize;
-
-      if (tickOffset * totalColumnWidth < scrollThreshold) {
-        scrollableRef.current.scrollLeft = 0;
-      } else if (currentTick === maxTick) {
-        scrollableRef.current.scrollLeft =
-          scrollableRef.current.scrollWidth - scrollableRef.current.clientWidth;
-      } else {
-        scrollableRef.current.scrollLeft =
-          tickOffset * totalColumnWidth - scrollOffset;
-      }
+    const el = scrollableRef.current;
+    if (el === null) {
+      liveScrollTargetRef.current = null;
+      return;
     }
+
+    const target = computeScrollTarget(currentTick);
+    if (target === null) {
+      liveScrollTargetRef.current = null;
+      return;
+    }
+
+    liveScrollTargetRef.current = target;
+    if (liveFollowing && scrolledAwayFromLive) {
+      return;
+    }
+    el.scrollLeft = target;
   }, [
     shouldScroll,
     currentTick,
-    maxTick,
-    totalColumnWidth,
-    cellSize,
-    scrollMinColumns,
-    scrollVisibleColumns,
-    resolver.startTick,
+    liveFollowing,
+    scrolledAwayFromLive,
+    computeScrollTarget,
   ]);
+
+  // Detect whether the user has moved away from the current live scroll
+  // target and pause auto-follow until they scroll back near it.
+  useEffect(() => {
+    if (!liveFollowing || !shouldScroll) {
+      return;
+    }
+    const el = scrollableRef.current;
+    if (el === null) {
+      return;
+    }
+
+    const handleScroll = () => {
+      const liveTarget = liveScrollTargetRef.current;
+      if (liveTarget === null) {
+        return;
+      }
+
+      const nearLiveTarget =
+        Math.abs(el.scrollLeft - liveTarget) <= totalColumnWidth * 2;
+      setScrolledAwayFromLive(!nearLiveTarget);
+    };
+
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [liveFollowing, shouldScroll, totalColumnWidth]);
+
+  useEffect(() => {
+    if (!liveFollowing) {
+      setScrolledAwayFromLive(false);
+    }
+  }, [liveFollowing]);
+
+  const handleReturnToLive = useCallback(() => {
+    const el = scrollableRef.current;
+    if (el === null || currentTick === undefined) {
+      return;
+    }
+    setScrolledAwayFromLive(false);
+    const target = computeScrollTarget(currentTick);
+    if (target === null) {
+      return;
+    }
+    liveScrollTargetRef.current = target;
+    el.scrollLeft = target;
+  }, [currentTick, computeScrollTarget]);
 
   const memoizedCoreTimeline = useMemo(
     () =>
@@ -362,6 +444,17 @@ export function BcfRenderer({
             memoizedCoreTimeline
           )}
         </HorizontalScrollable>
+        {liveFollowing && scrolledAwayFromLive && (
+          <button
+            type="button"
+            className={styles.returnToLiveButton}
+            onClick={handleReturnToLive}
+          >
+            <span className={styles.returnToLiveDot} />
+            LIVE
+            <i className="fa-solid fa-arrow-right" />
+          </button>
+        )}
         {tooltipId === undefined && (
           <BcfTooltip resolver={resolver} onActorSelect={onActorSelect} />
         )}

--- a/web/app/components/boss-page-attack-timeline/boss-page-attack-timeline.tsx
+++ b/web/app/components/boss-page-attack-timeline/boss-page-attack-timeline.tsx
@@ -158,6 +158,7 @@ export type CustomStateEntry = {
 type BossPageAttackTimelineProps = AttackTimelineProps & {
   bcf: BlertChartFormat;
   customStates?: CustomStateEntry[];
+  liveFollowing?: boolean;
 };
 
 export function BossPageAttackTimeline(props: BossPageAttackTimelineProps) {
@@ -420,6 +421,7 @@ export function BossPageAttackTimeline(props: BossPageAttackTimelineProps) {
     currentTick: props.currentTick,
     onTickSelect: props.updateTickOnPage,
     useCanvas: true,
+    liveFollowing: props.liveFollowing,
   };
 
   let fullTimeline = null;


### PR DESCRIPTION
Updates the timeline to be aware of users' manual scroll events and stop auto scrolling to the live tick when users scroll back.

Fixes #265.