### PR TITLE
challenge: Graphics state helpers for merging

### DIFF
--- a/challenge-server/merging/__tests__/fixtures.ts
+++ b/challenge-server/merging/__tests__/fixtures.ts
@@ -10,23 +10,36 @@ import {
   SkillLevel,
 } from '@blert/common';
 import {
+  Coords,
   NpcAttackMap,
   Event as ProtoEvent,
   StageMap,
 } from '@blert/common/generated/event_pb';
 
 import { TickState, PlayerState, EquippedItem } from '../tick-state';
+import { CoordsLike } from '../world';
 
-type ProtoStage = StageMap[keyof StageMap];
-type ProtoDataSource =
-  ProtoEvent.Player.DataSourceMap[keyof ProtoEvent.Player.DataSourceMap];
-type ProtoNpcAttack = NpcAttackMap[keyof NpcAttackMap];
+type Proto<T> = T[keyof T];
+
+type ProtoStage = Proto<StageMap>;
+type ProtoDataSource = Proto<ProtoEvent.Player.DataSourceMap>;
+type ProtoNpcAttack = Proto<NpcAttackMap>;
 
 export type PlayerAttackState = {
   type: PlayerAttack;
   weaponId: number;
   target: number | null;
 };
+
+export function createEvent(
+  type: Proto<ProtoEvent.TypeMap>,
+  tick: number,
+): ProtoEvent {
+  const event = new ProtoEvent();
+  event.setType(type);
+  event.setTick(tick);
+  return event;
+}
 
 export type PlayerStateOptions = {
   username: string;
@@ -236,28 +249,6 @@ export function createPlayerDeathEvent({
   return event;
 }
 
-export function createVerzikBounceEvent({
-  tick,
-  npcAttackTick,
-  bouncedPlayer,
-}: {
-  tick: number;
-  npcAttackTick: number;
-  bouncedPlayer: string;
-}): ProtoEvent {
-  const event = new ProtoEvent();
-  event.setType(ProtoEvent.Type.TOB_VERZIK_BOUNCE);
-  event.setTick(tick);
-  event.setStage(Stage.TOB_VERZIK as ProtoStage);
-
-  const bounce = new ProtoEvent.VerzikBounce();
-  bounce.setNpcAttackTick(npcAttackTick);
-  bounce.setBouncedPlayer(bouncedPlayer);
-  event.setVerzikBounce(bounce);
-
-  return event;
-}
-
 export function createNpcDeathEvent({
   tick,
   roomId,
@@ -284,6 +275,99 @@ export function createNpcDeathEvent({
   npc.setRoomId(roomId);
   npc.setId(npcId);
   event.setNpc(npc);
+
+  return event;
+}
+
+function protoCoords({ x, y }: CoordsLike): Coords {
+  const c = new Coords();
+  c.setX(x);
+  c.setY(y);
+  return c;
+}
+
+export function createMaidenBloodSplatsEvent({
+  tick,
+  coords,
+}: {
+  tick: number;
+  coords: CoordsLike[];
+}): ProtoEvent {
+  const event = createEvent(ProtoEvent.Type.TOB_MAIDEN_BLOOD_SPLATS, tick);
+  event.setStage(Stage.TOB_MAIDEN as ProtoStage);
+  event.setMaidenBloodSplatsList(coords.map(protoCoords));
+  return event;
+}
+
+export function createSoteMazePathEvent({
+  tick,
+  overworldTiles,
+}: {
+  tick: number;
+  overworldTiles: CoordsLike[];
+}): ProtoEvent {
+  const event = createEvent(ProtoEvent.Type.TOB_SOTE_MAZE_PATH, tick);
+  event.setStage(Stage.TOB_SOTETSEG as ProtoStage);
+  const maze = new ProtoEvent.SoteMaze();
+  maze.setOverworldTilesList(overworldTiles.map(protoCoords));
+  event.setSoteMaze(maze);
+  return event;
+}
+
+export function createVerzikYellowsEvent({
+  tick,
+  coords,
+}: {
+  tick: number;
+  coords: CoordsLike[];
+}): ProtoEvent {
+  const event = createEvent(ProtoEvent.Type.TOB_VERZIK_YELLOWS, tick);
+  event.setStage(Stage.TOB_VERZIK as ProtoStage);
+  event.setVerzikYellowsList(coords.map(protoCoords));
+  return event;
+}
+
+export function createVerzikBounceEvent({
+  tick,
+  npcAttackTick,
+  bouncedPlayer,
+}: {
+  tick: number;
+  npcAttackTick: number;
+  bouncedPlayer: string;
+}): ProtoEvent {
+  const event = new ProtoEvent();
+  event.setType(ProtoEvent.Type.TOB_VERZIK_BOUNCE);
+  event.setTick(tick);
+  event.setStage(Stage.TOB_VERZIK as ProtoStage);
+
+  const bounce = new ProtoEvent.VerzikBounce();
+  bounce.setNpcAttackTick(npcAttackTick);
+  bounce.setBouncedPlayer(bouncedPlayer);
+  event.setVerzikBounce(bounce);
+
+  return event;
+}
+
+export function createVerzikAttackStyleEvent({
+  tick,
+  npcAttackTick,
+  style,
+}: {
+  tick: number;
+  npcAttackTick: number;
+  style: number;
+}): ProtoEvent {
+  const event = new ProtoEvent();
+  event.setType(ProtoEvent.Type.TOB_VERZIK_ATTACK_STYLE);
+  event.setTick(tick);
+
+  const attackStyle = new ProtoEvent.AttackStyle();
+  attackStyle.setNpcAttackTick(npcAttackTick);
+  attackStyle.setStyle(
+    style as ProtoEvent.AttackStyle.StyleMap[keyof ProtoEvent.AttackStyle.StyleMap],
+  );
+  event.setVerzikAttackStyle(attackStyle);
 
   return event;
 }

--- a/challenge-server/merging/__tests__/graphics.test.ts
+++ b/challenge-server/merging/__tests__/graphics.test.ts
@@ -1,0 +1,412 @@
+import { Stage } from '@blert/common';
+import { Event as ProtoEvent } from '@blert/common/generated/event_pb';
+
+import { TaggedEvent } from '../event';
+import {
+  createMaidenBloodSplatsEvent,
+  createSoteMazePathEvent,
+  createVerzikYellowsEvent,
+} from './fixtures';
+import {
+  buildGraphicsForTick,
+  buildGraphicsStates,
+  cloneGraphics,
+  createGraphicsEvents,
+  GraphicsState,
+  GraphicsType,
+} from '../graphics';
+import { coordKey } from '../world';
+
+const CLIENT_A = 1;
+const CLIENT_B = 2;
+
+function tag(event: ProtoEvent, source: number): TaggedEvent {
+  return { event, source };
+}
+
+describe('buildGraphicsForTick', () => {
+  it('returns an empty map when there are no events', () => {
+    const result = buildGraphicsForTick([], null);
+    expect(result.size).toBe(0);
+  });
+
+  it('extracts snapshot coords from a blood splats event', () => {
+    const event = createMaidenBloodSplatsEvent({
+      tick: 0,
+      coords: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+    });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    expect(result.size).toBe(1);
+    const splats = result.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS);
+    expect(splats).toBeDefined();
+    expect(splats!.size).toBe(2);
+    expect(splats!.get(coordKey({ x: 1, y: 2 }))).toBe(CLIENT_A);
+    expect(splats!.get(coordKey({ x: 3, y: 4 }))).toBe(CLIENT_A);
+  });
+
+  it('extracts snapshot coords from a verzik yellows event', () => {
+    const event = createVerzikYellowsEvent({
+      tick: 0,
+      coords: [{ x: 50, y: 60 }],
+    });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    const yellows = result.get(GraphicsType.TOB_VERZIK_YELLOWS);
+    expect(yellows).toBeDefined();
+    expect(yellows!.size).toBe(1);
+    expect(yellows!.get(coordKey({ x: 50, y: 60 }))).toBe(CLIENT_A);
+  });
+
+  it('extracts overworld tiles from a sote maze path event', () => {
+    const event = createSoteMazePathEvent({
+      tick: 0,
+      overworldTiles: [
+        { x: 100, y: 200 },
+        { x: 101, y: 200 },
+      ],
+    });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    const tiles = result.get(GraphicsType.TOB_SOTE_OVERWORLD_TILES);
+    expect(tiles).toBeDefined();
+    expect(tiles!.size).toBe(2);
+    expect(tiles!.get(coordKey({ x: 100, y: 200 }))).toBe(CLIENT_A);
+    expect(tiles!.get(coordKey({ x: 101, y: 200 }))).toBe(CLIENT_A);
+  });
+
+  it("tags every coord with the events' source client", () => {
+    const event = createMaidenBloodSplatsEvent({
+      tick: 0,
+      coords: [
+        { x: 1, y: 1 },
+        { x: 2, y: 2 },
+      ],
+    });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    const splats = result.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)!;
+    expect(splats.get(coordKey({ x: 1, y: 1 }))).toBe(CLIENT_A);
+    expect(splats.get(coordKey({ x: 2, y: 2 }))).toBe(CLIENT_A);
+  });
+
+  it('deduplicates repeated coords within a single event', () => {
+    const event = createMaidenBloodSplatsEvent({
+      tick: 0,
+      coords: [
+        { x: 1, y: 1 },
+        { x: 1, y: 1 },
+        { x: 2, y: 2 },
+      ],
+    });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    const splats = result.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)!;
+    expect(splats.size).toBe(2);
+  });
+
+  it('records an empty entry when the snapshot event has no coords', () => {
+    const event = createMaidenBloodSplatsEvent({ tick: 0, coords: [] });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    const splats = result.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS);
+    expect(splats).toBeDefined();
+    expect(splats!.size).toBe(0);
+  });
+
+  it('does not carry snapshot state forward when no event is present', () => {
+    const previous: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 1 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const result = buildGraphicsForTick([], previous);
+    expect(result.size).toBe(0);
+  });
+
+  it('replaces snapshot state when a new event is present', () => {
+    const previous: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 1 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const event = createMaidenBloodSplatsEvent({
+      tick: 1,
+      coords: [
+        { x: 9, y: 9 },
+        { x: 8, y: 8 },
+      ],
+    });
+    const result = buildGraphicsForTick([tag(event, CLIENT_B)], previous);
+
+    const splats = result.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)!;
+    expect(splats.size).toBe(2);
+    expect(splats.has(coordKey({ x: 1, y: 1 }))).toBe(false);
+    expect(splats.get(coordKey({ x: 9, y: 9 }))).toBe(CLIENT_B);
+    expect(splats.get(coordKey({ x: 8, y: 8 }))).toBe(CLIENT_B);
+  });
+
+  it('treats different graphics types as independent', () => {
+    const splatsEvent = createMaidenBloodSplatsEvent({
+      tick: 0,
+      coords: [{ x: 1, y: 1 }],
+    });
+    const yellowsEvent = createVerzikYellowsEvent({
+      tick: 0,
+      coords: [{ x: 2, y: 2 }],
+    });
+
+    const result = buildGraphicsForTick(
+      [tag(splatsEvent, CLIENT_A), tag(yellowsEvent, CLIENT_A)],
+      null,
+    );
+
+    expect(result.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)?.size).toBe(1);
+    expect(result.get(GraphicsType.TOB_VERZIK_YELLOWS)?.size).toBe(1);
+  });
+
+  it('ignores events whose type is not in GRAPHICS_CONFIGS', () => {
+    const npcEvent = new ProtoEvent();
+    npcEvent.setType(ProtoEvent.Type.NPC_UPDATE);
+
+    const result = buildGraphicsForTick([tag(npcEvent, CLIENT_A)], null);
+    expect(result.size).toBe(0);
+  });
+
+  it('returns an empty overworld-tile entry when the maze has no tiles', () => {
+    const event = createSoteMazePathEvent({ tick: 0, overworldTiles: [] });
+    const result = buildGraphicsForTick([tag(event, CLIENT_A)], null);
+
+    const tiles = result.get(GraphicsType.TOB_SOTE_OVERWORLD_TILES);
+    expect(tiles).toBeDefined();
+    expect(tiles!.size).toBe(0);
+  });
+});
+
+describe('buildGraphicsStates', () => {
+  it('returns one state map per input tick', () => {
+    const ticks: TaggedEvent[][] = [[], [], []];
+    const result = buildGraphicsStates(ticks);
+    expect(result.length).toBe(3);
+    for (const state of result) {
+      expect(state.size).toBe(0);
+    }
+  });
+
+  it('produces independent snapshot state per tick', () => {
+    const ticks: TaggedEvent[][] = [
+      [
+        tag(
+          createMaidenBloodSplatsEvent({
+            tick: 0,
+            coords: [{ x: 1, y: 1 }],
+          }),
+          CLIENT_A,
+        ),
+      ],
+      [],
+      [
+        tag(
+          createMaidenBloodSplatsEvent({
+            tick: 2,
+            coords: [{ x: 2, y: 2 }],
+          }),
+          CLIENT_A,
+        ),
+      ],
+    ];
+    const result = buildGraphicsStates(ticks);
+
+    expect(result[0].get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)?.size).toBe(1);
+    expect(result[1].has(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)).toBe(false);
+    const tick2 = result[2].get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)!;
+    expect(tick2.size).toBe(1);
+    expect(tick2.has(coordKey({ x: 2, y: 2 }))).toBe(true);
+  });
+});
+
+describe('cloneGraphics', () => {
+  it('returns an empty map for an empty input', () => {
+    const result = cloneGraphics(new Map());
+    expect(result.size).toBe(0);
+  });
+
+  it('preserves all entries and sources', () => {
+    const original: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([
+          [coordKey({ x: 1, y: 1 }), CLIENT_A],
+          [coordKey({ x: 2, y: 2 }), CLIENT_B],
+        ]),
+      ],
+      [
+        GraphicsType.TOB_VERZIK_YELLOWS,
+        new Map([[coordKey({ x: 3, y: 3 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const copy = cloneGraphics(original);
+    expect(copy).toEqual(original);
+  });
+
+  it('isolates the outer map from mutations on the copy', () => {
+    const original: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 1 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const copy = cloneGraphics(original);
+    copy.set(GraphicsType.TOB_VERZIK_YELLOWS, new Map());
+    expect(original.has(GraphicsType.TOB_VERZIK_YELLOWS)).toBe(false);
+  });
+
+  it('isolates the inner maps from mutations on the copy', () => {
+    const original: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 1 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const copy = cloneGraphics(original);
+    copy
+      .get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)!
+      .set(coordKey({ x: 9, y: 9 }), CLIENT_B);
+
+    const originalSplats = original.get(GraphicsType.TOB_MAIDEN_BLOOD_SPLATS)!;
+    expect(originalSplats.size).toBe(1);
+    expect(originalSplats.has(coordKey({ x: 9, y: 9 }))).toBe(false);
+  });
+});
+
+describe('createGraphicsEvents', () => {
+  const STAGE = Stage.TOB_MAIDEN;
+  const TICK = 7;
+
+  it('returns no events when the graphics state is empty', () => {
+    expect(createGraphicsEvents(new Map(), null, STAGE, TICK)).toEqual([]);
+  });
+
+  it('emits the full snapshot set as a proto event', () => {
+    const state: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([
+          [coordKey({ x: 1, y: 2 }), CLIENT_A],
+          [coordKey({ x: 3, y: 4 }), CLIENT_A],
+        ]),
+      ],
+    ]);
+
+    const events = createGraphicsEvents(state, null, STAGE, TICK);
+    expect(events.length).toBe(1);
+
+    const event = events[0];
+    expect(event.getType()).toBe(ProtoEvent.Type.TOB_MAIDEN_BLOOD_SPLATS);
+    expect(event.getStage()).toBe(STAGE);
+    expect(event.getTick()).toBe(TICK);
+    const coords = event
+      .getMaidenBloodSplatsList()
+      .map((c) => ({ x: c.getX(), y: c.getY() }));
+    expect(coords).toEqual(
+      expect.arrayContaining([
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ]),
+    );
+    expect(coords.length).toBe(2);
+  });
+
+  it('emits the same full set on every tick the snapshot is present', () => {
+    const previous: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 2 }), CLIENT_A]]),
+      ],
+    ]);
+    const current: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 2 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const events = createGraphicsEvents(current, previous, STAGE, TICK);
+    expect(events.length).toBe(1);
+    expect(events[0].getMaidenBloodSplatsList().length).toBe(1);
+  });
+
+  it('skips graphics types with no current state', () => {
+    const previous: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 2 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const events = createGraphicsEvents(new Map(), previous, STAGE, TICK);
+    expect(events).toEqual([]);
+  });
+
+  it('emits a separate event per eventType', () => {
+    const state: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_MAIDEN_BLOOD_SPLATS,
+        new Map([[coordKey({ x: 1, y: 1 }), CLIENT_A]]),
+      ],
+      [
+        GraphicsType.TOB_VERZIK_YELLOWS,
+        new Map([[coordKey({ x: 9, y: 9 }), CLIENT_A]]),
+      ],
+    ]);
+
+    const events = createGraphicsEvents(state, null, STAGE, TICK);
+    const types = events.map((e) => e.getType()).sort();
+    expect(types).toEqual(
+      [
+        ProtoEvent.Type.TOB_MAIDEN_BLOOD_SPLATS,
+        ProtoEvent.Type.TOB_VERZIK_YELLOWS,
+      ].sort(),
+    );
+  });
+
+  it('writes overworld tiles into the SoteMaze proto wrapper', () => {
+    const state: GraphicsState = new Map([
+      [
+        GraphicsType.TOB_SOTE_OVERWORLD_TILES,
+        new Map([
+          [coordKey({ x: 100, y: 200 }), CLIENT_A],
+          [coordKey({ x: 101, y: 200 }), CLIENT_A],
+        ]),
+      ],
+    ]);
+
+    const events = createGraphicsEvents(state, null, Stage.TOB_SOTETSEG, TICK);
+    expect(events.length).toBe(1);
+
+    const event = events[0];
+    expect(event.getType()).toBe(ProtoEvent.Type.TOB_SOTE_MAZE_PATH);
+    const tiles = event.getSoteMaze()!.getOverworldTilesList();
+    expect(tiles.length).toBe(2);
+  });
+
+  it('emits an empty snapshot event when the state is an empty map', () => {
+    const state: GraphicsState = new Map([
+      [GraphicsType.TOB_MAIDEN_BLOOD_SPLATS, new Map()],
+    ]);
+
+    const events = createGraphicsEvents(state, null, STAGE, TICK);
+    expect(events.length).toBe(1);
+    expect(events[0].getMaidenBloodSplatsList().length).toBe(0);
+  });
+});

--- a/challenge-server/merging/graphics.ts
+++ b/challenge-server/merging/graphics.ts
@@ -1,0 +1,269 @@
+import { EventJson, jsonToProtoEvent, Stage } from '@blert/common';
+import { Event } from '@blert/common/generated/event_pb';
+
+import { EventType, TaggedEvent } from './event';
+import {
+  coordKey,
+  CoordKey,
+  CoordsLike,
+  coordsFromProto,
+  fromCoordKey,
+  protoCoords,
+} from './world';
+
+/**
+ * Fine-grained graphics types. A single event type can store multiple graphics.
+ */
+export const enum GraphicsType {
+  TOB_MAIDEN_BLOOD_SPLATS = 'TOB_MAIDEN_BLOOD_SPLATS',
+  TOB_VERZIK_YELLOWS = 'TOB_VERZIK_YELLOWS',
+  TOB_SOTE_OVERWORLD_TILES = 'TOB_SOTE_OVERWORLD_TILES',
+}
+
+/**
+ * Snapshot graphics: each event's payload is the full visible set on the tick.
+ */
+type SnapshotConfig = {
+  style: 'snapshot';
+  eventType: EventType;
+  extract: (event: Event) => CoordsLike[];
+  write: (event: Event, coords: CoordsLike[]) => void;
+};
+
+/**
+ * Delta graphics: each event's payload describes additions and removals
+ * since the previous tick.
+ */
+type DeltaConfig = {
+  style: 'delta';
+  eventType: EventType;
+  extract: (event: Event) => { added: CoordsLike[]; removed: CoordsLike[] };
+  write: (event: Event, added: CoordsLike[], removed: CoordsLike[]) => void;
+};
+
+export type GraphicsConfig = SnapshotConfig | DeltaConfig;
+
+/**
+ * Per-tick graphics state: the visible coords for each active
+ * {@link GraphicsType}, mapped to the client that originally observed each
+ * coord. Types with no graphics on a tick are absent from the outer map.
+ */
+export type GraphicsState = Map<GraphicsType, Map<CoordKey, number>>;
+
+export const GRAPHICS_CONFIGS: Record<GraphicsType, GraphicsConfig> = {
+  [GraphicsType.TOB_MAIDEN_BLOOD_SPLATS]: {
+    style: 'snapshot',
+    eventType: Event.Type.TOB_MAIDEN_BLOOD_SPLATS,
+    extract: (event) => event.getMaidenBloodSplatsList().map(coordsFromProto),
+    write: (event, coords) =>
+      event.setMaidenBloodSplatsList(coords.map(protoCoords)),
+  },
+  [GraphicsType.TOB_VERZIK_YELLOWS]: {
+    style: 'snapshot',
+    eventType: Event.Type.TOB_VERZIK_YELLOWS,
+    extract: (event) => event.getVerzikYellowsList().map(coordsFromProto),
+    write: (event, coords) =>
+      event.setVerzikYellowsList(coords.map(protoCoords)),
+  },
+  [GraphicsType.TOB_SOTE_OVERWORLD_TILES]: {
+    style: 'snapshot',
+    eventType: Event.Type.TOB_SOTE_MAZE_PATH,
+    extract: (event) =>
+      event.getSoteMaze()?.getOverworldTilesList().map(coordsFromProto) ?? [],
+    write: (event, coords) => {
+      const maze = event.getSoteMaze() ?? new Event.SoteMaze();
+      maze.setOverworldTilesList(coords.map(protoCoords));
+      event.setSoteMaze(maze);
+    },
+  },
+};
+
+/**
+ * Deep-copies a graphics state map.
+ */
+export function cloneGraphics(
+  graphics: Readonly<GraphicsState>,
+): GraphicsState {
+  const copy: GraphicsState = new Map();
+  for (const [type, coords] of graphics) {
+    copy.set(type, new Map(coords));
+  }
+  return copy;
+}
+
+/**
+ * Builds the graphics state map for a single tick from a single client's
+ * events, dispatching per-type via {@link GRAPHICS_CONFIGS}. Snapshot-style
+ * configs replace the entries with the event's full coordinate list.
+ * Delta-style configs seed from the previous tick's entries, then apply
+ * additions and removals.
+ *
+ * Each coord is tagged with the source client's ID.
+ *
+ * @param events Events for this tick.
+ * @param previous Graphics state from the immediately preceding tick, or
+ *   `null` if this is the first tick.
+ * @returns The graphics state map for this tick.
+ */
+export function buildGraphicsForTick(
+  events: TaggedEvent[],
+  previous: Readonly<GraphicsState> | null,
+): GraphicsState {
+  const result: GraphicsState = new Map();
+
+  for (const graphicsType of Object.keys(GRAPHICS_CONFIGS) as GraphicsType[]) {
+    const config = GRAPHICS_CONFIGS[graphicsType];
+    const matching = events.filter(
+      (t) => t.event.getType() === config.eventType,
+    );
+
+    if (config.style === 'snapshot') {
+      // Snapshots are absent when no event is present on this tick.
+      if (matching.length === 0) {
+        continue;
+      }
+      const coords = new Map<CoordKey, number>();
+      for (const tagged of matching) {
+        for (const coord of config.extract(tagged.event)) {
+          const key = coordKey(coord);
+          if (!coords.has(key)) {
+            coords.set(key, tagged.source);
+          }
+        }
+      }
+      result.set(graphicsType, coords);
+    } else {
+      // Deltas carry forward from the previous tick.
+      const prev = previous?.get(graphicsType);
+      if (matching.length === 0 && prev === undefined) {
+        continue;
+      }
+      const coords = new Map<CoordKey, number>(prev);
+      for (const tagged of matching) {
+        const { added, removed } = config.extract(tagged.event);
+        for (const coord of removed) {
+          coords.delete(coordKey(coord));
+        }
+        for (const coord of added) {
+          const key = coordKey(coord);
+          if (!coords.has(key)) {
+            coords.set(key, tagged.source);
+          }
+        }
+      }
+      result.set(graphicsType, coords);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Builds graphics state maps for an entire client's tick range, threading
+ * carried-forward state across ticks. Returns a parallel array indexed by
+ * tick.
+ */
+export function buildGraphicsStates(
+  eventsByTick: TaggedEvent[][],
+): GraphicsState[] {
+  const result: GraphicsState[] = [];
+  for (const events of eventsByTick) {
+    result.push(buildGraphicsForTick(events, result.at(-1) ?? null));
+  }
+  return result;
+}
+
+/**
+ * Synthesizes proto graphics events from the merged graphics state of a
+ * tick. {@link GraphicsType}s that share an `eventType` are emitted as a
+ * single event with each member's payload written into it.
+ *
+ * @param current Graphics state for this tick.
+ * @param previous Graphics state from the immediately preceding tick, or
+ *   `null` if this is the first tick.
+ * @param stage The stage in which the events occur.
+ * @param tick The tick at which the events occur.
+ * @returns Synthesized events.
+ */
+export function createGraphicsEvents(
+  current: Readonly<GraphicsState>,
+  previous: Readonly<GraphicsState> | null,
+  stage: Stage,
+  tick: number,
+): Event[] {
+  const groups = new Map<EventType, GraphicsType[]>();
+  for (const graphicsType of Object.keys(GRAPHICS_CONFIGS) as GraphicsType[]) {
+    const { eventType } = GRAPHICS_CONFIGS[graphicsType];
+    const types = groups.get(eventType);
+    if (types === undefined) {
+      groups.set(eventType, [graphicsType]);
+    } else {
+      types.push(graphicsType);
+    }
+  }
+
+  const events: Event[] = [];
+
+  for (const [eventType, types] of groups) {
+    let event: Event | null = null;
+
+    for (const graphicsType of types) {
+      const config = GRAPHICS_CONFIGS[graphicsType];
+      const currentCoords = current.get(graphicsType);
+
+      if (config.style === 'snapshot') {
+        if (currentCoords === undefined) {
+          continue;
+        }
+        event ??= emptyGraphicsEvent(eventType, stage, tick);
+        config.write(event, [...currentCoords.keys()].map(fromCoordKey));
+      } else {
+        const previousCoords = previous?.get(graphicsType);
+        const added: CoordsLike[] = [];
+        const removed: CoordsLike[] = [];
+
+        if (currentCoords !== undefined) {
+          for (const key of currentCoords.keys()) {
+            if (!previousCoords?.has(key)) {
+              added.push(fromCoordKey(key));
+            }
+          }
+        }
+        if (previousCoords !== undefined) {
+          for (const key of previousCoords.keys()) {
+            if (!currentCoords?.has(key)) {
+              removed.push(fromCoordKey(key));
+            }
+          }
+        }
+
+        if (added.length === 0 && removed.length === 0) {
+          continue;
+        }
+        event ??= emptyGraphicsEvent(eventType, stage, tick);
+        config.write(event, added, removed);
+      }
+    }
+
+    if (event !== null) {
+      events.push(event);
+    }
+  }
+
+  return events;
+}
+
+function emptyGraphicsEvent(
+  eventType: EventType,
+  stage: Stage,
+  tick: number,
+): Event {
+  const json: EventJson = {
+    type: eventType,
+    stage,
+    tick,
+    xCoord: 0,
+    yCoord: 0,
+  };
+  return jsonToProtoEvent(json);
+}


### PR DESCRIPTION
This creates a new graphics module for merging which accumulates maps of various graphics coordinates on a tick from a client's graphics events. A function is provided to convert these state maps back to proto events.

Graphics events are categorized into two types: snapshots and deltas. Snapshots encode the entire set of graphics objects visibile on a tick, while deltas only include what has been added or removed since the client's last known state. These map to how clients send different types of graphic-based information, although all ToB events (the only current multi-client challenge) use snapshot graphics as they were some of the earlier plugin code written.

These will be used by the merge system to create each client's state timeline and then union graphics among merged clients, then reconstruct canonical events.