### PR TITLE
web: Search filter for abandoned challenges

### DIFF
--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -816,6 +816,40 @@ describe('challenges', () => {
   });
 
   describe('findChallenges', () => {
+    describe('status filter', () => {
+      it('excludes abandoned challenges by default', async () => {
+        const [challenges] = await findChallenges(10, {});
+        expect(challenges.map((c) => c.uuid).sort()).toEqual([
+          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        ]);
+      });
+
+      it('returns only abandoned when status filter selects it', async () => {
+        const [challenges] = await findChallenges(10, {
+          status: ['==', ChallengeStatus.ABANDONED],
+        });
+        expect(challenges.map((c) => c.uuid)).toEqual([
+          'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        ]);
+      });
+
+      it('includes abandoned alongside other statuses via in-list', async () => {
+        const [challenges] = await findChallenges(10, {
+          status: [
+            'in',
+            [ChallengeStatus.COMPLETED, ChallengeStatus.ABANDONED],
+          ],
+        });
+        expect(challenges.map((c) => c.uuid).sort()).toEqual([
+          'cccccccc-cccc-cccc-cccc-cccccccccccc',
+          'dddddddd-dddd-dddd-dddd-dddddddddddd',
+          'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+        ]);
+      });
+    });
+
     describe('bloat down filters', () => {
       beforeEach(async () => {
         await sql`

--- a/web/app/search/challenges/__tests__/context.test.ts
+++ b/web/app/search/challenges/__tests__/context.test.ts
@@ -56,12 +56,17 @@ describe('challenges filter URL round-trip', () => {
   it('preserves status', () => {
     const filters: SearchFilters = {
       ...defaultSearchFilters(),
-      status: [ChallengeStatus.COMPLETED, ChallengeStatus.WIPED],
+      status: [
+        ChallengeStatus.COMPLETED,
+        ChallengeStatus.WIPED,
+        ChallengeStatus.ABANDONED,
+      ],
     };
     const result = roundTrip(filters);
     expect(result.status).toEqual([
       ChallengeStatus.COMPLETED,
       ChallengeStatus.WIPED,
+      ChallengeStatus.ABANDONED,
     ]);
   });
 

--- a/web/app/search/challenges/filters.tsx
+++ b/web/app/search/challenges/filters.tsx
@@ -54,6 +54,7 @@ const STATUS_OPTIONS = [
   { value: ChallengeStatus.COMPLETED, label: 'Completion' },
   { value: ChallengeStatus.WIPED, label: 'Wipe' },
   { value: ChallengeStatus.RESET, label: 'Reset' },
+  { value: ChallengeStatus.ABANDONED, label: 'Abandoned' },
 ];
 
 export function resetChallengeFilters(prev: SearchContext): SearchContext {


### PR DESCRIPTION
Extends the status filter in challenge search to include abandoned. Abandoned challenges remain excluded unless explicitly selected.

Closes #278.