### PR TITLE
common: Export structured spell/attack definitions

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -190,6 +190,7 @@ export { DataRepository } from './data-repository/data-repository';
 export {
   attackDefinitionJsonToProto,
   jsonToServerMessage,
+  jsonToProtoEvent,
   protoToJsonEvent,
   serverMessageToJson,
   spellDefinitionJsonToProto,
@@ -278,8 +279,29 @@ export type { TobChallengeStatsRow } from './db/challenge-stats';
 
 export { default as PriceTracker } from './price-tracker';
 
-export { default as attackDefinitions } from './generated/attack_definitions.json';
-export { default as spellDefinitions } from './generated/spell_definitions.json';
+import {
+  PlayerAttack as PlayerAttackEnum,
+  PlayerSpell as PlayerSpellEnum,
+} from './challenge';
+import attackDefinitionsJson from './generated/attack_definitions.json';
+import spellDefinitionsJson from './generated/spell_definitions.json';
+
+export const attackDefinitions = attackDefinitionsJson;
+export const spellDefinitions = spellDefinitionsJson;
+
+/** Lookup table of attack metadata keyed by `PlayerAttack`. */
+export const attackDefinitionsById: ReadonlyMap<
+  PlayerAttackEnum,
+  (typeof attackDefinitionsJson)[number]
+> = new Map(
+  attackDefinitionsJson.map((d) => [d.protoId as PlayerAttackEnum, d]),
+);
+
+/** Lookup table of spell metadata keyed by `PlayerSpell`. */
+export const spellDefinitionsById: ReadonlyMap<
+  PlayerSpellEnum,
+  (typeof spellDefinitionsJson)[number]
+> = new Map(spellDefinitionsJson.map((d) => [d.id as PlayerSpellEnum, d]));
 
 export {
   type LaneSpawnJson,

--- a/common/jest.config.js
+++ b/common/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     '!**/migrations/**',
     '!**/npcs/**',
     '!**/db/**',
-    '!index.ts',
+    '!**/index.ts',
     '!split.ts',
   ],
 };

--- a/common/protocol/index.ts
+++ b/common/protocol/index.ts
@@ -1,6 +1,7 @@
 export {
   attackDefinitionJsonToProto,
   jsonToServerMessage,
+  jsonToProtoEvent,
   serverMessageToJson,
   spellDefinitionJsonToProto,
 } from './json-converter';

--- a/common/protocol/json-converter.ts
+++ b/common/protocol/json-converter.ts
@@ -89,7 +89,7 @@ function serverMessageJsonToProto(json: ServerMessageJson): ServerMessage {
   }
 
   if (json.challengeEvents !== undefined) {
-    const events = json.challengeEvents.map(eventJsonToProto);
+    const events = json.challengeEvents.map(jsonToProtoEvent);
     msg.setChallengeEventsList(events);
   }
 
@@ -231,7 +231,7 @@ function serverMessageJsonToProto(json: ServerMessageJson): ServerMessage {
   return msg;
 }
 
-function eventJsonToProto(json: EventJson): Event {
+export function jsonToProtoEvent(json: EventJson): Event {
   const event = new Event();
   event.setType(json.type as AnyEnum);
   if (json.challengeId !== undefined) {


### PR DESCRIPTION
Updates common to export maps of player attack/spell ID to definition metadata alongside the raw JSON blobs. Additionally, exports the jsonToProtoEvent helper.