### PR TITLE
socket: Forward plugin versions to challenge server

### DIFF
--- a/challenge-server/api.ts
+++ b/challenge-server/api.ts
@@ -170,6 +170,8 @@ type NewChallengeRequest = {
   userId: number;
   clientId: number;
   sessionToken: string;
+  pluginVersion: string;
+  runeLiteVersion: string;
   type: ChallengeType;
   mode: ChallengeMode;
   stage: Stage;
@@ -192,9 +194,13 @@ async function newChallenge(req: Request, res: Response): Promise<void> {
     },
     async () => {
       const result = await res.locals.challengeManager.createOrJoin(
-        request.userId,
-        request.clientId,
-        request.sessionToken,
+        {
+          userId: request.userId,
+          clientId: request.clientId,
+          sessionToken: request.sessionToken,
+          pluginVersion: request.pluginVersion,
+          runeLiteVersion: request.runeLiteVersion,
+        },
         request.type,
         request.mode,
         request.stage,
@@ -288,6 +294,8 @@ type JoinChallengeRequest = {
   userId: number;
   clientId: number;
   sessionToken: string;
+  pluginVersion: string;
+  runeLiteVersion: string;
   recordingType: RecordingType;
 };
 
@@ -309,9 +317,13 @@ async function joinChallenge(req: Request, res: Response): Promise<void> {
     async () => {
       const status = await res.locals.challengeManager.addClient(
         challengeId,
-        request.userId,
-        request.clientId,
-        request.sessionToken,
+        {
+          userId: request.userId,
+          clientId: request.clientId,
+          sessionToken: request.sessionToken,
+          pluginVersion: request.pluginVersion,
+          runeLiteVersion: request.runeLiteVersion,
+        },
         request.recordingType,
       );
       res.json(status);

--- a/challenge-server/challenge-manager.ts
+++ b/challenge-server/challenge-manager.ts
@@ -178,17 +178,23 @@ type StartActionDecision =
       response: ChallengeStatusResponse;
     };
 
+export type ConnectingClient = {
+  userId: number;
+  clientId: number;
+  sessionToken: string;
+  pluginVersion: string;
+  runeLiteVersion: string;
+};
+
 async function createChallengeClient(
   txn: TransactionClient,
   challengeUuid: string,
-  userId: number,
-  clientId: number,
-  sessionToken: string,
+  client: ConnectingClient,
   recordingType: RecordingType,
   stage: Stage,
   stageAttempt: number | null = null,
 ): Promise<ChallengeClient> {
-  const existing = await txn.getChallengeClient(challengeUuid, clientId);
+  const existing = await txn.getChallengeClient(challengeUuid, client.clientId);
   if (existing !== null) {
     // If rejoining, maintain the last completed stage.
     return {
@@ -196,15 +202,15 @@ async function createChallengeClient(
       stage,
       stageAttempt,
       stageStatus: StageStatus.ENTERED,
-      sessionToken,
+      sessionToken: client.sessionToken,
       active: true,
+      pluginVersion: client.pluginVersion,
+      runeLiteVersion: client.runeLiteVersion,
     };
   }
 
   return {
-    userId,
-    clientId,
-    sessionToken,
+    ...client,
     type: recordingType,
     active: true,
     stage,
@@ -297,9 +303,7 @@ export default class ChallengeManager {
   /**
    * Creates a new challenge for the given party or joins an existing one.
    *
-   * @param userId ID of the user.
-   * @param clientId ID of the client.
-   * @param sessionToken Unique identifier for the client's session.
+   * @param client The client connecting to the challenge.
    * @param type Type of challenge.
    * @param mode Mode of challenge.
    * @param stage Stage of challenge.
@@ -309,9 +313,7 @@ export default class ChallengeManager {
    * @throws ChallengeError if a challenge could not be created or joined.
    */
   public async createOrJoin(
-    userId: number,
-    clientId: number,
-    sessionToken: string,
+    client: ConnectingClient,
     type: ChallengeType,
     mode: ChallengeMode,
     stage: Stage,
@@ -333,9 +335,7 @@ export default class ChallengeManager {
       let statusResponse: ChallengeStatusResponse | null = null;
 
       const decision = await this.determineStartAction(
-        userId,
-        clientId,
-        sessionToken,
+        client,
         type,
         recordingType,
         stage,
@@ -350,9 +350,7 @@ export default class ChallengeManager {
           statusResponse = await this.handleChallengeCreate(
             decision.uuid,
             decision.sessionId,
-            userId,
-            clientId,
-            sessionToken,
+            client,
             recordingType,
             type,
             mode,
@@ -366,9 +364,7 @@ export default class ChallengeManager {
         case StartAction.DEFERRED_JOIN: {
           statusResponse = await this.handleChallengeDeferredJoin(
             decision.uuid,
-            userId,
-            clientId,
-            sessionToken,
+            client,
             recordingType,
           );
           requestDecision = 'deferred';
@@ -386,7 +382,7 @@ export default class ChallengeManager {
 
       await ChallengeProcessor.addRecorder(
         decision.uuid,
-        userId,
+        client.userId,
         recordingType,
       );
 
@@ -403,9 +399,7 @@ export default class ChallengeManager {
   }
 
   private async determineStartAction(
-    userId: number,
-    clientId: number,
-    sessionToken: string,
+    client: ConnectingClient,
     type: ChallengeType,
     recordingType: RecordingType,
     stage: Stage,
@@ -418,8 +412,8 @@ export default class ChallengeManager {
       level: 'info' | 'warn' = 'info',
     ) => {
       logger[level]('challenge_join_decision', {
-        userId,
-        clientId,
+        userId: client.userId,
+        clientId: client.clientId,
         type,
         stage,
         party,
@@ -522,16 +516,14 @@ export default class ChallengeManager {
             const challengeClient = await createChallengeClient(
               txn,
               lastChallengeForParty,
-              userId,
-              clientId,
-              sessionToken,
+              client,
               recordingType,
               startDecision.response.stage,
               startDecision.response.stageAttempt,
             );
             txn.setChallengeClient(
               lastChallengeForParty,
-              clientId,
+              client.clientId,
               challengeClient,
             );
 
@@ -580,8 +572,8 @@ export default class ChallengeManager {
       // This should never happen as the transaction should always set these
       // values, but log some basic debugging information just in case.
       logger.error('challenge_start_failed', {
-        userId,
-        clientId,
+        userId: client.userId,
+        clientId: client.clientId,
         type,
         stage,
         party,
@@ -595,9 +587,7 @@ export default class ChallengeManager {
   private async handleChallengeCreate(
     uuid: string,
     sessionId: number | null,
-    userId: number,
-    clientId: number,
-    sessionToken: string,
+    client: ConnectingClient,
     recordingType: RecordingType,
     type: ChallengeType,
     mode: ChallengeMode,
@@ -625,8 +615,8 @@ export default class ChallengeManager {
       await processor.createNew(startTime, sessionId);
     } catch (e: unknown) {
       logger.error('challenge_create_failed', {
-        userId,
-        clientId,
+        userId: client.userId,
+        clientId: client.clientId,
         challengeUuid: uuid,
         type,
         mode,
@@ -651,9 +641,7 @@ export default class ChallengeManager {
       const challengeClient = await createChallengeClient(
         txn,
         uuid,
-        userId,
-        clientId,
-        sessionToken,
+        client,
         recordingType,
         stage,
       );
@@ -661,7 +649,7 @@ export default class ChallengeManager {
         ...processor.getState(),
         state: LifecycleState.ACTIVE,
       });
-      txn.setChallengeClient(uuid, clientId, challengeClient);
+      txn.setChallengeClient(uuid, client.clientId, challengeClient);
       txn.setSessionChallenge(processor.getSessionId(), type, party);
 
       for (const player of party) {
@@ -670,8 +658,8 @@ export default class ChallengeManager {
     });
 
     logger.info('challenge_created', {
-      userId,
-      clientId,
+      userId: client.userId,
+      clientId: client.clientId,
       challengeUuid: uuid,
       sessionId: processor.getSessionId(),
       type,
@@ -690,9 +678,7 @@ export default class ChallengeManager {
 
   private async handleChallengeDeferredJoin(
     uuid: string,
-    userId: number,
-    clientId: number,
-    sessionToken: string,
+    client: ConnectingClient,
     recordingType: RecordingType,
   ): Promise<ChallengeStatusResponse> {
     // Another client is simultaneously creating the challenge. Wait until
@@ -721,8 +707,8 @@ export default class ChallengeManager {
         ) {
           logger.error('deferred_join_missing_challenge', {
             challengeUuid: uuid,
-            userId,
-            clientId,
+            userId: client.userId,
+            clientId: client.clientId,
             lifecycleState,
           });
           throw new ChallengeError(
@@ -745,14 +731,12 @@ export default class ChallengeManager {
         const challengeClient = await createChallengeClient(
           txn,
           uuid,
-          userId,
-          clientId,
-          sessionToken,
+          client,
           recordingType,
           statusResponse.stage,
           statusResponse.stageAttempt,
         );
-        txn.setChallengeClient(uuid, clientId, challengeClient);
+        txn.setChallengeClient(uuid, client.clientId, challengeClient);
         return true;
       }, 'deferred_join');
 
@@ -768,20 +752,20 @@ export default class ChallengeManager {
     if (retries === DEFERRED_JOIN_MAX_RETRIES) {
       logger.error('deferred_join_max_retries', {
         challengeUuid: uuid,
-        userId,
-        clientId,
+        userId: client.userId,
+        clientId: client.clientId,
         retries,
       });
       throw new ChallengeError(
         ChallengeErrorType.INTERNAL,
-        `Failed to join challenge ${uuid} for client ${clientId} after ${retries} attempts`,
+        `Failed to join challenge ${uuid} for client ${client.clientId} after ${retries} attempts`,
       );
     }
 
     logger.info('deferred_join_success', {
       challengeUuid: uuid,
-      userId,
-      clientId,
+      userId: client.userId,
+      clientId: client.clientId,
       retries,
     });
 
@@ -1185,29 +1169,25 @@ export default class ChallengeManager {
   /**
    * Adds a client to an existing challenge.
    * @param challengeId ID of the challenge to join.
-   * @param userId ID of the user.
-   * @param clientId ID of the client.
-   * @param sessionToken Unique identifier for the client's session.
+   * @param client The client joining the challenge.
    * @param recordingType Type of client recording.
    * @returns The current status of the joined challenge.
    * @throws ChallengeError if the join fails.
    */
   public async addClient(
     challengeId: string,
-    userId: number,
-    clientId: number,
-    sessionToken: string,
+    client: ConnectingClient,
     recordingType: RecordingType,
   ): Promise<ChallengeStatusResponse> {
     let metricDecision: ChallengeRequestDecision = 'error';
 
     try {
       const currentChallenge =
-        await this.redisClient.getActiveChallengeForClient(clientId);
+        await this.redisClient.getActiveChallengeForClient(client.clientId);
       if (currentChallenge !== null && currentChallenge !== challengeId) {
         logger.warn('challenge_join_rejected', {
-          userId,
-          clientId,
+          userId: client.userId,
+          clientId: client.clientId,
           challengeUuid: challengeId,
           reason: 'already_in_challenge',
           currentChallenge,
@@ -1231,8 +1211,8 @@ export default class ChallengeManager {
 
         if (challenge?.state !== LifecycleState.ACTIVE) {
           logger.warn('challenge_join_rejected', {
-            userId,
-            clientId,
+            userId: client.userId,
+            clientId: client.clientId,
             challengeUuid: challengeId,
             reason: 'non_existent',
           });
@@ -1243,21 +1223,19 @@ export default class ChallengeManager {
         const clientInfo = await createChallengeClient(
           txn,
           challengeId,
-          userId,
-          clientId,
-          sessionToken,
+          client,
           recordingType,
           challenge.stage,
           challenge.stageAttempt ?? null,
         );
 
-        txn.setChallengeClient(challengeId, clientId, clientInfo);
+        txn.setChallengeClient(challengeId, client.clientId, clientInfo);
 
         const allInactive = clients.every((c) => !c.active);
         if (allInactive && challenge.timeoutState === TimeoutState.CLEANUP) {
           logger.info('challenge_cleanup_canceled', {
-            userId,
-            clientId,
+            userId: client.userId,
+            clientId: client.clientId,
             challengeUuid: challengeId,
             stage: clientInfo.stage,
             attempt: clientInfo.stageAttempt,
@@ -1287,8 +1265,8 @@ export default class ChallengeManager {
       const response = statusResponse as ChallengeStatusResponse;
 
       logger.info('client_reconnected', {
-        userId,
-        clientId,
+        userId: client.userId,
+        clientId: client.clientId,
         challengeUuid: challengeId,
         stage: response.stage,
         attempt: response.stageAttempt,
@@ -1298,8 +1276,8 @@ export default class ChallengeManager {
       return response;
     } catch (e) {
       logger.error('client_reconnect_error', {
-        userId,
-        clientId,
+        userId: client.userId,
+        clientId: client.clientId,
         challengeUuid: challengeId,
         recordingType,
         error: e instanceof Error ? e : new Error(String(e)),

--- a/challenge-server/redis-client.ts
+++ b/challenge-server/redis-client.ts
@@ -78,6 +78,8 @@ export type ChallengeClient = {
   userId: number;
   clientId: number;
   sessionToken: string;
+  pluginVersion: string;
+  runeLiteVersion: string;
   type: RecordingType;
   active: boolean;
   stage: Stage;

--- a/common/db/redis.ts
+++ b/common/db/redis.ts
@@ -169,9 +169,21 @@ export type StageUpdate = {
 export enum StageStreamType {
   STAGE_EVENTS,
   STAGE_END,
+  CLIENT_METADATA,
 }
 
-export type ClientStageStream = StageStreamEvents | StageStreamEnd;
+export type ClientStageStream =
+  | StageStreamMetadata
+  | StageStreamEvents
+  | StageStreamEnd;
+
+export type StageStreamMetadata = {
+  type: StageStreamType.CLIENT_METADATA;
+  clientId: number;
+  userId: number;
+  pluginVersion: string;
+  runeLiteVersion: string;
+};
 
 export type StageStreamEvents = {
   type: StageStreamType.STAGE_EVENTS;
@@ -239,6 +251,11 @@ export function stageStreamToRecord(
   };
 
   switch (event.type) {
+    case StageStreamType.CLIENT_METADATA:
+      evt.userId = event.userId.toString();
+      evt.pluginVersion = event.pluginVersion;
+      evt.runeLiteVersion = event.runeLiteVersion;
+      break;
     case StageStreamType.STAGE_EVENTS:
       evt.events = Buffer.from(event.events);
       break;
@@ -271,11 +288,18 @@ export function stageStreamFromRecord(
         update: JSON.parse(event.update.toString()) as StageUpdate,
       } as StageStreamEnd;
 
-    default:
-      throw new Error(
-        `Unknown stage stream type: ${type as unknown as number}`,
-      );
+    case StageStreamType.CLIENT_METADATA:
+      return {
+        type,
+        clientId,
+        userId: Number.parseInt(event.userId.toString()),
+        pluginVersion: event.pluginVersion.toString(),
+        runeLiteVersion: event.runeLiteVersion.toString(),
+      } as StageStreamMetadata;
   }
+
+  const _exhaustive: never = type;
+  throw new Error(`Unknown stage stream type: ${type as unknown as number}`);
 }
 
 /**

--- a/common/index.ts
+++ b/common/index.ts
@@ -247,6 +247,7 @@ export {
   StageStreamType,
   type StageStreamEnd,
   type StageStreamEvents,
+  type StageStreamMetadata,
   type StageUpdate,
   activePlayerKey,
   challengeProcessedStagesKey,

--- a/socket-server/client.ts
+++ b/socket-server/client.ts
@@ -59,6 +59,8 @@ type ActiveChallengeInfo = {
   uuid: string;
   /** Mapping of stage to attempt number. */
   stages: Map<Stage, number | null>;
+  /** Set of stage streams to which the client has written its metadata. */
+  metadataWritten: Set<string>;
 };
 
 export type Session = {
@@ -270,13 +272,11 @@ export default class Client {
     return this.activeChallenge?.uuid ?? null;
   }
 
-  public setActiveChallenge(
-    challengeId: string,
-    stages?: Map<Stage, number | null>,
-  ): void {
+  public setActiveChallenge(challengeId: string): void {
     this.activeChallenge = {
       uuid: challengeId,
-      stages: stages ?? new Map<Stage, number | null>(),
+      stages: new Map<Stage, number | null>(),
+      metadataWritten: new Set<string>(),
     };
     logger.info(
       'client_active_challenge_set',
@@ -313,6 +313,16 @@ export default class Client {
 
   public getStageAttempt(stage: Stage): number | null {
     return this.activeChallenge?.stages.get(stage) ?? null;
+  }
+
+  public hasWrittenMetadata(streamKey: string): boolean {
+    return this.activeChallenge?.metadataWritten.has(streamKey) ?? false;
+  }
+
+  public recordMetadataWritten(streamKey: string): void {
+    if (this.activeChallenge !== null) {
+      this.activeChallenge.metadataWritten.add(streamKey);
+    }
   }
 
   public getLoggedInRsn(): string | null {

--- a/socket-server/remote-challenge-manager.ts
+++ b/socket-server/remote-challenge-manager.ts
@@ -21,6 +21,7 @@ import {
   challengeProcessedStagesKey,
   challengeStreamsSetKey,
   stageAttemptKey,
+  StageStreamMetadata,
 } from '@blert/common';
 import { Event } from '@blert/common/generated/event_pb';
 import { ChallengeEvents } from '@blert/common/generated/challenge_storage_pb';
@@ -76,6 +77,8 @@ export class RemoteChallengeManager extends ChallengeManager {
     stage: Stage,
     recordingType: RecordingType,
   ): Promise<ChallengeStatusResponse> {
+    const versions = client.getPluginVersions();
+
     const res = await this.request('start', '/challenges/new', {
       method: 'POST',
       headers: {
@@ -85,6 +88,8 @@ export class RemoteChallengeManager extends ChallengeManager {
         userId: client.getUserId(),
         clientId: client.getClientId(),
         sessionToken: client.getSessionToken(),
+        pluginVersion: versions.getVersion(),
+        runeLiteVersion: versions.getRuneLiteVersion(),
         type: challengeType,
         mode,
         party,
@@ -334,6 +339,21 @@ export class RemoteChallengeManager extends ChallengeManager {
         return;
       }
 
+      const streamKey = challengeStageStreamKey(challengeId, stage, attempt);
+
+      if (!client.hasWrittenMetadata(streamKey)) {
+        const metadata: StageStreamMetadata = {
+          type: StageStreamType.CLIENT_METADATA,
+          clientId: client.getClientId(),
+          userId: client.getUserId(),
+          pluginVersion: client.getPluginVersions().getVersion(),
+          runeLiteVersion: client.getPluginVersions().getRuneLiteVersion(),
+        };
+        multi.xAdd(streamKey, '*', stageStreamToRecord(metadata));
+        client.recordMetadataWritten(streamKey);
+        hasWrites = true;
+      }
+
       const eventsMessage = new ChallengeEvents();
       eventsMessage.setEventsList(stageEvents);
 
@@ -342,7 +362,6 @@ export class RemoteChallengeManager extends ChallengeManager {
         clientId: client.getClientId(),
         events: eventsMessage.serializeBinary(),
       };
-      const streamKey = challengeStageStreamKey(challengeId, stage, attempt);
       multi.xAdd(streamKey, '*', stageStreamToRecord(eventsStream));
       multi.sAdd(challengeStreamsSetKey(challengeId), streamKey);
       multi.expire(streamKey, RemoteChallengeManager.STAGE_STREAM_TTL_SECONDS);
@@ -360,6 +379,8 @@ export class RemoteChallengeManager extends ChallengeManager {
     recordingType: RecordingType,
   ): Promise<ChallengeStatusResponse | null> {
     try {
+      const versions = client.getPluginVersions();
+
       const res = await this.request(
         'join',
         `/challenges/${challengeId}/join`,
@@ -372,6 +393,8 @@ export class RemoteChallengeManager extends ChallengeManager {
             userId: client.getUserId(),
             clientId: client.getClientId(),
             sessionToken: client.getSessionToken(),
+            pluginVersion: versions.getVersion(),
+            runeLiteVersion: versions.getRuneLiteVersion(),
             recordingType,
           }),
         },


### PR DESCRIPTION
Updates the challenge server's creation and join endpoints to take the client's plugin and RuneLite versions in their payloads and store them in Redis. Adds a new stage stream type for client metadata, emitted once per stream by the socket server, also containing version information. No consumers are added yet.