### PR TITLE
challenge: Classify events by merge strategy

### DIFF
--- a/challenge-server/jest.config.js
+++ b/challenge-server/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testMatch: ['**/*.test.ts'],
   coveragePathIgnorePatterns: [
     '/__tests__/fixtures\\.ts$',
+    '/merging/event\\.ts$', // Classification only, no logic.
     '/merging/trace\\.ts$',
   ],
   transform: {

--- a/challenge-server/merging/event.ts
+++ b/challenge-server/merging/event.ts
@@ -1,35 +1,447 @@
-// import { Event } from '@blert/common/generated/event_pb';
+import { NpcAttack, PlayerAttack } from '@blert/common';
+import { Event } from '@blert/common/generated/event_pb';
 
-// import logger from '../log';
+export type EventType = Event.TypeMap[keyof Event.TypeMap];
 
-// /**
-//  * Returns a unique key for the given event.
-//  * @param event
-//  */
-// function eventKey(event: Event): string {
-//   const type = event.getType();
-//   switch (type) {
-//     case Event.Type.DEPRECATED_CHALLENGE_START:
-//     case Event.Type.DEPRECATED_CHALLENGE_END:
-//     case Event.Type.DEPRECATED_CHALLENGE_UPDATE:
-//     case Event.Type.DEPRECATED_STAGE_UPDATE:
-//       return `deprecated-${type}`;
+export const SYNTHETIC_EVENT_SOURCE = 0;
 
-//     case Event.Type.PLAYER_UPDATE:
-//       return `player-update-${event.getPlayer()!.getName()}`;
-//   }
+/**
+ * An event paired with merge pipeline metadata.
+ *
+ * Mutated by stages of the merge pipeline to attach metadata.
+ * A `source` of `SYNTHETIC_EVENT_SOURCE` indicates that the event did not
+ * originate from any client.
+ */
+export type TaggedEvent = {
+  event: Event;
+  source: number;
+};
 
-//   const _exhaustive: never = type;
+/**
+ * Utility type that asserts two types are equal. Used to enforce exhaustive
+ * event classification at compile time.
+ */
+export type Assert<_T extends true> = never;
+export type Equals<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false;
 
-//   logger.error('unknown_event_type', { type });
-//   return `unknown-${type}`;
-// }
+/**
+ * Event types that no longer exist in the protocol and are never processed.
+ */
+type DeprecatedEventType =
+  | typeof Event.Type.DEPRECATED_CHALLENGE_START
+  | typeof Event.Type.DEPRECATED_CHALLENGE_END
+  | typeof Event.Type.DEPRECATED_CHALLENGE_UPDATE
+  | typeof Event.Type.DEPRECATED_STAGE_UPDATE;
 
-// /**
-//  * Returns a map of event keys to events.
-//  * @param events Events to map.
-//  * @returns The resulting map.
-//  */
-// export function eventKeyMap(events: Event[]): Map<string, Event> {
-//   return new Map(events.map((event) => [eventKey(event), event]));
-// }
+/**
+ * Event types from solo-only challenges that never have to be merged, instead
+ * getting forwarded through the pipeline as-is.
+ */
+type SoloEventType =
+  | typeof Event.Type.COLOSSEUM_HANDICAP_CHOICE
+  | typeof Event.Type.COLOSSEUM_DOOM_APPLIED
+  | typeof Event.Type.COLOSSEUM_TOTEM_HEAL
+  | typeof Event.Type.COLOSSEUM_REENTRY_POOLS
+  | typeof Event.Type.COLOSSEUM_SOL_DUST
+  | typeof Event.Type.COLOSSEUM_SOL_GRAPPLE
+  | typeof Event.Type.COLOSSEUM_SOL_POOLS
+  | typeof Event.Type.COLOSSEUM_SOL_LASERS
+  | typeof Event.Type.MOKHAIOTL_ATTACK_STYLE
+  | typeof Event.Type.MOKHAIOTL_ORB
+  | typeof Event.Type.MOKHAIOTL_OBJECTS
+  | typeof Event.Type.MOKHAIOTL_LARVA_LEAK
+  | typeof Event.Type.MOKHAIOTL_SHOCKWAVE
+  | typeof Event.Type.INFERNO_WAVE_START;
+
+/**
+ * Event types that are derived from the final merged timeline rather than
+ * being reconciled from client data.
+ */
+export type DerivedEventType =
+  | typeof Event.Type.TOB_NYLO_WAVE_STALL
+  | typeof Event.Type.TOB_NYLO_CLEANUP_END
+  | typeof Event.Type.TOB_NYLO_BOSS_SPAWN
+  | typeof Event.Type.TOB_VERZIK_REDS_SPAWN;
+
+const DERIVED_EVENT_RECORD: Record<DerivedEventType, true> = {
+  [Event.Type.TOB_NYLO_WAVE_STALL]: true,
+  [Event.Type.TOB_NYLO_CLEANUP_END]: true,
+  [Event.Type.TOB_NYLO_BOSS_SPAWN]: true,
+  [Event.Type.TOB_VERZIK_REDS_SPAWN]: true,
+};
+
+export const DERIVED_EVENT_TYPES: ReadonlySet<EventType> = new Set(
+  Object.keys(DERIVED_EVENT_RECORD).map(Number) as EventType[],
+);
+
+/**
+ * Player event types that are merged tick-by-tick using PRIMARY/SECONDARY
+ * data source priority.
+ *
+ * TODO(frolv): PLAYER_ATTACK and PLAYER_SPELL are tick-state temporarily
+ * until enough test data to understand spell/attack desync exists.
+ */
+export type PlayerTickStateEventType =
+  | typeof Event.Type.PLAYER_UPDATE
+  | typeof Event.Type.PLAYER_ATTACK
+  | typeof Event.Type.PLAYER_SPELL;
+
+const PLAYER_TICK_STATE_RECORD: Record<PlayerTickStateEventType, true> = {
+  [Event.Type.PLAYER_UPDATE]: true,
+  [Event.Type.PLAYER_ATTACK]: true,
+  [Event.Type.PLAYER_SPELL]: true,
+};
+
+export const PLAYER_TICK_STATE_TYPES: ReadonlySet<EventType> = new Set(
+  Object.keys(PLAYER_TICK_STATE_RECORD).map(Number) as EventType[],
+);
+
+/**
+ * Graphics and positional event types that are merged tick-by-tick. Both
+ * sides' events are kept without deduplication because some are delta-based
+ * and resolved during resynchronization.
+ */
+export type GraphicsEventType =
+  | typeof Event.Type.TOB_MAIDEN_BLOOD_SPLATS
+  | typeof Event.Type.TOB_VERZIK_YELLOWS
+  | typeof Event.Type.TOB_SOTE_MAZE_PATH;
+
+const GRAPHICS_EVENT_RECORD: Record<GraphicsEventType, true> = {
+  [Event.Type.TOB_MAIDEN_BLOOD_SPLATS]: true,
+  [Event.Type.TOB_VERZIK_YELLOWS]: true,
+  [Event.Type.TOB_SOTE_MAZE_PATH]: true,
+};
+
+export const GRAPHICS_EVENT_TYPES: ReadonlySet<EventType> = new Set(
+  Object.keys(GRAPHICS_EVENT_RECORD).map(Number) as EventType[],
+);
+
+/**
+ * NPC event types merged tick-by-tick: missing NPCs are added from the
+ * target.
+ *
+ * TODO(frolv): NPC_ATTACK is tick-state temporarily until enough test data to
+ * understand desync exists.
+ */
+type NpcTickStateEventType =
+  | typeof Event.Type.NPC_UPDATE
+  | typeof Event.Type.NPC_ATTACK;
+
+const NPC_TICK_STATE_RECORD: Record<NpcTickStateEventType, true> = {
+  [Event.Type.NPC_UPDATE]: true,
+  [Event.Type.NPC_ATTACK]: true,
+};
+
+export const NPC_TICK_STATE_TYPES: ReadonlySet<EventType> = new Set(
+  Object.keys(NPC_TICK_STATE_RECORD).map(Number) as EventType[],
+);
+
+/**
+ * All event types representing per-tick game state, merged on a tick-by-tick
+ * basis.
+ */
+export type TickStateEventType =
+  | PlayerTickStateEventType
+  | NpcTickStateEventType
+  | GraphicsEventType;
+
+export const TICK_STATE_EVENT_TYPES =
+  PLAYER_TICK_STATE_TYPES.union(NPC_TICK_STATE_TYPES).union(
+    GRAPHICS_EVENT_TYPES,
+  );
+
+/**
+ * Event types that are deferred from the tick-by-tick merge and collected
+ * into per-client buffers for stream reconciliation (temporal dedup).
+ */
+export type StreamEventType =
+  | typeof Event.Type.PLAYER_DEATH
+  | typeof Event.Type.NPC_SPAWN
+  | typeof Event.Type.NPC_DEATH
+  | typeof Event.Type.TOB_MAIDEN_CRAB_LEAK
+  | typeof Event.Type.TOB_BLOAT_DOWN
+  | typeof Event.Type.TOB_BLOAT_UP
+  | typeof Event.Type.TOB_BLOAT_HANDS_DROP
+  | typeof Event.Type.TOB_BLOAT_HANDS_SPLAT
+  | typeof Event.Type.TOB_NYLO_WAVE_SPAWN
+  | typeof Event.Type.TOB_SOTE_MAZE_PROC
+  | typeof Event.Type.TOB_SOTE_MAZE_END
+  | typeof Event.Type.TOB_XARPUS_PHASE
+  | typeof Event.Type.TOB_XARPUS_EXHUMED
+  | typeof Event.Type.TOB_XARPUS_SPLAT
+  | typeof Event.Type.TOB_VERZIK_PHASE
+  | typeof Event.Type.TOB_VERZIK_DAWN_DROP
+  | typeof Event.Type.TOB_VERZIK_HEAL;
+
+/**
+ * Event types that augment a previous attack with additional context.
+ * These are resolved by mapping them back to their attack in the merged
+ * timeline rather than being temporally deduped.
+ */
+export type AttackMappedEventType =
+  | typeof Event.Type.TOB_VERZIK_ATTACK_STYLE
+  | typeof Event.Type.TOB_VERZIK_BOUNCE
+  | typeof Event.Type.TOB_VERZIK_DAWN;
+
+// Compile-time check: every EventType must be classified into exactly one
+// category. Adding a new event type to the proto without classifying it here
+// will cause a compile error.
+type _ExhaustiveClassification = Assert<
+  Equals<
+    EventType,
+    | DeprecatedEventType
+    | SoloEventType
+    | DerivedEventType
+    | TickStateEventType
+    | StreamEventType
+    | AttackMappedEventType
+  >
+>;
+
+/**
+ * Extracts a deduplication identity key from a stream event. Events with the
+ * same key from different clients are candidates for temporal matching.
+ */
+type IdentityKeyFn = (event: Event) => string;
+
+/**
+ * Configuration for deduplicating a stream event type.
+ */
+export type StreamEventConfig = {
+  /** Extracts the identity key from an event. */
+  identityKey: IdentityKeyFn;
+  /**
+   * Maximum tick gap within which two events are considered the same.
+   * If null, the event is unique within the stage.
+   */
+  temporalWindow: number | null;
+};
+
+function actorIdKey(event: Event): string {
+  const player = event.getPlayer();
+  if (player !== undefined) {
+    return player.getName();
+  }
+  const npc = event.getNpc();
+  if (npc !== undefined) {
+    return String(npc.getRoomId());
+  }
+  return '';
+}
+
+function singletonKey(_event: Event): string {
+  return '';
+}
+
+function bloatHandsKey(event: Event): string {
+  return event
+    .getBloatHandsList()
+    .map((c) => `${c.getX()},${c.getY()}`)
+    .sort()
+    .join('|');
+}
+
+/**
+ * Record ensuring every stream event type has a dedup config. Adding a new
+ * StreamEventType without a config entry here will cause a compile error.
+ */
+export const STREAM_EVENT_CONFIGS: Record<StreamEventType, StreamEventConfig> =
+  {
+    // Deaths are keyed by actor with a moderate window since clients can see
+    // them several ticks apart depending on how they detect the death.
+    [Event.Type.PLAYER_DEATH]: { identityKey: actorIdKey, temporalWindow: 5 },
+    [Event.Type.NPC_DEATH]: { identityKey: actorIdKey, temporalWindow: 5 },
+
+    [Event.Type.NPC_SPAWN]: { identityKey: actorIdKey, temporalWindow: null },
+
+    [Event.Type.TOB_MAIDEN_CRAB_LEAK]: {
+      identityKey: actorIdKey,
+      temporalWindow: null,
+    },
+
+    // Bloat downs are distinguished temporally.
+    [Event.Type.TOB_BLOAT_DOWN]: {
+      identityKey: singletonKey,
+      temporalWindow: 32,
+    },
+    [Event.Type.TOB_BLOAT_UP]: {
+      identityKey: singletonKey,
+      temporalWindow: 32,
+    },
+
+    // Bloat hands drops and splats are distinguished by their coord set.
+    [Event.Type.TOB_BLOAT_HANDS_DROP]: {
+      identityKey: bloatHandsKey,
+      temporalWindow: 5,
+    },
+    [Event.Type.TOB_BLOAT_HANDS_SPLAT]: {
+      identityKey: bloatHandsKey,
+      temporalWindow: 5,
+    },
+
+    // Nylocas wave spawns keyed by wave number.
+    [Event.Type.TOB_NYLO_WAVE_SPAWN]: {
+      identityKey: (e) => String(e.getNyloWave()?.getWave() ?? 0),
+      temporalWindow: 3,
+    },
+
+    // Sotetseg maze events keyed by maze number.
+    [Event.Type.TOB_SOTE_MAZE_PROC]: {
+      identityKey: (e) => String(e.getSoteMaze()?.getMaze() ?? 0),
+      temporalWindow: null,
+    },
+    [Event.Type.TOB_SOTE_MAZE_END]: {
+      identityKey: (e) => String(e.getSoteMaze()?.getMaze() ?? 0),
+      temporalWindow: null,
+    },
+
+    [Event.Type.TOB_XARPUS_PHASE]: {
+      identityKey: (e) => String(e.getXarpusPhase()),
+      temporalWindow: null,
+    },
+    [Event.Type.TOB_XARPUS_EXHUMED]: {
+      identityKey: (e) => `${e.getXCoord()},${e.getYCoord()}`,
+      temporalWindow: 16,
+    },
+    // Xarpus splats are permanent; the same coord across the fight always
+    // refers to the same splat regardless of when each client first saw it.
+    [Event.Type.TOB_XARPUS_SPLAT]: {
+      identityKey: (e) => `${e.getXCoord()},${e.getYCoord()}`,
+      temporalWindow: null,
+    },
+
+    [Event.Type.TOB_VERZIK_PHASE]: {
+      identityKey: (e) => String(e.getVerzikPhase()),
+      temporalWindow: null,
+    },
+    // Dawn drops repeat every 4 ticks with alternating dropped values.
+    // Key by dropped value with a tight window to avoid crossing cycles.
+    [Event.Type.TOB_VERZIK_DAWN_DROP]: {
+      identityKey: (e) => String(e.getVerzikDawnDrop()?.getDropped() ?? false),
+      temporalWindow: 3,
+    },
+
+    // Verzik heals keyed by player name and distinct temporally.
+    [Event.Type.TOB_VERZIK_HEAL]: {
+      identityKey: (e) => e.getVerzikHeal()?.getPlayer() ?? '',
+      temporalWindow: 30,
+    },
+  };
+
+const ATTACK_MAPPED_EVENT_RECORD: Record<AttackMappedEventType, true> = {
+  [Event.Type.TOB_VERZIK_ATTACK_STYLE]: true,
+  [Event.Type.TOB_VERZIK_BOUNCE]: true,
+  [Event.Type.TOB_VERZIK_DAWN]: true,
+};
+
+export const ATTACK_MAPPED_EVENT_TYPES: ReadonlySet<AttackMappedEventType> =
+  new Set(
+    Object.keys(ATTACK_MAPPED_EVENT_RECORD).map(
+      Number,
+    ) as AttackMappedEventType[],
+  );
+
+/**
+ * All event types that are extracted from ticks during the build step and
+ * buffered for reconciliation. This is the union of stream and attack-mapped
+ * types.
+ */
+export const BUFFERED_EVENT_TYPES: ReadonlySet<EventType> = new Set([
+  ...(Object.keys(STREAM_EVENT_CONFIGS).map(Number) as EventType[]),
+  ...(Object.keys(ATTACK_MAPPED_EVENT_RECORD).map(Number) as EventType[]),
+]);
+
+/**
+ * Creates a copy of an event with all its tick references remapped using the
+ * provided mapping function.
+ *
+ * @param tagged The event to remap.
+ * @param remap Maps a tick in the event's source tick space to the merged
+ *   tick space.
+ * @returns The remapped event.
+ */
+export function remapEventTick(
+  tagged: TaggedEvent,
+  remap: (tick: number) => number,
+): TaggedEvent {
+  if (TICK_STATE_EVENT_TYPES.has(tagged.event.getType())) {
+    throw new Error('remapEventTick called with a tick-state event');
+  }
+
+  const remapped = {
+    ...tagged,
+    event: tagged.event.clone(),
+  };
+
+  remapped.event.setTick(remap(remapped.event.getTick()));
+
+  switch (remapped.event.getType()) {
+    case Event.Type.TOB_XARPUS_EXHUMED: {
+      const xarpusExhumed = remapped.event.getXarpusExhumed()!;
+      xarpusExhumed.setSpawnTick(remap(xarpusExhumed.getSpawnTick()));
+      xarpusExhumed.setHealTicksList(
+        xarpusExhumed.getHealTicksList().map(remap),
+      );
+      break;
+    }
+
+    case Event.Type.TOB_VERZIK_ATTACK_STYLE: {
+      const style = remapped.event.getVerzikAttackStyle()!;
+      style.setNpcAttackTick(remap(style.getNpcAttackTick()));
+      break;
+    }
+
+    case Event.Type.TOB_VERZIK_BOUNCE: {
+      const bounce = remapped.event.getVerzikBounce()!;
+      bounce.setNpcAttackTick(remap(bounce.getNpcAttackTick()));
+      break;
+    }
+
+    case Event.Type.TOB_VERZIK_DAWN: {
+      const dawn = remapped.event.getVerzikDawn()!;
+      dawn.setAttackTick(remap(dawn.getAttackTick()));
+      break;
+    }
+
+    case Event.Type.MOKHAIOTL_ATTACK_STYLE: {
+      const style = remapped.event.getMokhaiotlAttackStyle()!;
+      style.setNpcAttackTick(remap(style.getNpcAttackTick()));
+      break;
+    }
+  }
+
+  return remapped;
+}
+
+// Some player and NPC attacks share the same animation and are identified by
+// which projectile is fired. However, projectiles have a shorter render
+// distance than actors, so two clients could report contradictory attacks from
+// the same actor on what is legitimately the same tick.
+const ATTACKS_NORMALIZED_FOR_PROJECTILE = new Map<number, number>([
+  // Deliberately ignore DAWN_AUTO/DAWN_SPEC as there isn't a realistic case
+  // where someone would be out of render distance of the projectile.
+  [PlayerAttack.BLOWPIPE, PlayerAttack.BLOWPIPE],
+  [PlayerAttack.BLOWPIPE_SPEC, PlayerAttack.BLOWPIPE],
+  [PlayerAttack.ZCB_AUTO, PlayerAttack.ZCB_AUTO],
+  [PlayerAttack.ZCB_SPEC, PlayerAttack.ZCB_AUTO],
+
+  [NpcAttack.TOB_SOTE_BALL, NpcAttack.TOB_SOTE_BALL],
+  [NpcAttack.TOB_SOTE_DEATH_BALL, NpcAttack.TOB_SOTE_BALL],
+]);
+
+/**
+ * Normalizes an attack type by collapsing projectile-ambiguous variants to
+ * a canonical value.
+ */
+export function normalizeAttackType(attack: number): number {
+  return ATTACKS_NORMALIZED_FOR_PROJECTILE.get(attack) ?? attack;
+}
+
+/** Returns whether two attack types differ only by projectile. */
+export function areProjectileAmbiguous(a: number, b: number): boolean {
+  return a !== b && normalizeAttackType(a) === normalizeAttackType(b);
+}


### PR DESCRIPTION
Creates an exhaustive compile-time classification of all challenge events into categories determining on how they are merged:

- Deprecated events: legacy events sent by early plugin versions that still exist in proto definitions.
- Solo events: Events specific to solo-only challenge types which can just pass through the merger directly.
- Derived events: Events which are easily derived from other events (e.g. Nylo wave stalls). The versions sent by plugins will be discarded and new events will be recomputed following the merge.
- Tick state events: Events which describe the state of the game world on a tick (actor updates, graphics/ground objects). These will be processed into rich state for granular merging, with the original events discarded and new ones reconstructed after the merge.
- Stream events: Events which represent actual discrete occurrences in game that need to be consolidated and resolved (e.g. actor spawns and deaths, boss phases, mechanics, etc.). For these events, defines a key which identifies a specific occurrence, and a temporal window for deduping (with null representing single-occurrence events).
- Attack mapped events: Events which reference and augment a past player or NPC attack. These require the main merge pass to run first, then will be consolidated between clients by the attack they reference.

This commit simply defines the classification. No actual merging or resolution logic is implemented.