### PR TITLE
challenge: Ignore bounce events without targets

### DIFF
--- a/challenge-server/event-processing/theatre.ts
+++ b/challenge-server/event-processing/theatre.ts
@@ -663,6 +663,9 @@ export default class TheatreProcessor extends ChallengeProcessor {
 
       case Event.Type.TOB_VERZIK_BOUNCE: {
         const bounce = event.getVerzikBounce()!;
+        if (!bounce.hasBouncedPlayer()) {
+          break;
+        }
 
         if (bounce.getNpcAttackTick() !== -1) {
           const attack = allEvents


### PR DESCRIPTION
When handling Verzik bounce events to retroactively set a target on the bounce attack, skip bounce chance events that don't have a target.