### PR TITLE
challenge: Define merge quality flags

### DIFF
--- a/challenge-server/merging/__tests__/merge.test.ts
+++ b/challenge-server/merging/__tests__/merge.test.ts
@@ -14,12 +14,8 @@ import {
 
 import { ReferenceSelectionMethod } from '../classification';
 import { ClientEvents } from '../client-events';
-import {
-  Merger,
-  MergeAlertType,
-  MergeClientClassification,
-  MergeClientStatus,
-} from '../merge';
+import { Merger, MergeClientClassification, MergeClientStatus } from '../merge';
+import { MergeAlertType } from '../quality';
 
 type Proto<T> = T[keyof T];
 

--- a/challenge-server/merging/index.ts
+++ b/challenge-server/merging/index.ts
@@ -1,10 +1,24 @@
-export { ClientEvents } from './client-events';
+export {
+  type ClientAnomaly,
+  ClientEvents,
+  type ServerTicks,
+} from './client-events';
 export {
   type ChallengeInfo,
   type MergeClient,
+  MergeClientClassification,
   MergeClientStatus,
   type MergeResult,
   MergedEvents,
   Merger,
 } from './merge';
+export {
+  type AttackTargetMismatchFlag,
+  type LargeTemporalGapFlag,
+  type MergeAlert,
+  MergeAlertType,
+  type QualityFlag,
+  type UnexpectedConflictFlag,
+  type UnmappedCrossTickReferenceFlag,
+} from './quality';
 export { MergeTracer, type MergeTrace } from './trace';

--- a/challenge-server/merging/merge.ts
+++ b/challenge-server/merging/merge.ts
@@ -17,6 +17,7 @@ import {
 import { ClientAnomaly, ClientEvents, ServerTicks } from './client-events';
 import { ConsistencyIssue } from './consistency';
 import logger from '../log';
+import { MergeAlert, MergeAlertType } from './quality';
 import { SimilarityScorer } from './similarity-scorer';
 import { TickState, TickStateArray } from './tick-state';
 import { MergeTracer, TickMergeDecisionType } from './trace';
@@ -26,15 +27,6 @@ export type ChallengeInfo = {
   type: ChallengeType;
   mode: ChallengeMode;
   party: string[];
-};
-
-export const enum MergeAlertType {
-  MULTIPLE_ACCURATE_TICK_MODES = 'MULTIPLE_ACCURATE_TICK_MODES',
-}
-
-export type MergeAlert = {
-  type: MergeAlertType;
-  details?: Record<string, unknown>;
 };
 
 export const enum MergeClientStatus {

--- a/challenge-server/merging/quality.ts
+++ b/challenge-server/merging/quality.ts
@@ -1,0 +1,152 @@
+import { EventType } from './event';
+
+/**
+ * Emitted when a paired stream event has a temporal gap between base and
+ * target larger than the configured threshold.
+ */
+export type LargeTemporalGapFlag = {
+  kind: 'LARGE_TEMPORAL_GAP';
+  eventType: EventType;
+  tickGap: number;
+  baseTick: number;
+  targetTick: number;
+};
+
+/**
+ * Emitted when an attack-mapped event has multiple candidates that disagree on
+ * content and the conflict-resolution strategy is `unexpected`.
+ */
+export type UnexpectedConflictFlag = {
+  kind: 'UNEXPECTED_CONFLICT';
+  eventType: EventType;
+  attackTick: number;
+  candidateCount: number;
+};
+
+/**
+ * Emitted when an event's cross-tick reference (e.g. `npcAttackTick`) points
+ * to a client tick with no merged-space mapping. The reference is resolved
+ * heuristically by offset; the result may be inaccurate.
+ */
+export type UnmappedCrossTickReferenceFlag = {
+  kind: 'UNMAPPED_CROSS_TICK_REFERENCE';
+  eventType: EventType;
+  mergedTick: number;
+  sourceTick: number;
+  resolvedTick: number;
+};
+
+/**
+ * Emitted when two clients disagree on a player attack's target on the same
+ * merged tick.
+ */
+export type AttackTargetMismatchFlag = {
+  kind: 'ATTACK_TARGET_MISMATCH';
+  tick: number;
+  player: string;
+  keptRoomId: number;
+  discardedRoomId: number;
+  keptSourceClientId: number;
+  discardedSourceClientId: number;
+};
+
+/**
+ * Emitted when two clients disagree on a player attack's type.
+ */
+export type AttackTypeMismatchFlag = {
+  kind: 'ATTACK_TYPE_MISMATCH';
+  tick: number;
+  player: string;
+  keptType: number;
+  discardedType: number;
+  keptSourceClientId: number;
+  discardedSourceClientId: number;
+};
+
+/**
+ * Emitted when two clients disagree on a player spell's target on the same
+ * merged tick.
+ */
+export type SpellTargetMismatchFlag = {
+  kind: 'SPELL_TARGET_MISMATCH';
+  tick: number;
+  player: string;
+  keptTargetKind: 'player' | 'npc';
+  keptTargetId: number | string;
+  discardedTargetKind: 'player' | 'npc';
+  discardedTargetId: number | string;
+  keptSourceClientId: number;
+  discardedSourceClientId: number;
+};
+
+/**
+ * Emitted when two clients disagree on a player spell's type on the same
+ * merged tick.
+ */
+export type SpellTypeMismatchFlag = {
+  kind: 'SPELL_TYPE_MISMATCH';
+  tick: number;
+  player: string;
+  keptType: number;
+  discardedType: number;
+  keptSourceClientId: number;
+  discardedSourceClientId: number;
+};
+
+/**
+ * Emitted when two clients disagree on an NPC attack's type for the same NPC
+ * on a shared merged tick.
+ */
+export type NpcAttackTypeMismatchFlag = {
+  kind: 'NPC_ATTACK_TYPE_MISMATCH';
+  tick: number;
+  roomId: number;
+  npcId: number;
+  keptType: number;
+  discardedType: number;
+  keptSourceClientId: number;
+  discardedSourceClientId: number;
+};
+
+/**
+ * Emitted when two clients disagree on an NPC attack's target on the same
+ * merged tick.
+ */
+export type NpcAttackTargetMismatchFlag = {
+  kind: 'NPC_ATTACK_TARGET_MISMATCH';
+  tick: number;
+  roomId: number;
+  npcId: number;
+  keptTarget: string | null;
+  discardedTarget: string | null;
+  keptSourceClientId: number;
+  discardedSourceClientId: number;
+};
+
+/**
+ * A diagnostic signal emitted during merge consolidation. Quality flags
+ * describe data anomalies, conflicts, or alignment issues encountered while
+ * merging two timelines.
+ */
+export type QualityFlag =
+  | LargeTemporalGapFlag
+  | UnexpectedConflictFlag
+  | UnmappedCrossTickReferenceFlag
+  | AttackTargetMismatchFlag
+  | AttackTypeMismatchFlag
+  | SpellTargetMismatchFlag
+  | SpellTypeMismatchFlag
+  | NpcAttackTypeMismatchFlag
+  | NpcAttackTargetMismatchFlag;
+
+export const enum MergeAlertType {
+  MULTIPLE_ACCURATE_TICK_MODES = 'MULTIPLE_ACCURATE_TICK_MODES',
+}
+
+/**
+ * A merge-level signal emitted during merge orchestration.
+ */
+export type MergeAlert = {
+  type: MergeAlertType;
+  details?: Record<string, unknown>;
+};

--- a/challenge-server/merging/similarity-scorer.ts
+++ b/challenge-server/merging/similarity-scorer.ts
@@ -1,6 +1,7 @@
-import { EquipmentSlot, Npc, NpcAttack, PlayerAttack } from '@blert/common';
+import { EquipmentSlot, Npc } from '@blert/common';
 import { Event } from '@blert/common/generated/event_pb';
 
+import { normalizeAttackType } from './event';
 import { TickState, NpcState } from './tick-state';
 
 const VISIBLE_EQUIPMENT_SLOTS: EquipmentSlot[] = [
@@ -57,27 +58,6 @@ const ScoringConstants = {
   DEATHS_MAX_SCORE: 3,
   DEATHS_MIN_SCORE: -3,
 } as const;
-
-// Some player and NPC attacks share the same animation and are identified by
-// which projectile is fired. However, projectiles have a shorter render
-// distance than actors, so two clients could report contradictory attacks from
-// the same actor on what is legitimately the same tick. These attacks are
-// listed below and don't penalize scores.
-const ATTACKS_NORMALIZED_FOR_PROJECTILE = new Map<number, number>([
-  // Deliberately ignore DAWN_AUTO/DAWN_SPEC as there isn't a realistic case
-  // where someone would be out of render distance of the projectile.
-  [PlayerAttack.BLOWPIPE, PlayerAttack.BLOWPIPE],
-  [PlayerAttack.BLOWPIPE_SPEC, PlayerAttack.BLOWPIPE],
-  [PlayerAttack.ZCB_AUTO, PlayerAttack.ZCB_AUTO],
-  [PlayerAttack.ZCB_SPEC, PlayerAttack.ZCB_AUTO],
-
-  [NpcAttack.TOB_SOTE_BALL, NpcAttack.TOB_SOTE_BALL],
-  [NpcAttack.TOB_SOTE_DEATH_BALL, NpcAttack.TOB_SOTE_BALL],
-]);
-
-function normalizeAttackType(attack: number): number {
-  return ATTACKS_NORMALIZED_FOR_PROJECTILE.get(attack) ?? attack;
-}
 
 const enum AttackComparison {
   MATCH,

--- a/challenge-server/metrics.ts
+++ b/challenge-server/metrics.ts
@@ -20,11 +20,11 @@ import {
   Registry,
 } from 'prom-client';
 import {
+  ClientAnomaly,
   MergeAlertType,
   MergeClientClassification,
   MergeClientStatus,
-} from './merging/merge';
-import { ClientAnomaly } from './merging/client-events';
+} from './merging';
 
 const register = new Registry();
 collectDefaultMetrics({ register });


### PR DESCRIPTION
Defines "quality flags" which will be emitted by a merge step when it encounters issues that required a non-normal conflict resolution. Additionally, extracts the existing merge alert types (for overall merge issues) into this new quality file.