### PR TITLE
web: Optional end date for migration helpers

### DIFF
--- a/web/__tests__/actions/name-change-processor.test.ts
+++ b/web/__tests__/actions/name-change-processor.test.ts
@@ -12,6 +12,10 @@ import { sql } from '@/actions/db';
 import {
   NameChangeProcessor,
   processNameChange,
+  recomputePbHistoryFrom,
+  updateApiKeys,
+  updatePersonalBestHistory,
+  updatePlayerStats,
 } from '@/actions/name-change-processor';
 import redis from '@/actions/redis';
 
@@ -54,6 +58,37 @@ type TestPlayer = {
 type CountResult = { count: string };
 
 describe('processNameChange', () => {
+  type SeededSplit = {
+    id: number;
+    type: number;
+    scale: number;
+    ticks: number;
+  };
+
+  type ChallengeHistorySeed = {
+    uuid: string;
+    startTime: Date;
+    finishTime: Date;
+    type?: ChallengeType;
+    scale: number;
+    players: {
+      playerId: number;
+      username: string;
+      orb: number;
+      primaryGear?: number;
+    }[];
+    splits: {
+      type: number;
+      scale: number;
+      ticks: number;
+      accurate?: boolean;
+    }[];
+    personalBests?: {
+      playerId: number;
+      splitIndex: number;
+    }[];
+  };
+
   const arbitraryExperience: PlayerExperience = {
     [Skill.OVERALL]: 300_000_000,
     [Skill.ATTACK]: 7_000_000,
@@ -70,12 +105,7 @@ describe('processNameChange', () => {
   let oldPlayerId: number;
   let newPlayerId: number;
   let otherPlayerId: number;
-  let challengeSplits: {
-    id: number;
-    type: number;
-    scale: number;
-    ticks: number;
-  }[];
+  let challengeSplits: SeededSplit[];
   let mockRedisClient: MockRedisClient;
 
   beforeAll(async () => {
@@ -170,257 +200,7 @@ describe('processNameChange', () => {
     ];
     await sql`INSERT INTO api_keys ${sql(apiKeys)}`;
 
-    const challenges = [
-      {
-        uuid: '11111111-1111-1111-1111-111111111111',
-        start_time: new Date('2024-04-21'),
-        finish_time: new Date('2024-04-21'),
-        type: ChallengeType.TOB,
-        scale: 2,
-      },
-      {
-        uuid: '22222222-2222-2222-2222-222222222222',
-        start_time: new Date('2024-04-21'),
-        finish_time: new Date('2024-04-21'),
-        type: ChallengeType.TOB,
-        scale: 1,
-      },
-      {
-        uuid: '33333333-3333-3333-3333-333333333333',
-        start_time: new Date('2024-04-22'),
-        finish_time: new Date('2024-04-22'),
-        type: ChallengeType.TOB,
-        scale: 2,
-      },
-      {
-        uuid: '44444444-4444-4444-4444-444444444444',
-        start_time: new Date('2024-04-22'),
-        finish_time: new Date('2024-04-22'),
-        type: ChallengeType.TOB,
-        scale: 1,
-      },
-      {
-        uuid: '55555555-5555-5555-5555-555555555555',
-        start_time: new Date('2024-04-23'),
-        finish_time: new Date('2024-04-23'),
-        type: ChallengeType.TOB,
-        scale: 2,
-      },
-    ];
-    const challengeIds =
-      await sql`INSERT INTO challenges ${sql(challenges)} RETURNING id`.then(
-        (res) => res.map((r) => r.id),
-      );
-
-    const challengePlayers = [
-      {
-        challenge_id: challengeIds[0],
-        player_id: oldPlayerId,
-        username: 'Old Name',
-        orb: 0,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[0],
-        player_id: otherPlayerId,
-        username: 'SomeRandom',
-        orb: 1,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[1],
-        player_id: oldPlayerId,
-        username: 'Old Name',
-        orb: 0,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[2],
-        player_id: newPlayerId,
-        username: 'New Name',
-        orb: 0,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[2],
-        player_id: otherPlayerId,
-        username: 'SomeRandom',
-        orb: 1,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[3],
-        player_id: otherPlayerId,
-        username: 'SomeRandom',
-        orb: 0,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[4],
-        player_id: otherPlayerId,
-        username: 'SomeRandom',
-        orb: 0,
-        primary_gear: 1,
-      },
-      {
-        challenge_id: challengeIds[4],
-        player_id: newPlayerId,
-        username: 'New Name',
-        orb: 1,
-        primary_gear: 1,
-      },
-    ];
-    await sql`INSERT INTO challenge_players ${sql(challengePlayers)}`;
-
-    const splits = [
-      {
-        challenge_id: challengeIds[0],
-        type: 1,
-        scale: 2,
-        ticks: 100,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[0],
-        type: 2,
-        scale: 2,
-        ticks: 100,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[1],
-        type: 3,
-        scale: 2,
-        ticks: 100,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[1],
-        type: 5,
-        scale: 2,
-        ticks: 100,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[2],
-        type: 2,
-        scale: 2,
-        ticks: 75,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[2],
-        type: 3,
-        scale: 2,
-        ticks: 200,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[4],
-        type: 1,
-        scale: 2,
-        ticks: 100,
-        accurate: true,
-      },
-      {
-        challenge_id: challengeIds[4],
-        type: 4,
-        scale: 2,
-        ticks: 50,
-        accurate: true,
-      },
-    ];
-    const splitIds = await sql`
-      INSERT INTO challenge_splits ${sql(splits)} RETURNING id
-    `.then((res) => res.map((r) => r.id));
-
-    challengeSplits = splits.map((split, index) => ({
-      id: splitIds[index],
-      type: split.type,
-      scale: split.scale,
-      ticks: split.ticks,
-    }));
-
-    const personalBests = [
-      {
-        player_id: oldPlayerId,
-        challenge_split_id: splitIds[0],
-        created_at: challenges[0].finish_time,
-      },
-      {
-        player_id: oldPlayerId,
-        challenge_split_id: splitIds[1],
-        created_at: challenges[0].finish_time,
-      },
-      {
-        player_id: oldPlayerId,
-        challenge_split_id: splitIds[2],
-        created_at: challenges[1].finish_time,
-      },
-      {
-        player_id: oldPlayerId,
-        challenge_split_id: splitIds[3],
-        created_at: challenges[1].finish_time,
-      },
-      {
-        player_id: newPlayerId,
-        challenge_split_id: splitIds[4],
-        created_at: challenges[2].finish_time,
-      },
-      {
-        player_id: newPlayerId,
-        challenge_split_id: splitIds[5],
-        created_at: challenges[2].finish_time,
-      },
-      {
-        player_id: newPlayerId,
-        challenge_split_id: splitIds[6],
-        created_at: challenges[4].finish_time,
-      },
-      {
-        player_id: newPlayerId,
-        challenge_split_id: splitIds[7],
-        created_at: challenges[4].finish_time,
-      },
-    ];
-
-    await sql`INSERT INTO personal_best_history ${sql(personalBests)}`;
-
-    const playerStats = [
-      {
-        player_id: oldPlayerId,
-        date: new Date('2024-04-20'),
-        tob_completions: 5,
-        tob_wipes: 1,
-        deaths_total: 8,
-        hammer_bops: 9,
-      },
-      {
-        player_id: oldPlayerId,
-        date: new Date('2024-04-21'),
-        tob_completions: 7,
-        tob_wipes: 2,
-        deaths_total: 12,
-        hammer_bops: 10,
-      },
-      {
-        player_id: newPlayerId,
-        date: new Date('2024-04-22'),
-        tob_completions: 2,
-        tob_wipes: 0,
-        deaths_total: 1,
-        hammer_bops: 1,
-      },
-      {
-        player_id: newPlayerId,
-        date: new Date('2024-04-23'),
-        tob_completions: 5,
-        tob_wipes: 2,
-        deaths_total: 4,
-        hammer_bops: 1,
-      },
-    ];
-    await sql`INSERT INTO player_stats ${sql(playerStats)}`;
+    challengeSplits = [];
   });
 
   afterEach(async () => {
@@ -435,7 +215,205 @@ describe('processNameChange', () => {
     await sql`DELETE FROM players`;
   });
 
+  async function seedChallengeHistory(
+    seeds: ChallengeHistorySeed[],
+  ): Promise<{ challengeIds: number[]; splits: SeededSplit[] }> {
+    const challengeIds: number[] = [];
+    const seededSplits: SeededSplit[] = [];
+
+    for (const seed of seeds) {
+      const [{ id: challengeId }] = await sql<[{ id: number }]>`
+        INSERT INTO challenges (uuid, start_time, finish_time, type, scale)
+        VALUES (
+          ${seed.uuid},
+          ${seed.startTime},
+          ${seed.finishTime},
+          ${seed.type ?? ChallengeType.TOB},
+          ${seed.scale}
+        )
+        RETURNING id
+      `;
+      challengeIds.push(challengeId);
+
+      await sql`
+        INSERT INTO challenge_players ${sql(
+          seed.players.map((player) => ({
+            challenge_id: challengeId,
+            player_id: player.playerId,
+            username: player.username,
+            orb: player.orb,
+            primary_gear: player.primaryGear ?? 1,
+          })),
+        )}
+      `;
+
+      const splitRows = seed.splits.map((split) => ({
+        challenge_id: challengeId,
+        type: split.type,
+        scale: split.scale,
+        ticks: split.ticks,
+        accurate: split.accurate ?? true,
+      }));
+      const insertedSplits =
+        splitRows.length > 0
+          ? await sql<{ id: number }[]>`
+              INSERT INTO challenge_splits ${sql(splitRows)} RETURNING id
+            `
+          : [];
+
+      for (let i = 0; i < seed.splits.length; i++) {
+        seededSplits.push({
+          id: insertedSplits[i].id,
+          type: seed.splits[i].type,
+          scale: seed.splits[i].scale,
+          ticks: seed.splits[i].ticks,
+        });
+      }
+
+      if (seed.personalBests !== undefined && seed.personalBests.length > 0) {
+        await sql`
+          INSERT INTO personal_best_history ${sql(
+            seed.personalBests.map((pb) => ({
+              player_id: pb.playerId,
+              challenge_split_id: insertedSplits[pb.splitIndex].id,
+              created_at: seed.finishTime,
+            })),
+          )}
+        `;
+      }
+    }
+
+    return { challengeIds, splits: seededSplits };
+  }
+
+  async function seedDefaultHistory(): Promise<{
+    challengeIds: number[];
+    splits: SeededSplit[];
+  }> {
+    const seeded = await seedChallengeHistory([
+      {
+        uuid: '11111111-1111-1111-1111-111111111111',
+        startTime: new Date('2024-04-21'),
+        finishTime: new Date('2024-04-21'),
+        scale: 2,
+        players: [
+          { playerId: oldPlayerId, username: 'Old Name', orb: 0 },
+          { playerId: otherPlayerId, username: 'SomeRandom', orb: 1 },
+        ],
+        splits: [
+          { type: 1, scale: 2, ticks: 100 },
+          { type: 2, scale: 2, ticks: 100 },
+        ],
+        personalBests: [
+          { playerId: oldPlayerId, splitIndex: 0 },
+          { playerId: oldPlayerId, splitIndex: 1 },
+        ],
+      },
+      {
+        uuid: '22222222-2222-2222-2222-222222222222',
+        startTime: new Date('2024-04-21'),
+        finishTime: new Date('2024-04-21'),
+        scale: 1,
+        players: [{ playerId: oldPlayerId, username: 'Old Name', orb: 0 }],
+        splits: [
+          { type: 3, scale: 2, ticks: 100 },
+          { type: 5, scale: 2, ticks: 100 },
+        ],
+        personalBests: [
+          { playerId: oldPlayerId, splitIndex: 0 },
+          { playerId: oldPlayerId, splitIndex: 1 },
+        ],
+      },
+      {
+        uuid: '33333333-3333-3333-3333-333333333333',
+        startTime: new Date('2024-04-22'),
+        finishTime: new Date('2024-04-22'),
+        scale: 2,
+        players: [
+          { playerId: newPlayerId, username: 'New Name', orb: 0 },
+          { playerId: otherPlayerId, username: 'SomeRandom', orb: 1 },
+        ],
+        splits: [
+          { type: 2, scale: 2, ticks: 75 },
+          { type: 3, scale: 2, ticks: 200 },
+        ],
+        personalBests: [
+          { playerId: newPlayerId, splitIndex: 0 },
+          { playerId: newPlayerId, splitIndex: 1 },
+        ],
+      },
+      {
+        uuid: '44444444-4444-4444-4444-444444444444',
+        startTime: new Date('2024-04-22'),
+        finishTime: new Date('2024-04-22'),
+        scale: 1,
+        players: [{ playerId: otherPlayerId, username: 'SomeRandom', orb: 0 }],
+        splits: [],
+      },
+      {
+        uuid: '55555555-5555-5555-5555-555555555555',
+        startTime: new Date('2024-04-23'),
+        finishTime: new Date('2024-04-23'),
+        scale: 2,
+        players: [
+          { playerId: otherPlayerId, username: 'SomeRandom', orb: 0 },
+          { playerId: newPlayerId, username: 'New Name', orb: 1 },
+        ],
+        splits: [
+          { type: 1, scale: 2, ticks: 100 },
+          { type: 4, scale: 2, ticks: 50 },
+        ],
+        personalBests: [
+          { playerId: newPlayerId, splitIndex: 0 },
+          { playerId: newPlayerId, splitIndex: 1 },
+        ],
+      },
+    ]);
+
+    await sql`
+      INSERT INTO player_stats ${sql([
+        {
+          player_id: oldPlayerId,
+          date: new Date('2024-04-20'),
+          tob_completions: 5,
+          tob_wipes: 1,
+          deaths_total: 8,
+          hammer_bops: 9,
+        },
+        {
+          player_id: oldPlayerId,
+          date: new Date('2024-04-21'),
+          tob_completions: 7,
+          tob_wipes: 2,
+          deaths_total: 12,
+          hammer_bops: 10,
+        },
+        {
+          player_id: newPlayerId,
+          date: new Date('2024-04-22'),
+          tob_completions: 2,
+          tob_wipes: 0,
+          deaths_total: 1,
+          hammer_bops: 1,
+        },
+        {
+          player_id: newPlayerId,
+          date: new Date('2024-04-23'),
+          tob_completions: 5,
+          tob_wipes: 2,
+          deaths_total: 4,
+          hammer_bops: 1,
+        },
+      ])}
+    `;
+
+    challengeSplits = seeded.splits;
+    return seeded;
+  }
+
   it('successfully migrates data from the new player to the old', async () => {
+    await seedDefaultHistory();
+
     // Mock the OSRS Hiscores API responses.
     // First response (old player): doesn't exist.
     // Second response (new player): exists.
@@ -593,7 +571,8 @@ describe('processNameChange', () => {
     const updatedRequest = await loadNameChangeRequest(id);
     expect(updatedRequest.status).toBe(NameChangeStatus.ACCEPTED);
     expect(updatedRequest.processedAt).not.toBeNull();
-    expect(updatedRequest.migratedDocuments).toBe(12);
+    // 11 = 4 challenge_players + 2 api_keys + 2 player_stats + 3 PB history.
+    expect(updatedRequest.migratedDocuments).toBe(11);
   });
 
   it('succeeds when a player has previously existed with the new name', async () => {
@@ -607,43 +586,36 @@ describe('processNameChange', () => {
       INSERT INTO api_keys (user_id, player_id, key, last_used)
       VALUES (${userId}, ${newPlayerId}, 'older-key', ${new Date('2024-03-21')})
     `;
-    const newChallenges = await sql<{ id: number; finish_time: Date }[]>`
-      INSERT INTO challenges (uuid, start_time, type, scale, finish_time)
-      VALUES
-        ('66666666-6666-6666-6666-666666666666', ${new Date('2024-03-20')}, 1, 2, ${new Date('2024-03-20')}),
-        ('77777777-7777-7777-7777-777777777777', ${new Date('2024-03-20')}, 1, 2, ${new Date('2024-03-20')})
-      RETURNING id, finish_time
-    `;
-    const newChallengeIds = newChallenges.map((r) => r.id);
-    const newChallengeFinishTimes = newChallenges.map((r) => r.finish_time);
+    const priorHistory = await seedChallengeHistory([
+      {
+        uuid: '66666666-6666-6666-6666-666666666666',
+        startTime: new Date('2024-03-20'),
+        finishTime: new Date('2024-03-20'),
+        scale: 2,
+        players: [
+          { playerId: newPlayerId, username: 'New Name', orb: 0 },
+          { playerId: otherPlayerId, username: 'SomeRandom', orb: 1 },
+        ],
+        splits: [{ type: 6, scale: 2, ticks: 33 }],
+        personalBests: [{ playerId: newPlayerId, splitIndex: 0 }],
+      },
+      {
+        uuid: '77777777-7777-7777-7777-777777777777',
+        startTime: new Date('2024-03-20'),
+        finishTime: new Date('2024-03-20'),
+        scale: 2,
+        players: [
+          { playerId: newPlayerId, username: 'New Name', orb: 0 },
+          { playerId: otherPlayerId, username: 'SomeRandom', orb: 1 },
+        ],
+        splits: [{ type: 1, scale: 2, ticks: 105 }],
+        personalBests: [{ playerId: newPlayerId, splitIndex: 0 }],
+      },
+    ]);
+    const extraSplitIds = priorHistory.splits.map((split) => split.id);
 
-    await sql`
-      INSERT INTO challenge_players (
-        challenge_id,
-        player_id,
-        username,
-        orb,
-        primary_gear
-      )
-      VALUES
-        (${newChallengeIds[0]}, ${newPlayerId}, 'New Name', 0, 1),
-        (${newChallengeIds[0]}, ${otherPlayerId}, 'SomeRandom', 1, 1),
-        (${newChallengeIds[1]}, ${newPlayerId}, 'New Name', 0, 1),
-        (${newChallengeIds[1]}, ${otherPlayerId}, 'SomeRandom', 1, 1)
-    `;
-    const extraSplitIds = await sql<{ id: number }[]>`
-      INSERT INTO challenge_splits (challenge_id, type, scale, ticks, accurate)
-      VALUES
-        (${newChallengeIds[0]}, 6, 2, 33, true),
-        (${newChallengeIds[1]}, 1, 2, 105, true)
-      RETURNING id
-    `.then((res) => res.map((r) => r.id));
-    await sql`
-      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
-      VALUES
-        (${newPlayerId}, ${extraSplitIds[0]}, ${newChallengeFinishTimes[0]}),
-        (${newPlayerId}, ${extraSplitIds[1]}, ${newChallengeFinishTimes[1]})
-    `;
+    await seedDefaultHistory();
+
     await sql`
       INSERT INTO player_stats (
         player_id,
@@ -782,6 +754,7 @@ describe('processNameChange', () => {
 
     const expectedApiKeys = [
       { player_id: oldPlayerId, key: 'new-key' },
+      { player_id: newPlayerId, key: 'new-key-2' },
       { player_id: newPlayerId, key: 'older-key' },
       { player_id: oldPlayerId, key: 'old-key' },
     ];
@@ -853,7 +826,7 @@ describe('processNameChange', () => {
     const updatedRequest = await loadNameChangeRequest(id);
     expect(updatedRequest.status).toBe(NameChangeStatus.ACCEPTED);
     expect(updatedRequest.processedAt).not.toBeNull();
-    expect(updatedRequest.migratedDocuments).toBe(12);
+    expect(updatedRequest.migratedDocuments).toBe(11);
   });
 
   it('updates name without any migration if the new player has no data', async () => {
@@ -1319,10 +1292,1028 @@ describe('NameChangeProcessor.processBatch', () => {
 
     // Should only process 2 (the batchSize), though they fail due to hiscores.
     // The third should not even be attempted.
-    expect(global.fetch).toHaveBeenCalledTimes(4); // 2 requests * 2 hiscore calls each
+    expect(global.fetch).toHaveBeenCalledTimes(4);
 
     await sql`DELETE FROM name_changes WHERE old_name LIKE 'Bp%'`;
     await sql`DELETE FROM players WHERE username LIKE 'Bp%' OR username LIKE 'Nn%'`;
+  });
+});
+
+describe('updatePlayerStats', () => {
+  let oldPlayerId: number;
+  let newPlayerId: number;
+
+  beforeEach(async () => {
+    const [old] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('OldStats', ${normalizeRsn('OldStats')}, 0)
+      RETURNING id
+    `;
+    oldPlayerId = old.id;
+
+    const [neu] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('NewStats', ${normalizeRsn('NewStats')}, 0)
+      RETURNING id
+    `;
+    newPlayerId = neu.id;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM player_stats WHERE player_id = ANY(${[oldPlayerId, newPlayerId]})`;
+    await sql`DELETE FROM players WHERE id = ANY(${[oldPlayerId, newPlayerId]})`;
+  });
+
+  type StatsSeed = {
+    date: string;
+    tobCompletions?: number;
+    deathsTotal?: number;
+  };
+
+  async function seedStats(playerId: number, rows: StatsSeed[]) {
+    for (const r of rows) {
+      await sql`
+        INSERT INTO player_stats (
+          player_id, date, tob_completions, deaths_total
+        ) VALUES (
+          ${playerId}, ${new Date(r.date)}, ${r.tobCompletions ?? 0}, ${r.deathsTotal ?? 0}
+        )
+      `;
+    }
+  }
+
+  type StatsRow = {
+    date: Date;
+    tob_completions: number;
+    deaths_total: number;
+  };
+
+  async function loadStats(playerId: number) {
+    return sql<StatsRow[]>`
+      SELECT date, tob_completions, deaths_total
+      FROM player_stats
+      WHERE player_id = ${playerId}
+      ORDER BY date ASC
+    `;
+  }
+
+  it('moves all post-fromDate rows when toDate is null', async () => {
+    await seedStats(oldPlayerId, [
+      { date: '2026-01-01', tobCompletions: 5, deathsTotal: 2 },
+    ]);
+    await seedStats(newPlayerId, [
+      { date: '2026-02-01', tobCompletions: 6, deathsTotal: 3 },
+      { date: '2026-03-01', tobCompletions: 9, deathsTotal: 4 },
+    ]);
+
+    const moved = await updatePlayerStats(
+      oldPlayerId,
+      newPlayerId,
+      new Date('2026-01-15'),
+    );
+    expect(moved).toBe(2);
+
+    expect(await loadStats(newPlayerId)).toEqual([]);
+
+    const oldRows = await loadStats(oldPlayerId);
+    expect(oldRows).toHaveLength(3);
+    // Original row, untouched.
+    expect(oldRows[0].tob_completions).toBe(5);
+    expect(oldRows[0].deaths_total).toBe(2);
+    // Migrated rows are rebased onto old's last (5, 2) baseline.
+    expect(oldRows[1].tob_completions).toBe(11);
+    expect(oldRows[1].deaths_total).toBe(5);
+    expect(oldRows[2].tob_completions).toBe(14);
+    expect(oldRows[2].deaths_total).toBe(6);
+  });
+
+  it('migrates only in-window stats when toDate is set', async () => {
+    await seedStats(newPlayerId, [
+      { date: '2026-01-01', tobCompletions: 4 }, // pre-window
+      { date: '2026-02-01', tobCompletions: 7 }, // in window
+      { date: '2026-03-01', tobCompletions: 9 }, // in window
+      { date: '2026-05-01', tobCompletions: 15 }, // post-window
+    ]);
+
+    const moved = await updatePlayerStats(
+      oldPlayerId,
+      newPlayerId,
+      new Date('2026-01-15'),
+      new Date('2026-04-01'),
+      sql,
+    );
+    expect(moved).toBe(2);
+
+    const newRows = await loadStats(newPlayerId);
+    expect(newRows.map((r) => r.tob_completions)).toEqual([
+      4, // pre-window untouched
+      10, // post-window: original 15, delta 5
+    ]);
+
+    const oldRows = await loadStats(oldPlayerId);
+    expect(oldRows.map((r) => r.tob_completions)).toEqual([3, 5]);
+  });
+
+  it('symmetrically adjusts post-window rows', async () => {
+    await seedStats(newPlayerId, [
+      // pre-window baseline
+      { date: '2026-01-01', tobCompletions: 10, deathsTotal: 2 },
+      // in-window (gain 5 tob, 1 death)
+      { date: '2026-02-01', tobCompletions: 12, deathsTotal: 2 },
+      { date: '2026-03-01', tobCompletions: 15, deathsTotal: 3 },
+      // post-window (gain 4 tob, 1 death from new player's own recordings)
+      { date: '2026-05-01', tobCompletions: 17, deathsTotal: 4 },
+      { date: '2026-06-01', tobCompletions: 19, deathsTotal: 4 },
+    ]);
+    await seedStats(oldPlayerId, [
+      // pre-window baseline
+      { date: '2026-01-01', tobCompletions: 50, deathsTotal: 7 },
+      // post-window: old player has its own activity recorded under its own
+      // player_id; these counters never saw the in-window period.
+      { date: '2026-05-01', tobCompletions: 53, deathsTotal: 8 },
+      { date: '2026-06-01', tobCompletions: 55, deathsTotal: 9 },
+    ]);
+
+    await updatePlayerStats(
+      oldPlayerId,
+      newPlayerId,
+      new Date('2026-01-15'),
+      new Date('2026-04-01'),
+      sql,
+    );
+
+    // In-window deltas: tob_completions 5, deaths_total 1. Subtract from new.
+    const newRows = await loadStats(newPlayerId);
+    expect(newRows).toEqual([
+      expect.objectContaining({ tob_completions: 10, deaths_total: 2 }),
+      expect.objectContaining({ tob_completions: 12, deaths_total: 3 }),
+      expect.objectContaining({ tob_completions: 14, deaths_total: 3 }),
+    ]);
+
+    // Add to old.
+    const oldRows = await loadStats(oldPlayerId);
+    expect(oldRows).toEqual([
+      expect.objectContaining({ tob_completions: 50, deaths_total: 7 }),
+      expect.objectContaining({ tob_completions: 52, deaths_total: 7 }),
+      expect.objectContaining({ tob_completions: 55, deaths_total: 8 }),
+      expect.objectContaining({ tob_completions: 58, deaths_total: 9 }),
+      expect.objectContaining({ tob_completions: 60, deaths_total: 10 }),
+    ]);
+  });
+
+  it('is a no-op when there are no in-window rows', async () => {
+    await seedStats(newPlayerId, [
+      { date: '2026-01-01', tobCompletions: 4 },
+      { date: '2026-05-01', tobCompletions: 10 },
+    ]);
+
+    const moved = await updatePlayerStats(
+      oldPlayerId,
+      newPlayerId,
+      new Date('2026-02-01'),
+      new Date('2026-04-01'),
+      sql,
+    );
+    expect(moved).toBe(0);
+
+    const newRows = await loadStats(newPlayerId);
+    expect(newRows.map((r) => r.tob_completions)).toEqual([4, 10]);
+    expect(await loadStats(oldPlayerId)).toEqual([]);
+  });
+
+  it('handles a missing newPlayer at fromDate snapshot', async () => {
+    await seedStats(newPlayerId, [
+      { date: '2026-02-01', tobCompletions: 8 },
+      { date: '2026-05-01', tobCompletions: 12 },
+    ]);
+
+    await updatePlayerStats(
+      oldPlayerId,
+      newPlayerId,
+      new Date('2026-01-15'),
+      new Date('2026-04-01'),
+      sql,
+    );
+
+    // In-window row's delta against zero baseline = 8.
+    // Post-window 2026-05-01 originally 12, minus 8 = 4.
+    const newRows = await loadStats(newPlayerId);
+    expect(newRows.map((r) => r.tob_completions)).toEqual([4]);
+
+    const oldRows = await loadStats(oldPlayerId);
+    expect(oldRows.map((r) => r.tob_completions)).toEqual([8]);
+  });
+});
+
+describe('updateApiKeys', () => {
+  let targetPlayerId: number;
+  let sourcePlayerId: number;
+  let userId: number;
+
+  beforeEach(async () => {
+    const [user] = await sql<[{ id: number }]>`
+      INSERT INTO users (username, email, password)
+      VALUES ('key_tester', 'apikeytest@example.com', 'pw')
+      RETURNING id
+    `;
+    userId = user.id;
+
+    const [tgt] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('WWWWWWWWWWQQ', ${normalizeRsn('WWWWWWWWWWQQ')}, 0)
+      RETURNING id
+    `;
+    targetPlayerId = tgt.id;
+
+    const [src] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('1Ogp', ${normalizeRsn('1Ogp')}, 0)
+      RETURNING id
+    `;
+    sourcePlayerId = src.id;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM api_keys WHERE user_id = ${userId}`;
+    await sql`DELETE FROM players WHERE id = ANY(${[targetPlayerId, sourcePlayerId]})`;
+    await sql`DELETE FROM users WHERE id = ${userId}`;
+  });
+
+  type KeySeed = { key: string; lastUsed: string | null };
+
+  async function seedKeys(playerId: number, keys: KeySeed[]) {
+    for (const k of keys) {
+      await sql`
+        INSERT INTO api_keys (user_id, player_id, key, last_used)
+        VALUES (
+          ${userId},
+          ${playerId},
+          ${k.key},
+          ${k.lastUsed === null ? null : new Date(k.lastUsed)}
+        )
+      `;
+    }
+  }
+
+  async function loadKeys() {
+    return sql<{ key: string; player_id: number; last_used: Date | null }[]>`
+      SELECT key, player_id, last_used FROM api_keys
+      WHERE user_id = ${userId}
+      ORDER BY key
+    `;
+  }
+
+  it('reassigns keys with last_used > fromDate when toDate is null', async () => {
+    await seedKeys(sourcePlayerId, [
+      { key: 'pre-fromdate', lastUsed: '2026-01-01' },
+      { key: 'post-fromdate', lastUsed: '2026-03-01' },
+      { key: 'unused', lastUsed: null },
+    ]);
+
+    const moved = await updateApiKeys(
+      targetPlayerId,
+      sourcePlayerId,
+      new Date('2026-02-01'),
+    );
+    expect(moved).toBe(1);
+
+    const rows = await loadKeys();
+    expect(rows).toEqual([
+      expect.objectContaining({
+        key: 'post-fromdate',
+        player_id: targetPlayerId,
+      }),
+      expect.objectContaining({
+        key: 'pre-fromdate',
+        player_id: sourcePlayerId,
+      }),
+      expect.objectContaining({ key: 'unused', player_id: sourcePlayerId }),
+    ]);
+  });
+
+  it('reassigns only in-window keys when toDate is set', async () => {
+    await seedKeys(sourcePlayerId, [
+      { key: 'pre', lastUsed: '2026-01-01' },
+      { key: 'in-window-1', lastUsed: '2026-02-15' },
+      { key: 'in-window-2', lastUsed: '2026-03-15' },
+      { key: 'post', lastUsed: '2026-05-15' },
+      { key: 'unused', lastUsed: null },
+    ]);
+
+    const moved = await updateApiKeys(
+      targetPlayerId,
+      sourcePlayerId,
+      new Date('2026-02-01'),
+      new Date('2026-04-01'),
+      sql,
+    );
+    expect(moved).toBe(2);
+
+    const rows = await loadKeys();
+    const byKey = (k: string) => rows.find((r) => r.key === k);
+    expect(byKey('pre')?.player_id).toBe(sourcePlayerId);
+    expect(byKey('in-window-1')?.player_id).toBe(targetPlayerId);
+    expect(byKey('in-window-2')?.player_id).toBe(targetPlayerId);
+    expect(byKey('post')?.player_id).toBe(sourcePlayerId);
+    expect(byKey('unused')?.player_id).toBe(sourcePlayerId);
+  });
+
+  it('does not touch keys whose last_used is exactly fromDate or toDate boundaries', async () => {
+    await seedKeys(sourcePlayerId, [
+      { key: 'at-fromdate', lastUsed: '2026-02-01' },
+      { key: 'at-todate', lastUsed: '2026-04-01' },
+    ]);
+
+    await updateApiKeys(
+      targetPlayerId,
+      sourcePlayerId,
+      new Date('2026-02-01'),
+      new Date('2026-04-01'),
+      sql,
+    );
+
+    const rows = await loadKeys();
+    expect(rows.find((r) => r.key === 'at-fromdate')?.player_id).toBe(
+      sourcePlayerId,
+    );
+    expect(rows.find((r) => r.key === 'at-todate')?.player_id).toBe(
+      targetPlayerId,
+    );
+  });
+
+  it('returns 0 and changes nothing when no keys are in the window', async () => {
+    await seedKeys(sourcePlayerId, [
+      { key: 'pre', lastUsed: '2026-01-01' },
+      { key: 'post', lastUsed: '2026-05-01' },
+      { key: 'unused', lastUsed: null },
+    ]);
+
+    const moved = await updateApiKeys(
+      targetPlayerId,
+      sourcePlayerId,
+      new Date('2026-02-01'),
+      new Date('2026-04-01'),
+      sql,
+    );
+    expect(moved).toBe(0);
+
+    const rows = await loadKeys();
+    expect(rows.every((r) => r.player_id === sourcePlayerId)).toBe(true);
+  });
+});
+
+describe('recomputePbHistoryFrom', () => {
+  let playerId: number;
+  let challengeIdSeq = 0;
+
+  beforeEach(async () => {
+    const [p] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('PbRecompute', ${normalizeRsn('PbRecompute')}, 0)
+      RETURNING id
+    `;
+    playerId = p.id;
+  });
+
+  afterEach(async () => {
+    const challenges = await sql<{ id: number }[]>`
+      SELECT challenge_id AS id FROM challenge_players WHERE player_id = ${playerId}
+    `;
+    const challengeIds = challenges.map((c) => c.id);
+    if (challengeIds.length > 0) {
+      await sql`DELETE FROM personal_best_history WHERE challenge_split_id IN (
+        SELECT id FROM challenge_splits WHERE challenge_id = ANY(${challengeIds})
+      )`;
+      await sql`DELETE FROM challenge_splits WHERE challenge_id = ANY(${challengeIds})`;
+      await sql`DELETE FROM challenge_players WHERE challenge_id = ANY(${challengeIds})`;
+      await sql`DELETE FROM challenges WHERE id = ANY(${challengeIds})`;
+    }
+    await sql`DELETE FROM players WHERE id = ${playerId}`;
+  });
+
+  type SplitSeed = {
+    finishedAt: string;
+    type: number;
+    scale: number;
+    ticks: number;
+    accurate?: boolean;
+  };
+
+  type SeededSplit = { challengeId: number; splitId: number };
+
+  /**
+   * Seeds one challenge per split.
+   * inserted challenge and challenge_split row IDs in input order.
+   */
+  async function seedSplits(splits: SplitSeed[]): Promise<SeededSplit[]> {
+    const out: SeededSplit[] = [];
+    for (const s of splits) {
+      challengeIdSeq += 1;
+      const uuid = `00000000-0000-0000-0000-${String(challengeIdSeq).padStart(12, '0')}`;
+      const [{ id: challengeId }] = await sql<[{ id: number }]>`
+        INSERT INTO challenges (uuid, type, scale, start_time, finish_time)
+        VALUES (${uuid}, ${s.type}, ${s.scale}, ${new Date(s.finishedAt)}, ${new Date(s.finishedAt)})
+        RETURNING id
+      `;
+      await sql`
+        INSERT INTO challenge_players (challenge_id, player_id, username, orb, primary_gear)
+        VALUES (${challengeId}, ${playerId}, 'PbRecompute', 0, 1)
+      `;
+      const [{ id: splitId }] = await sql<[{ id: number }]>`
+        INSERT INTO challenge_splits (challenge_id, type, scale, ticks, accurate)
+        VALUES (${challengeId}, ${s.type}, ${s.scale}, ${s.ticks}, ${s.accurate ?? true})
+        RETURNING id
+      `;
+      out.push({ challengeId, splitId });
+    }
+    return out;
+  }
+
+  async function loadPbHistory() {
+    return sql<
+      {
+        challenge_split_id: number;
+        type: number;
+        scale: number;
+        ticks: number;
+        created_at: Date;
+      }[]
+    >`
+      SELECT
+        pbh.challenge_split_id,
+        cs.type,
+        cs.scale,
+        cs.ticks,
+        pbh.created_at
+      FROM personal_best_history pbh
+      JOIN challenge_splits cs ON pbh.challenge_split_id = cs.id
+      WHERE pbh.player_id = ${playerId}
+      ORDER BY pbh.created_at ASC
+    `;
+  }
+
+  it('returns 0 and changes nothing when splitsToRecompute is empty', async () => {
+    const [s0] = await seedSplits([
+      { finishedAt: '2026-02-15', type: 1, scale: 5, ticks: 200 },
+    ]);
+    await sql`
+      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
+      VALUES (${playerId}, ${s0.splitId}, ${new Date('2026-02-15')})
+    `;
+
+    const touched = await recomputePbHistoryFrom(playerId, [], s0.challengeId);
+    expect(touched).toBe(0);
+
+    expect(await loadPbHistory()).toHaveLength(1);
+  });
+
+  it('inserts a PB for the only post-cutoff split when no pre-cutoff best exists', async () => {
+    const [s0] = await seedSplits([
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 200 },
+    ]);
+
+    const touched = await recomputePbHistoryFrom(
+      playerId,
+      [[1, 5]],
+      s0.challengeId,
+    );
+    expect(touched).toBe(1);
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id)).toEqual([s0.splitId]);
+  });
+
+  it('only inserts PBs for splits that beat the running best', async () => {
+    const seeds = await seedSplits([
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 200 },
+      { finishedAt: '2026-04-01', type: 1, scale: 5, ticks: 220 }, // worse
+      { finishedAt: '2026-05-01', type: 1, scale: 5, ticks: 180 }, // PB
+      { finishedAt: '2026-06-01', type: 1, scale: 5, ticks: 190 }, // worse
+      { finishedAt: '2026-07-01', type: 1, scale: 5, ticks: 170 }, // PB
+    ]);
+
+    await recomputePbHistoryFrom(playerId, [[1, 5]], seeds[0].challengeId);
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id)).toEqual([
+      seeds[0].splitId,
+      seeds[2].splitId,
+      seeds[4].splitId,
+    ]);
+  });
+
+  it("uses the player's pre-cutoff best as the starting threshold", async () => {
+    const [_pre, worse, pb] = await seedSplits([
+      { finishedAt: '2026-01-01', type: 1, scale: 5, ticks: 150 }, // pre-cutoff
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 160 }, // worse
+      { finishedAt: '2026-04-01', type: 1, scale: 5, ticks: 140 }, // PB
+    ]);
+
+    await recomputePbHistoryFrom(playerId, [[1, 5]], worse.challengeId);
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id)).toEqual([pb.splitId]);
+    expect(rows).not.toContainEqual(
+      expect.objectContaining({ challenge_split_id: worse.splitId }),
+    );
+  });
+
+  it('deletes existing post-cutoff PB rows that are no longer best', async () => {
+    const [_pre, post] = await seedSplits([
+      { finishedAt: '2026-01-01', type: 1, scale: 5, ticks: 100 }, // pre-cutoff
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 150 }, // now worse
+    ]);
+    await sql`
+      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
+      VALUES (${playerId}, ${post.splitId}, ${new Date('2026-03-01')})
+    `;
+
+    const touched = await recomputePbHistoryFrom(
+      playerId,
+      [[1, 5]],
+      post.challengeId,
+    );
+    expect(touched).toBe(1); // 1 deleted, 0 inserted
+
+    expect(await loadPbHistory()).toEqual([]);
+  });
+
+  it('leaves pre-cutoff PB rows alone', async () => {
+    const [pre, post] = await seedSplits([
+      { finishedAt: '2026-01-01', type: 1, scale: 5, ticks: 100 },
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 90 },
+    ]);
+    await sql`
+      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
+      VALUES (${playerId}, ${pre.splitId}, ${new Date('2026-01-01')})
+    `;
+
+    await recomputePbHistoryFrom(playerId, [[1, 5]], pre.challengeId);
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id)).toEqual([
+      pre.splitId,
+      post.splitId,
+    ]);
+  });
+
+  it('handles multiple (type, scale) pairs independently', async () => {
+    const seeds = await seedSplits([
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 200 }, // type 1: PB
+      { finishedAt: '2026-03-02', type: 2, scale: 5, ticks: 300 }, // type 2: PB
+      { finishedAt: '2026-04-01', type: 1, scale: 5, ticks: 250 }, // type 1: no
+      { finishedAt: '2026-04-02', type: 2, scale: 5, ticks: 280 }, // type 2: PB
+    ]);
+
+    await recomputePbHistoryFrom(
+      playerId,
+      [
+        [1, 5],
+        [2, 5],
+      ],
+      seeds[0].challengeId,
+    );
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id)).toEqual([
+      seeds[0].splitId,
+      seeds[1].splitId,
+      seeds[3].splitId,
+    ]);
+  });
+
+  it('ignores splits with accurate=false', async () => {
+    const [inaccurate, accurate] = await seedSplits([
+      {
+        finishedAt: '2026-03-01',
+        type: 1,
+        scale: 5,
+        ticks: 100,
+        accurate: false,
+      },
+      {
+        finishedAt: '2026-04-01',
+        type: 1,
+        scale: 5,
+        ticks: 200,
+        accurate: true,
+      },
+    ]);
+
+    await recomputePbHistoryFrom(playerId, [[1, 5]], inaccurate.challengeId);
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id)).toEqual([accurate.splitId]);
+    expect(rows).not.toContainEqual(
+      expect.objectContaining({ challenge_split_id: inaccurate.splitId }),
+    );
+  });
+
+  it('only touches the requested (type, scale) pairs', async () => {
+    const [type1, type2] = await seedSplits([
+      { finishedAt: '2026-03-01', type: 1, scale: 5, ticks: 200 },
+      { finishedAt: '2026-03-02', type: 2, scale: 5, ticks: 300 },
+    ]);
+    // Pre-existing PB on type=2 should remain as we only ask recompute to
+    // handle (type=1, scale=5).
+    await sql`
+      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
+      VALUES (${playerId}, ${type2.splitId}, ${new Date('2026-03-02')})
+    `;
+
+    await recomputePbHistoryFrom(playerId, [[1, 5]], type1.challengeId);
+
+    const rows = await loadPbHistory();
+    expect(rows.map((r) => r.challenge_split_id).sort()).toEqual(
+      [type1.splitId, type2.splitId].sort(),
+    );
+  });
+});
+
+describe('updatePersonalBestHistory', () => {
+  let oldPlayerId: number;
+  let newPlayerId: number;
+  let challengeIdSeq = 0;
+
+  beforeEach(async () => {
+    const [old] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('PbOld', ${normalizeRsn('PbOld')}, 0)
+      RETURNING id
+    `;
+    oldPlayerId = old.id;
+    const [neu] = await sql<[{ id: number }]>`
+      INSERT INTO players (username, normalized_username, total_recordings)
+      VALUES ('PbNew', ${normalizeRsn('PbNew')}, 0)
+      RETURNING id
+    `;
+    newPlayerId = neu.id;
+  });
+
+  afterEach(async () => {
+    const challenges = await sql<{ id: number }[]>`
+      SELECT DISTINCT challenge_id AS id FROM challenge_players
+      WHERE player_id = ANY(${[oldPlayerId, newPlayerId]})
+    `;
+    const challengeIds = challenges.map((c) => c.id);
+    if (challengeIds.length > 0) {
+      await sql`DELETE FROM personal_best_history WHERE challenge_split_id IN (
+        SELECT id FROM challenge_splits WHERE challenge_id = ANY(${challengeIds})
+      )`;
+      await sql`DELETE FROM challenge_splits WHERE challenge_id = ANY(${challengeIds})`;
+      await sql`DELETE FROM challenge_players WHERE challenge_id = ANY(${challengeIds})`;
+      await sql`DELETE FROM challenges WHERE id = ANY(${challengeIds})`;
+    }
+    await sql`DELETE FROM players WHERE id = ANY(${[oldPlayerId, newPlayerId]})`;
+  });
+
+  /**
+   * Inserts one challenge + challenge_player + challenge_split row and
+   * returns the IDs. `attachedTo` controls which player owns the cp row.
+   */
+  async function seedSplit(args: {
+    finishedAt: string;
+    type: number;
+    scale: number;
+    ticks: number;
+    attachedTo: number;
+    accurate?: boolean;
+  }): Promise<{ challengeId: number; splitId: number }> {
+    challengeIdSeq += 1;
+    const uuid = `00000000-0000-0000-0000-${String(challengeIdSeq).padStart(12, '0')}`;
+    const [{ id: challengeId }] = await sql<[{ id: number }]>`
+      INSERT INTO challenges (uuid, type, scale, start_time, finish_time)
+      VALUES (${uuid}, ${args.type}, ${args.scale}, ${new Date(args.finishedAt)}, ${new Date(args.finishedAt)})
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO challenge_players (challenge_id, player_id, username, orb, primary_gear)
+      VALUES (${challengeId}, ${args.attachedTo}, 'pb', 0, 1)
+    `;
+    const [{ id: splitId }] = await sql<[{ id: number }]>`
+      INSERT INTO challenge_splits (challenge_id, type, scale, ticks, accurate)
+      VALUES (${challengeId}, ${args.type}, ${args.scale}, ${args.ticks}, ${args.accurate ?? true})
+      RETURNING id
+    `;
+    return { challengeId, splitId };
+  }
+
+  async function insertPb(
+    playerId: number,
+    splitId: number,
+    finishedAt: string,
+  ) {
+    await sql`
+      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
+      VALUES (${playerId}, ${splitId}, ${new Date(finishedAt)})
+    `;
+  }
+
+  async function pbHistoryFor(playerId: number) {
+    return sql<{ challenge_split_id: number; ticks: number }[]>`
+      SELECT pbh.challenge_split_id, cs.ticks
+      FROM personal_best_history pbh
+      JOIN challenge_splits cs ON pbh.challenge_split_id = cs.id
+      WHERE pbh.player_id = ${playerId}
+      ORDER BY pbh.created_at ASC
+    `;
+  }
+
+  it('returns 0 when challengeIds is empty', async () => {
+    const touched = await updatePersonalBestHistory(
+      oldPlayerId,
+      newPlayerId,
+      [],
+    );
+    expect(touched).toBe(0);
+  });
+
+  it('returns 0 when none of the migrated challenges have accurate splits', async () => {
+    const c = await seedSplit({
+      finishedAt: '2026-02-15',
+      type: 1,
+      scale: 5,
+      ticks: 100,
+      attachedTo: oldPlayerId,
+      accurate: false,
+    });
+    const touched = await updatePersonalBestHistory(oldPlayerId, newPlayerId, [
+      c.challengeId,
+    ]);
+    expect(touched).toBe(0);
+    expect(await pbHistoryFor(oldPlayerId)).toEqual([]);
+  });
+
+  it("inserts old player PBs for migrated splits that beat the old player's prior best", async () => {
+    // Old player's existing PB.
+    const oldPb = await seedSplit({
+      finishedAt: '2026-01-01',
+      type: 1,
+      scale: 5,
+      ticks: 200,
+      attachedTo: oldPlayerId,
+    });
+    await insertPb(oldPlayerId, oldPb.splitId, '2026-01-01');
+
+    // Two migrated splits: 220 (worse, no PB) and 180 (better, PB).
+    const worse = await seedSplit({
+      finishedAt: '2026-02-15',
+      type: 1,
+      scale: 5,
+      ticks: 220,
+      attachedTo: oldPlayerId,
+    });
+    const better = await seedSplit({
+      finishedAt: '2026-02-16',
+      type: 1,
+      scale: 5,
+      ticks: 180,
+      attachedTo: oldPlayerId,
+    });
+
+    await updatePersonalBestHistory(oldPlayerId, newPlayerId, [
+      worse.challengeId,
+      better.challengeId,
+    ]);
+
+    const oldRows = await pbHistoryFor(oldPlayerId);
+    expect(oldRows.map((r) => r.challenge_split_id)).toEqual([
+      oldPb.splitId,
+      better.splitId,
+    ]);
+  });
+
+  it('walks migrated splits chronologically, only inserting progressive PBs', async () => {
+    const splits = await Promise.all([
+      seedSplit({
+        finishedAt: '2026-02-01',
+        type: 1,
+        scale: 5,
+        ticks: 200,
+        attachedTo: oldPlayerId,
+      }), // PB
+      seedSplit({
+        finishedAt: '2026-02-02',
+        type: 1,
+        scale: 5,
+        ticks: 220,
+        attachedTo: oldPlayerId,
+      }), // not a PB
+      seedSplit({
+        finishedAt: '2026-02-03',
+        type: 1,
+        scale: 5,
+        ticks: 180,
+        attachedTo: oldPlayerId,
+      }), // PB
+      seedSplit({
+        finishedAt: '2026-02-04',
+        type: 1,
+        scale: 5,
+        ticks: 190,
+        attachedTo: oldPlayerId,
+      }), // not a PB
+      seedSplit({
+        finishedAt: '2026-02-05',
+        type: 1,
+        scale: 5,
+        ticks: 170,
+        attachedTo: oldPlayerId,
+      }), // PB
+    ]);
+
+    await updatePersonalBestHistory(
+      oldPlayerId,
+      newPlayerId,
+      splits.map((s) => s.challengeId),
+    );
+
+    const oldRows = await pbHistoryFor(oldPlayerId);
+    expect(oldRows.map((r) => r.challenge_split_id)).toEqual([
+      splits[0].splitId,
+      splits[2].splitId,
+      splits[4].splitId,
+    ]);
+  });
+
+  it("deletes the new player's PB rows for the migrated challenges' splits", async () => {
+    // New player has a PB row for a split that's about to be migrated.
+    const migrated = await seedSplit({
+      finishedAt: '2026-02-15',
+      type: 1,
+      scale: 5,
+      ticks: 100,
+      attachedTo: oldPlayerId, // already migrated to old
+    });
+    await insertPb(newPlayerId, migrated.splitId, '2026-02-15');
+    // New player also has an unrelated PB row that must NOT be touched.
+    const untouched = await seedSplit({
+      finishedAt: '2026-03-01',
+      type: 2,
+      scale: 5,
+      ticks: 250,
+      attachedTo: newPlayerId,
+    });
+    await insertPb(newPlayerId, untouched.splitId, '2026-03-01');
+
+    await updatePersonalBestHistory(oldPlayerId, newPlayerId, [
+      migrated.challengeId,
+    ]);
+
+    const newRows = await pbHistoryFor(newPlayerId);
+    expect(newRows.map((r) => r.challenge_split_id)).toEqual([
+      untouched.splitId,
+    ]);
+  });
+
+  it('handles multiple (type, scale) pairs independently', async () => {
+    const splits = await Promise.all([
+      seedSplit({
+        finishedAt: '2026-02-01',
+        type: 1,
+        scale: 5,
+        ticks: 100,
+        attachedTo: oldPlayerId,
+      }),
+      seedSplit({
+        finishedAt: '2026-02-02',
+        type: 2,
+        scale: 5,
+        ticks: 200,
+        attachedTo: oldPlayerId,
+      }),
+      seedSplit({
+        finishedAt: '2026-02-03',
+        type: 1,
+        scale: 5,
+        ticks: 150,
+        attachedTo: oldPlayerId,
+      }), // worse for type=1
+      seedSplit({
+        finishedAt: '2026-02-04',
+        type: 2,
+        scale: 5,
+        ticks: 180,
+        attachedTo: oldPlayerId,
+      }), // PB for type=2
+    ]);
+
+    await updatePersonalBestHistory(
+      oldPlayerId,
+      newPlayerId,
+      splits.map((s) => s.challengeId),
+    );
+
+    const oldRows = await pbHistoryFor(oldPlayerId);
+    expect(oldRows.map((r) => r.challenge_split_id)).toEqual([
+      splits[0].splitId,
+      splits[1].splitId,
+      splits[3].splitId,
+    ]);
+  });
+
+  describe('recomputePostCutoff', () => {
+    it('drops a stale post-cutoff PB on old player when in-window absorbs a better one', async () => {
+      const inWindow = await seedSplit({
+        finishedAt: '2026-02-15',
+        type: 1,
+        scale: 5,
+        ticks: 150,
+        attachedTo: oldPlayerId,
+      });
+      const post = await seedSplit({
+        finishedAt: '2026-05-01',
+        type: 1,
+        scale: 5,
+        ticks: 200,
+        attachedTo: oldPlayerId,
+      });
+      await insertPb(oldPlayerId, post.splitId, '2026-05-01');
+
+      await updatePersonalBestHistory(
+        oldPlayerId,
+        newPlayerId,
+        [inWindow.challengeId],
+        sql,
+      );
+
+      const oldRows = await pbHistoryFor(oldPlayerId);
+      expect(oldRows.map((r) => r.challenge_split_id)).toEqual([
+        inWindow.splitId,
+      ]);
+    });
+
+    it('inserts an in-window PB even when the target has a faster post-cutoff PB', async () => {
+      const preWindow = await seedSplit({
+        finishedAt: '2026-01-01',
+        type: 1,
+        scale: 5,
+        ticks: 200,
+        attachedTo: oldPlayerId,
+      });
+      await insertPb(oldPlayerId, preWindow.splitId, '2026-01-01');
+
+      const inWindow = await seedSplit({
+        finishedAt: '2026-02-15',
+        type: 1,
+        scale: 5,
+        ticks: 180,
+        attachedTo: oldPlayerId,
+      });
+
+      const postCutoff = await seedSplit({
+        finishedAt: '2026-05-01',
+        type: 1,
+        scale: 5,
+        ticks: 150,
+        attachedTo: oldPlayerId,
+      });
+      await insertPb(oldPlayerId, postCutoff.splitId, '2026-05-01');
+
+      await updatePersonalBestHistory(
+        oldPlayerId,
+        newPlayerId,
+        [inWindow.challengeId],
+        sql,
+      );
+
+      const oldRows = await pbHistoryFor(oldPlayerId);
+      expect(oldRows.map((r) => r.challenge_split_id)).toEqual([
+        preWindow.splitId,
+        inWindow.splitId,
+        postCutoff.splitId,
+      ]);
+    });
+
+    it("adds a new eligible PB on new player's post-cutoff history", async () => {
+      // In-window split, currently the new player's PB.
+      const inWindow = await seedSplit({
+        finishedAt: '2026-02-15',
+        type: 1,
+        scale: 5,
+        ticks: 100,
+        attachedTo: oldPlayerId, // already moved
+      });
+      await insertPb(newPlayerId, inWindow.splitId, '2026-02-15');
+      // Post-cutoff split on new player that wasn't a PB at the time.
+      const post = await seedSplit({
+        finishedAt: '2026-05-01',
+        type: 1,
+        scale: 5,
+        ticks: 120,
+        attachedTo: newPlayerId,
+      });
+
+      await updatePersonalBestHistory(
+        oldPlayerId,
+        newPlayerId,
+        [inWindow.challengeId],
+        sql,
+      );
+
+      const newRows = await pbHistoryFor(newPlayerId);
+      expect(newRows.map((r) => r.challenge_split_id)).toEqual([post.splitId]);
+    });
   });
 });
 

--- a/web/app/actions/name-change-processor.ts
+++ b/web/app/actions/name-change-processor.ts
@@ -50,25 +50,26 @@ type PlayerStatsRow = CamelToSnakeCase<PlayerStats> & {
   id: number;
 };
 
-async function updatePlayerStats(
-  oldPlayerId: number,
-  newPlayerId: number,
+export async function updatePlayerStats(
+  targetPlayerId: number,
+  sourcePlayerId: number,
   fromDate: Date,
+  toDate: Date | null = null,
   db: Db = sql,
 ): Promise<number> {
-  const [lastStats] = await db<[PlayerStatsRow?]>`
+  const [targetPlayerLastStats] = await db<[PlayerStatsRow?]>`
     SELECT *
     FROM player_stats
-    WHERE player_id = ${oldPlayerId}
+    WHERE player_id = ${targetPlayerId}
     AND date <= ${fromDate}
     ORDER BY date DESC
     LIMIT 1
   `;
 
-  const [newPlayerLastStats] = await db<[PlayerStatsRow?]>`
+  const [sourcePlayerLastStats] = await db<[PlayerStatsRow?]>`
     SELECT *
     FROM player_stats
-    WHERE player_id = ${newPlayerId}
+    WHERE player_id = ${sourcePlayerId}
     AND date <= ${fromDate}
     ORDER BY date DESC
     LIMIT 1
@@ -77,55 +78,105 @@ async function updatePlayerStats(
   const statsToMigrate = await db<PlayerStatsRow[]>`
     SELECT *
     FROM player_stats
-    WHERE player_id = ${newPlayerId}
+    WHERE player_id = ${sourcePlayerId}
     AND date > ${fromDate}
+    ${toDate !== null ? sql`AND date <= ${toDate}` : sql``}
+    ORDER BY date ASC
   `;
 
   // Reassign the new player's stats to the old player, adjusting the values by
   // the difference accumulated since the fromDate.
+  let lastInWindowDeltas: Record<string, number> = {};
   for (const stats of statsToMigrate) {
     const newStats: Record<string, number> = {
-      player_id: oldPlayerId,
+      player_id: targetPlayerId,
     };
+    const deltas: Record<string, number> = {};
 
     Object.entries(stats).forEach(([key, value]) => {
       if (key === 'id' || key === 'player_id' || typeof value !== 'number') {
         return;
       }
       const k = key as keyof PlayerStatsRow;
-      const base = (newPlayerLastStats?.[k] as number | undefined) ?? 0;
+      const base = (sourcePlayerLastStats?.[k] as number | undefined) ?? 0;
       const delta = value - base;
-      const old = (lastStats?.[k] as number | undefined) ?? 0;
+      deltas[key] = delta;
+      const old = (targetPlayerLastStats?.[k] as number | undefined) ?? 0;
       newStats[key] = old + delta;
     });
+
+    lastInWindowDeltas = deltas;
 
     await db`
       UPDATE player_stats SET ${sql(newStats)} WHERE id = ${stats.id}
     `;
   }
 
+  // Per-player activity counters need symmetric adjustment for any rows that
+  // exist after `toDate`:
+  //
+  // - source player's post-window rows still include the in-window contribution
+  //   they recorded at the time: subtract the window delta.
+  // - target player's post-window rows never saw the in-window activity (it was
+  //   credited to the source): add the window delta.
+  //
+  if (toDate !== null && statsToMigrate.length > 0) {
+    const nonZero = Object.entries(lastInWindowDeltas).filter(
+      ([, v]) => v !== 0,
+    );
+    if (nonZero.length > 0) {
+      const [firstCol, firstDelta] = nonZero[0];
+
+      let tgtClause = sql`${sql(firstCol)} = ${sql(firstCol)} + ${firstDelta}`;
+      let srcClause = sql`${sql(firstCol)} = ${sql(firstCol)} - ${firstDelta}`;
+
+      for (let i = 1; i < nonZero.length; i++) {
+        const [col, delta] = nonZero[i];
+        tgtClause = sql`${tgtClause}, ${sql(col)} = ${sql(col)} + ${delta}`;
+        srcClause = sql`${srcClause}, ${sql(col)} = ${sql(col)} - ${delta}`;
+      }
+      await Promise.all([
+        db`
+          UPDATE player_stats SET ${tgtClause}
+          WHERE player_id = ${targetPlayerId} AND date > ${toDate}
+        `,
+        db`
+          UPDATE player_stats SET ${srcClause}
+          WHERE player_id = ${sourcePlayerId} AND date > ${toDate}
+        `,
+      ]);
+    }
+  }
+
   return statsToMigrate.length;
 }
 
-async function updateApiKeys(
-  oldPlayerId: number,
-  newPlayerId: number,
+/**
+ * Reassigns API keys whose `last_used` falls within a migration window from
+ * source to target. Keys outside the window are left in place.
+ *
+ * @param targetPlayerId ID of the target player.
+ * @param sourcePlayerId ID of the source player.
+ * @param fromDate Start date of the migration window.
+ * @param toDate Optional end date of the migration window.
+ * @param db The database connection.
+ * @returns The number of API keys reassigned.
+ */
+export async function updateApiKeys(
+  targetPlayerId: number,
+  sourcePlayerId: number,
   fromDate: Date,
+  toDate: Date | null = null,
   db: Db = sql,
 ): Promise<number> {
   const updated = await db`
     UPDATE api_keys
-    SET player_id = ${oldPlayerId}
-    WHERE player_id = ${newPlayerId} AND last_used > ${fromDate}
+    SET player_id = ${targetPlayerId}
+    WHERE player_id = ${sourcePlayerId}
+      AND last_used > ${fromDate}
+      ${toDate !== null ? sql`AND last_used <= ${toDate}` : sql``}
   `;
-
-  // Delete unused keys for the new player.
-  const deleted = await db`
-    DELETE FROM api_keys
-    WHERE player_id = ${newPlayerId} AND last_used IS NULL
-  `;
-
-  return updated.count + deleted.count;
+  return updated.count;
 }
 
 type SplitRow = {
@@ -136,9 +187,9 @@ type SplitRow = {
   finish_time: Date;
 };
 
-async function updatePersonalBestHistory(
-  oldPlayerId: number,
-  newPlayerId: number,
+export async function updatePersonalBestHistory(
+  targetPlayerId: number,
+  sourcePlayerId: number,
   challengeIds: number[],
   db: Db = sql,
 ): Promise<number> {
@@ -146,10 +197,9 @@ async function updatePersonalBestHistory(
     return 0;
   }
 
-  // Find all splits from the challenges that are being migrated from the new
-  // player to the old player. These are ordered chronologically to correctly
-  // determine the PB progression.
-  const newPlayerSplits = await db<SplitRow[]>`
+  // Find all splits from the challenges that are being migrated from the source
+  // player to the target player.
+  const sourcePlayerSplits = await db<SplitRow[]>`
     SELECT
       cs.id,
       cs.type,
@@ -162,13 +212,11 @@ async function updatePersonalBestHistory(
     ORDER BY c.finish_time ASC
   `;
 
-  if (newPlayerSplits.length === 0) {
+  if (sourcePlayerSplits.length === 0) {
     return 0;
   }
 
-  // For each distinct split type (type and scale), get the old player's current
-  // personal best.
-  const distinctSplitTypes = newPlayerSplits
+  const distinctSplitTypes: [number, number][] = sourcePlayerSplits
     .filter(
       (split: SplitRow, index: number, self: SplitRow[]) =>
         index ===
@@ -176,60 +224,113 @@ async function updatePersonalBestHistory(
           (s: SplitRow) => s.type === split.type && s.scale === split.scale,
         ),
     )
-    .map((split: SplitRow) => sql([split.type, split.scale]));
+    .map((split: SplitRow) => [split.type, split.scale]);
 
-  const oldPlayerPbs = await db<
-    { type: number; scale: number; best_time: number }[]
+  // Recompute the PB history for both players to account for the moved
+  // challenges, starting from the first migrated challenge.
+  const cutoffChallengeId = Math.min(...challengeIds);
+  let recomputedCount = 0;
+
+  recomputedCount += await recomputePbHistoryFrom(
+    sourcePlayerId,
+    distinctSplitTypes,
+    cutoffChallengeId,
+    db,
+  );
+  recomputedCount += await recomputePbHistoryFrom(
+    targetPlayerId,
+    distinctSplitTypes,
+    cutoffChallengeId,
+    db,
+  );
+
+  return recomputedCount;
+}
+
+/**
+ * Rebuilds a player's PB history for a set of splits and scales over challenges
+ * with an `id` starting at `cutoffChallengeId`.
+ *
+ * @param playerId ID of the player.
+ * @param splitsToRecompute Array of split (type, scale) pairs to recompute.
+ * @param cutoffChallengeId First challenge ID to recompute.
+ * @param db The database connection.
+ * @returns Number of PB history rows affected.
+ */
+export async function recomputePbHistoryFrom(
+  playerId: number,
+  splitsToRecompute: [number, number][],
+  cutoffChallengeId: number,
+  db: Db = sql,
+): Promise<number> {
+  if (splitsToRecompute.length === 0) {
+    return 0;
+  }
+
+  const splitFragments = splitsToRecompute.map(([t, s]) => sql([t, s]));
+
+  const deleted = await db`
+    DELETE FROM personal_best_history pbh
+    USING challenge_splits cs
+    WHERE pbh.challenge_split_id = cs.id
+      AND pbh.player_id = ${playerId}
+      AND cs.challenge_id >= ${cutoffChallengeId}
+      AND (cs.type, cs.scale) IN ${sql(splitFragments)}
+  `;
+
+  const bestRows = await db<
+    { type: number; scale: number; best: number | null }[]
   >`
-    SELECT
-      cs.type,
-      cs.scale,
-      MIN(cs.ticks) as best_time
-    FROM personal_best_history pbh
-    JOIN challenge_splits cs ON pbh.challenge_split_id = cs.id
-    WHERE
-      pbh.player_id = ${oldPlayerId}
-      AND (cs.type, cs.scale) IN ${sql(distinctSplitTypes)}
+    SELECT cs.type, cs.scale, MIN(cs.ticks) AS best
+    FROM challenge_splits cs
+    JOIN challenge_players cp ON cp.challenge_id = cs.challenge_id
+    WHERE cp.player_id = ${playerId}
+      AND (cs.type, cs.scale) IN ${sql(splitFragments)}
+      AND cs.accurate
+      AND cs.challenge_id < ${cutoffChallengeId}
     GROUP BY cs.type, cs.scale
   `;
 
   const splitKey = (type: number, scale: number) => `${type}-${scale}`;
+  const bestMap: Record<string, number> = {};
+  for (const r of bestRows) {
+    if (r.best !== null) {
+      bestMap[splitKey(r.type, r.scale)] = r.best;
+    }
+  }
 
-  const oldPlayerPbMap: Record<string, number> = oldPlayerPbs.reduce(
-    (
-      acc: Record<string, number>,
-      pb: { type: number; scale: number; best_time: number },
-    ) => {
-      acc[splitKey(pb.type, pb.scale)] = pb.best_time;
-      return acc;
-    },
-    {} as Record<string, number>,
-  );
+  const splits = await db<SplitRow[]>`
+    SELECT cs.id, cs.type, cs.scale, cs.ticks, c.finish_time
+    FROM challenge_splits cs
+    JOIN challenges c ON cs.challenge_id = c.id
+    JOIN challenge_players cp ON cp.challenge_id = c.id
+    WHERE cp.player_id = ${playerId}
+      AND (cs.type, cs.scale) IN ${sql(splitFragments)}
+      AND cs.accurate
+      AND cs.challenge_id >= ${cutoffChallengeId}
+    ORDER BY c.finish_time ASC
+  `;
 
-  // Iterate through all of the chronologically-sorted splits from the new
-  // player, inserting a new PB history record if it beats the old player's
-  // previous best.
   const pbsToInsert: {
     player_id: number;
     challenge_split_id: number;
     created_at: Date;
   }[] = [];
 
-  for (const split of newPlayerSplits) {
-    const key = splitKey(split.type, split.scale);
-    const currentBest = oldPlayerPbMap[key];
-
+  for (const split of splits) {
+    const k = splitKey(split.type, split.scale);
+    const currentBest = bestMap[k];
     if (currentBest === undefined || split.ticks < currentBest) {
       pbsToInsert.push({
-        player_id: oldPlayerId,
+        player_id: playerId,
         challenge_split_id: split.id,
         created_at: split.finish_time,
       });
-      oldPlayerPbMap[key] = split.ticks;
+      bestMap[k] = split.ticks;
     }
   }
 
-  let insertedCount = 0;
+  let inserted = 0;
   if (pbsToInsert.length > 0) {
     const result = await db`
       INSERT INTO personal_best_history ${sql(
@@ -239,32 +340,10 @@ async function updatePersonalBestHistory(
         'created_at',
       )}
     `;
-    insertedCount = result.count;
+    inserted = result.count;
   }
 
-  // Delete all of the new player's personal bests that were associated with the
-  // migrated challenges. This effectively rolls back their PB history to the
-  // state before the name change, as the underlying challenges now belong to
-  // the old player.
-  const splitsInMigratedChallengesRows = await db<{ id: number }[]>`
-    SELECT id FROM challenge_splits WHERE challenge_id = ANY(${challengeIds})
-  `;
-  const splitsInMigratedChallenges = splitsInMigratedChallengesRows.map(
-    (r) => r.id,
-  );
-
-  let deletedCount = 0;
-  if (splitsInMigratedChallenges.length > 0) {
-    const result = await db`
-      DELETE FROM personal_best_history
-      WHERE
-        player_id = ${newPlayerId}
-        AND challenge_split_id = ANY(${splitsInMigratedChallenges})
-    `;
-    deletedCount = result.count;
-  }
-
-  return insertedCount + deletedCount;
+  return deleted.count + inserted;
 }
 
 function compareExperience(
@@ -493,24 +572,26 @@ export async function processNameChange(
         count: challengesToUpdate.length,
       });
 
-      const updateChallengePlayers = db`
+      // Update players serially as the other migrations depend on
+      // player-challenge associations.
+      const updatedPlayerCount = await db`
         UPDATE challenge_players
         SET player_id = ${playerId}
         WHERE
           player_id = ${newPlayer.id}
           AND challenge_id = ANY(${challengesToUpdate})
       `.then((res) => res.count);
+      migratedDocuments += updatedPlayerCount;
 
       const modifiedDocuments = await Promise.all([
-        updateChallengePlayers,
-        updateApiKeys(playerId, newPlayer.id, updateFrom, db),
+        updateApiKeys(playerId, newPlayer.id, updateFrom, null, db),
         updatePersonalBestHistory(
           playerId,
           newPlayer.id,
           challengesToUpdate,
           db,
         ),
-        updatePlayerStats(playerId, newPlayer.id, updateFrom, db),
+        updatePlayerStats(playerId, newPlayer.id, updateFrom, null, db),
       ]);
 
       challengesUpdated = challengesToUpdate.length;


### PR DESCRIPTION
Updates the name change migration functions to optionally accept an end date, only migrating records from within that period. Records beyond the cutoff date are adjusted accordingly: PBs are recomputed, player stats are offset by the migrated delta's baseline, etc.

No code path sets an end date yet; the existing name change processor is unchanged.