### PR TITLE
challenge: TickMapping and MergeMapping helpers

### DIFF
--- a/challenge-server/merging/__tests__/tick-mapping.test.ts
+++ b/challenge-server/merging/__tests__/tick-mapping.test.ts
@@ -1,0 +1,370 @@
+import { AlignmentAction, AlignmentResult } from '../alignment';
+import { MergeMapping, TickMapping } from '../tick-mapping';
+
+describe('TickMapping', () => {
+  describe('identity', () => {
+    it('maps every tick to itself', () => {
+      const mapping = TickMapping.identity(5);
+      for (let i = 0; i < 5; i++) {
+        expect(mapping.toMerged(i)).toBe(i);
+        expect(mapping.toClient(i)).toBe(i);
+      }
+    });
+
+    it('returns undefined for out-of-range ticks', () => {
+      const mapping = TickMapping.identity(3);
+      expect(mapping.toMerged(3)).toBeUndefined();
+      expect(mapping.toClient(3)).toBeUndefined();
+    });
+  });
+
+  describe('fromAlignment', () => {
+    it('maps ticks correctly with an INSERT', () => {
+      // base:   0,1,_,2,3,4
+      // target: 0,1,2,3,4,5
+      const alignment: AlignmentResult = {
+        alignments: [
+          [
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 0,
+              targetIndex: 0,
+              score: 1,
+            },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 1,
+              targetIndex: 1,
+              score: 1,
+            },
+            { action: AlignmentAction.INSERT, targetIndex: 2 },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 2,
+              targetIndex: 3,
+              score: 1,
+            },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 3,
+              targetIndex: 4,
+              score: 1,
+            },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 4,
+              targetIndex: 5,
+              score: 1,
+            },
+          ],
+        ],
+        coverage: 0.8,
+        gapCount: 1,
+      };
+
+      const result = TickMapping.fromAlignment(5, 5, alignment);
+      expect(result.mergedTickCount).toBe(6);
+
+      expect(result.base.toMerged(0)).toBe(0);
+      expect(result.base.toMerged(1)).toBe(1);
+      expect(result.base.toMerged(2)).toBe(3);
+      expect(result.base.toMerged(3)).toBe(4);
+      expect(result.base.toMerged(4)).toBe(5);
+      expect(result.base.toMerged(5)).toBeUndefined();
+
+      expect(result.target.toMerged(0)).toBe(0);
+      expect(result.target.toMerged(1)).toBe(1);
+      expect(result.target.toMerged(2)).toBe(2);
+      expect(result.target.toMerged(3)).toBe(3);
+      expect(result.target.toMerged(4)).toBe(4);
+      expect(result.target.toMerged(5)).toBe(5);
+
+      expect(result.base.toClient(0)).toBe(0);
+      expect(result.base.toClient(1)).toBe(1);
+      expect(result.base.toClient(2)).toBeUndefined();
+      expect(result.base.toClient(3)).toBe(2);
+      expect(result.base.toClient(4)).toBe(3);
+      expect(result.base.toClient(5)).toBe(4);
+    });
+
+    it('maps ticks correctly with a KEEP', () => {
+      // base:   0,1,2,3
+      // target: 0,_,1,2
+      const alignment: AlignmentResult = {
+        alignments: [
+          [
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 0,
+              targetIndex: 0,
+              score: 1,
+            },
+            { action: AlignmentAction.KEEP, baseIndex: 1 },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 2,
+              targetIndex: 1,
+              score: 1,
+            },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 3,
+              targetIndex: 2,
+              score: 1,
+            },
+          ],
+        ],
+        coverage: 0.75,
+        gapCount: 1,
+      };
+
+      const result = TickMapping.fromAlignment(4, 3, alignment);
+      expect(result.mergedTickCount).toBe(4);
+
+      expect(result.base.toMerged(0)).toBe(0);
+      expect(result.base.toMerged(1)).toBe(1);
+      expect(result.base.toMerged(2)).toBe(2);
+      expect(result.base.toMerged(3)).toBe(3);
+
+      expect(result.target.toMerged(0)).toBe(0);
+      expect(result.target.toMerged(1)).toBe(2);
+      expect(result.target.toMerged(2)).toBe(3);
+
+      expect(result.target.toClient(1)).toBeUndefined();
+    });
+
+    it('handles base ticks before and after the alignment', () => {
+      // base:   0,1,2,3,4,5
+      // target: _,_,0,1,_,_
+      const alignment: AlignmentResult = {
+        alignments: [
+          [
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 2,
+              targetIndex: 0,
+              score: 1,
+            },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 3,
+              targetIndex: 1,
+              score: 1,
+            },
+          ],
+        ],
+        coverage: 1 / 3,
+        gapCount: 0,
+      };
+
+      const result = TickMapping.fromAlignment(6, 2, alignment);
+      expect(result.mergedTickCount).toBe(6);
+
+      expect(result.base.toMerged(0)).toBe(0);
+      expect(result.base.toMerged(1)).toBe(1);
+      expect(result.base.toMerged(2)).toBe(2);
+      expect(result.base.toMerged(3)).toBe(3);
+      expect(result.base.toMerged(4)).toBe(4);
+      expect(result.base.toMerged(5)).toBe(5);
+
+      expect(result.target.toMerged(0)).toBe(2);
+      expect(result.target.toMerged(1)).toBe(3);
+    });
+
+    it('exposes clientTickCount', () => {
+      const result = TickMapping.fromAlignment(6, 3, {
+        alignments: [
+          [
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 0,
+              targetIndex: 0,
+              score: 1,
+            },
+            {
+              action: AlignmentAction.MERGE,
+              baseIndex: 1,
+              targetIndex: 1,
+              score: 1,
+            },
+          ],
+        ],
+        coverage: 1 / 3,
+        gapCount: 0,
+      });
+
+      expect(result.base.clientTickCount).toBe(6);
+      expect(result.target.clientTickCount).toBe(3);
+    });
+  });
+});
+
+describe('MergeMapping', () => {
+  // Simulate a three-client merge: A (base), B (step 1), C (step 2).
+  //
+  // Step 1: A(5 ticks) + B(5 ticks), identity alignment.
+  //
+  // Step 2: Merged(5 ticks) + C(5 ticks), aligned with INSERT at position 2.
+  //   Merged ticks: 0,1,2,3,4,_
+  //   C ticks:      _,0,1,2,3,4
+  //   Alignment: merge(0,0), merge(1,1), insert(C:2), merge(2,3), merge(3,4)
+
+  const CLIENT_A = 1;
+  const CLIENT_B = 2;
+  const CLIENT_C = 3;
+
+  function buildStep1Mappings() {
+    return {
+      base: TickMapping.identity(5),
+      target: TickMapping.identity(5),
+    };
+  }
+
+  function buildStep2Mappings() {
+    const alignment: AlignmentResult = {
+      alignments: [
+        [
+          {
+            action: AlignmentAction.MERGE,
+            baseIndex: 0,
+            targetIndex: 0,
+            score: 1,
+          },
+          {
+            action: AlignmentAction.MERGE,
+            baseIndex: 1,
+            targetIndex: 1,
+            score: 1,
+          },
+          { action: AlignmentAction.INSERT, targetIndex: 2 },
+          {
+            action: AlignmentAction.MERGE,
+            baseIndex: 2,
+            targetIndex: 3,
+            score: 1,
+          },
+          {
+            action: AlignmentAction.MERGE,
+            baseIndex: 3,
+            targetIndex: 4,
+            score: 1,
+          },
+        ],
+      ],
+      coverage: 0.8,
+      gapCount: 1,
+    };
+    const result = TickMapping.fromAlignment(5, 5, alignment);
+    return { base: result.base, target: result.target };
+  }
+
+  describe('resolveClientTick', () => {
+    it('resolves the base client through the full chain', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+      mm.commit();
+
+      const step2 = buildStep2Mappings();
+      mm.begin(CLIENT_C, step2.base, step2.target, 6);
+      mm.commit();
+
+      expect(mm.resolveClientTick(0, CLIENT_A)).toBe(0);
+      expect(mm.resolveClientTick(3, CLIENT_A)).toBe(2);
+      expect(mm.resolveClientTick(5, CLIENT_A)).toBe(4);
+    });
+
+    it('resolves a step-1 target through the chain', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+      mm.commit();
+
+      const step2 = buildStep2Mappings();
+      mm.begin(CLIENT_C, step2.base, step2.target, 6);
+      mm.commit();
+
+      expect(mm.resolveClientTick(0, CLIENT_B)).toBe(0);
+      expect(mm.resolveClientTick(3, CLIENT_B)).toBe(2);
+      expect(mm.resolveClientTick(5, CLIENT_B)).toBe(4);
+    });
+
+    it('resolves the latest target directly', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+      mm.commit();
+
+      const step2 = buildStep2Mappings();
+      mm.begin(CLIENT_C, step2.base, step2.target, 6);
+      mm.commit();
+
+      expect(mm.resolveClientTick(2, CLIENT_C)).toBe(2);
+      expect(mm.resolveClientTick(0, CLIENT_C)).toBe(0);
+    });
+
+    it('returns undefined for an unknown client', () => {
+      const mm = new MergeMapping(CLIENT_A);
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+      mm.commit();
+
+      expect(mm.resolveClientTick(0, 999)).toBeUndefined();
+    });
+
+    it('returns undefined when a tick has no mapping in the chain', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step2 = buildStep2Mappings();
+      mm.begin(CLIENT_C, step2.base, step2.target, 6);
+      mm.commit();
+
+      // Tick 2 was inserted from C, it has no mapping in the other clients.
+      expect(mm.resolveClientTick(2, CLIENT_A)).toBeUndefined();
+      expect(mm.resolveClientTick(2, CLIENT_B)).toBeUndefined();
+      expect(mm.resolveClientTick(2, CLIENT_C)).toBe(2);
+    });
+  });
+
+  describe('in-flight entry', () => {
+    it('participates in resolution before commit', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+
+      expect(mm.resolveClientTick(2, CLIENT_B)).toBe(2);
+      expect(mm.resolveClientTick(2, CLIENT_A)).toBe(2);
+    });
+
+    it('is cleared by discard', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+      mm.discard();
+
+      expect(mm.resolveClientTick(0, CLIENT_B)).toBeUndefined();
+      expect(mm.resolveClientTick(0, CLIENT_A)).toBe(0);
+    });
+
+    it('moves to the committed chain on commit', () => {
+      const mm = new MergeMapping(CLIENT_A);
+
+      const step1 = buildStep1Mappings();
+      mm.begin(CLIENT_B, step1.base, step1.target, 5);
+      mm.commit();
+
+      // Begin a new in-flight for C.
+      const step2 = buildStep2Mappings();
+      mm.begin(CLIENT_C, step2.base, step2.target, 6);
+      expect(mm.resolveClientTick(4, CLIENT_B)).toBe(3);
+      expect(mm.resolveClientTick(2, CLIENT_A)).toBeUndefined();
+      expect(mm.resolveClientTick(2, CLIENT_B)).toBeUndefined();
+      expect(mm.resolveClientTick(2, CLIENT_C)).toBe(2);
+    });
+  });
+});

--- a/challenge-server/merging/tick-mapping.ts
+++ b/challenge-server/merging/tick-mapping.ts
@@ -1,0 +1,275 @@
+import { AlignmentAction, AlignmentResult } from './alignment';
+
+/**
+ * Maps tick indices between a client's local tick space and the merged
+ * timeline's tick space.
+ */
+export class TickMapping {
+  private readonly forward: (number | undefined)[];
+  private readonly reverse: (number | undefined)[];
+
+  private constructor(
+    forward: (number | undefined)[],
+    reverse: (number | undefined)[],
+  ) {
+    this.forward = forward;
+    this.reverse = reverse;
+  }
+
+  /**
+   * Creates an identity mapping where tick N maps to merged tick N.
+   * @param tickCount The number of client ticks in the mapping.
+   */
+  public static identity(tickCount: number): TickMapping {
+    const mapping = Array.from({ length: tickCount }, (_, i) => i);
+    return new TickMapping([...mapping], [...mapping]);
+  }
+
+  /**
+   * Builds base and target tick mappings from an alignment result.
+   *
+   * Walks through the alignment entries in order, copying base ticks outside
+   * alignments at their natural positions. Within each local alignment:
+   * - MERGE maps both base and target to the same merged position
+   * - KEEP maps only the base tick
+   * - INSERT maps only the target tick, increasing the merged tick count
+   *
+   * @param baseTickCount The number of base ticks in the alignment.
+   * @param targetTickCount The number of target ticks in the alignment.
+   * @param alignment The alignment result to build mappings from.
+   * @returns The base and target mappings, and the combined tick count.
+   */
+  public static fromAlignment(
+    baseTickCount: number,
+    targetTickCount: number,
+    alignment: AlignmentResult,
+  ): { base: TickMapping; target: TickMapping; mergedTickCount: number } {
+    const baseToMerged = Array<number | undefined>(baseTickCount).fill(
+      undefined,
+    );
+    const targetToMerged = Array<number | undefined>(targetTickCount).fill(
+      undefined,
+    );
+
+    let mergedPos = 0;
+    let basePos = 0;
+
+    for (const localAlignment of alignment.alignments) {
+      // Alignments always start and end with a MERGE entry.
+      const firstBase = (localAlignment[0] as { baseIndex: number }).baseIndex;
+      const lastEntry = localAlignment[localAlignment.length - 1];
+      const lastBase = (lastEntry as { baseIndex: number }).baseIndex;
+
+      while (basePos < firstBase) {
+        baseToMerged[basePos] = mergedPos;
+        mergedPos++;
+        basePos++;
+      }
+
+      for (const entry of localAlignment) {
+        switch (entry.action) {
+          case AlignmentAction.MERGE:
+            baseToMerged[entry.baseIndex] = mergedPos;
+            targetToMerged[entry.targetIndex] = mergedPos;
+            break;
+          case AlignmentAction.KEEP:
+            baseToMerged[entry.baseIndex] = mergedPos;
+            break;
+          case AlignmentAction.INSERT:
+            targetToMerged[entry.targetIndex] = mergedPos;
+            break;
+        }
+        mergedPos++;
+      }
+
+      basePos = lastBase + 1;
+    }
+
+    while (basePos < baseTickCount) {
+      baseToMerged[basePos] = mergedPos;
+      mergedPos++;
+      basePos++;
+    }
+
+    const mergedTickCount = mergedPos;
+
+    const mergedToBase = Array<number | undefined>(mergedTickCount).fill(
+      undefined,
+    );
+    const mergedToTarget = Array<number | undefined>(mergedTickCount).fill(
+      undefined,
+    );
+
+    for (let i = 0; i < baseTickCount; i++) {
+      if (baseToMerged[i] !== undefined) {
+        mergedToBase[baseToMerged[i]!] = i;
+      }
+    }
+    for (let i = 0; i < targetTickCount; i++) {
+      if (targetToMerged[i] !== undefined) {
+        mergedToTarget[targetToMerged[i]!] = i;
+      }
+    }
+
+    return {
+      base: new TickMapping(baseToMerged, mergedToBase),
+      target: new TickMapping(targetToMerged, mergedToTarget),
+      mergedTickCount,
+    };
+  }
+
+  /** The number of client ticks in this mapping. */
+  public get clientTickCount(): number {
+    return this.forward.length;
+  }
+
+  /** Maps a client tick index to its merged tick index. */
+  public toMerged(clientTick: number): number | undefined {
+    return this.forward[clientTick];
+  }
+
+  /** Maps a merged tick index to its client tick index. */
+  public toClient(mergedTick: number): number | undefined {
+    return this.reverse[mergedTick];
+  }
+}
+
+type MappingChainEntry = {
+  targetClientId: number;
+  baseMapping: TickMapping;
+  targetMapping: TickMapping;
+  mergedTickCount: number;
+};
+
+/**
+ * Tracks the composed tick mapping state across an entire merge operation.
+ *
+ * Each successful merge step appends an entry recording its base and target
+ * mappings. To resolve a tick from the current merged space back to any
+ * client's original tick space, the chain is walked in reverse.
+ *
+ * The in-flight entry represents the current (uncommitted) merge step. It
+ * participates in resolution but is not part of the committed chain. If
+ * the step fails, clear it; if it succeeds, call {@link commit}.
+ */
+export class MergeMapping {
+  private readonly baseClientId: number;
+  private readonly chain: MappingChainEntry[] = [];
+  private inFlight: MappingChainEntry | null = null;
+
+  constructor(baseClientId: number) {
+    this.baseClientId = baseClientId;
+  }
+
+  /**
+   * Sets the in-flight entry for the current merge step.
+   *
+   * @param targetClientId The ID of the target client.
+   * @param baseMapping The tick mapping for base timeline.
+   * @param targetMapping The tick mapping for target client's timeline.
+   * @param mergedTickCount The merged tick count for the merge step.
+   */
+  public begin(
+    targetClientId: number,
+    baseMapping: TickMapping,
+    targetMapping: TickMapping,
+    mergedTickCount: number,
+  ): void {
+    this.inFlight = {
+      targetClientId,
+      baseMapping,
+      targetMapping,
+      mergedTickCount,
+    };
+  }
+
+  /** Commits the in-flight entry to the chain. */
+  public commit(): void {
+    if (this.inFlight !== null) {
+      this.chain.push(this.inFlight);
+      this.inFlight = null;
+    }
+  }
+
+  /** Discards the in-flight entry. */
+  public discard(): void {
+    this.inFlight = null;
+  }
+
+  /**
+   * Returns the target client ID for the current in-flight merge step, or
+   * `null` if no step is in progress.
+   */
+  public getTargetClientId(): number | null {
+    return this.inFlight?.targetClientId ?? null;
+  }
+
+  /**
+   * Returns the base mapping for the current in-flight merge step, or
+   * `null` if no step is in progress.
+   */
+  public getBaseMapping(): TickMapping | null {
+    return this.inFlight?.baseMapping ?? null;
+  }
+
+  /**
+   * Returns the target mapping for the current in-flight merge step, or
+   * `null` if no step is in progress.
+   */
+  public getTargetMapping(): TickMapping | null {
+    return this.inFlight?.targetMapping ?? null;
+  }
+
+  /**
+   * Returns the merged tick count for the current in-flight merge step, or
+   * `null` if no step is in progress.
+   */
+  public getMergedTickCount(): number | null {
+    return this.inFlight?.mergedTickCount ?? null;
+  }
+
+  /**
+   * Resolves a tick index in the current merged space back to a specific
+   * client's original tick space.
+   *
+   * @param mergedIndex The index of the tick in the merged space.
+   * @param clientId ID of the client for which to resolve the tick.
+   * @returns Index of the tick in the client's original tick space,
+   *   or `undefined` if the tick is not mapped.
+   */
+  public resolveClientTick(
+    mergedIndex: number,
+    clientId: number,
+  ): number | undefined {
+    let current: number | undefined = mergedIndex;
+
+    if (this.inFlight !== null) {
+      if (this.inFlight.targetClientId === clientId) {
+        return this.inFlight.targetMapping.toClient(current);
+      }
+      current = this.inFlight.baseMapping.toClient(current);
+      if (current === undefined) {
+        return undefined;
+      }
+    }
+
+    for (let i = this.chain.length - 1; i >= 0; i--) {
+      const entry = this.chain[i];
+
+      if (entry.targetClientId === clientId) {
+        return entry.targetMapping.toClient(current);
+      }
+
+      current = entry.baseMapping.toClient(current);
+      if (current === undefined) {
+        return undefined;
+      }
+    }
+
+    if (clientId === this.baseClientId) {
+      return current;
+    }
+
+    return undefined;
+  }
+}

--- a/challenge-server/merging/trace.ts
+++ b/challenge-server/merging/trace.ts
@@ -5,6 +5,7 @@ import { AlignmentResult, LocalAlignment } from './alignment';
 import { ReferenceSelection } from './classification';
 import { MergeClientClassification, MergeClientStatus } from './merge';
 import { NpcState, PlayerState, TickState, TickStateArray } from './tick-state';
+import { TickMapping } from './tick-mapping';
 
 export type PlayerSummary = {
   username: string;
@@ -163,6 +164,18 @@ export function serializeAlignmentResult(
     coverage: result.coverage,
     gapCount: result.gapCount,
   };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function serializeTickMapping(mapping: TickMapping): Record<number, number> {
+  const result: Record<number, number> = {};
+  for (let i = 0; i < mapping.clientTickCount; i++) {
+    const merged = mapping.toMerged(i);
+    if (merged !== undefined) {
+      result[i] = merged;
+    }
+  }
+  return result;
 }
 
 export class MergeTracer {


### PR DESCRIPTION
A TickMapping stores a forward and reverse map of tick numbers between two clients. They can be created either as an identity mapping or from an alignment output.

A MergeMapping stores a chain of tick mappings between client pairs through an incremental multi-client merge. It allows resolving any tick within the current merged tick space back to its original client tick space. Additionally, it stores an "in-flight" merge entry for an ongoing client merge, which can be either committed or discarded.