### PR TITLE
common: Add support for player snapshots

### DIFF
--- a/challenge-server/merging/__tests__/client-events.test.ts
+++ b/challenge-server/merging/__tests__/client-events.test.ts
@@ -2,6 +2,7 @@ import {
   ChallengeMode,
   ChallengeType,
   DataSource,
+  EquipmentSlot,
   EventType,
   ItemDelta,
   Stage,
@@ -261,6 +262,45 @@ describe('ClientEvents', () => {
       });
       const tick1State = client.getTickState(1)?.getPlayerState('player1');
       expect(tick1State?.equipment[1]).toBeNull();
+    });
+
+    it('rebuilds equipment from empty on a snapshot update', () => {
+      const client = ClientEvents.fromRawEvents(
+        8,
+        challengeInfo,
+        {
+          stage: Stage.TOB_MAIDEN,
+          status: StageStatus.STARTED,
+          accurate: true,
+          recordedTicks: 2,
+          serverTicks: null,
+        },
+        [
+          createPlayerUpdateEvent({
+            tick: 0,
+            name: 'player1',
+            source: DataSource.PRIMARY,
+            equipmentDeltas: [
+              new ItemDelta(11840, 1, EquipmentSlot.WEAPON, true),
+            ],
+          }),
+          createPlayerUpdateEvent({
+            tick: 1,
+            name: 'player1',
+            source: DataSource.PRIMARY,
+            snapshot: true,
+            equipmentDeltas: [new ItemDelta(6570, 1, EquipmentSlot.CAPE, true)],
+          }),
+        ],
+      );
+
+      const tick1State = client.getTickState(1)?.getPlayerState('player1');
+      expect(tick1State?.equipment[EquipmentSlot.CAPE]).toMatchObject({
+        id: 6570,
+        quantity: 1,
+      });
+      // The snapshot rebuilds from empty, dropping the tick 0 weapon.
+      expect(tick1State?.equipment[EquipmentSlot.WEAPON]).toBeNull();
     });
   });
 });

--- a/challenge-server/merging/__tests__/fixtures.ts
+++ b/challenge-server/merging/__tests__/fixtures.ts
@@ -100,6 +100,7 @@ export function createPlayerUpdateEvent({
   x = 0,
   y = 0,
   equipmentDeltas = [],
+  snapshot = false,
   stage = Stage.TOB_MAIDEN,
 }: {
   tick: number;
@@ -108,6 +109,7 @@ export function createPlayerUpdateEvent({
   x?: number;
   y?: number;
   equipmentDeltas?: ItemDelta[];
+  snapshot?: boolean;
   stage?: Stage;
 }): ProtoEvent {
   const event = new ProtoEvent();
@@ -121,6 +123,7 @@ export function createPlayerUpdateEvent({
   player.setName(name);
   player.setDataSource(source as ProtoDataSource);
   player.setEquipmentDeltasList(equipmentDeltas.map((delta) => delta.toRaw()));
+  player.setSnapshot(snapshot);
   event.setPlayer(player);
 
   return event;

--- a/challenge-server/merging/client-events.ts
+++ b/challenge-server/merging/client-events.ts
@@ -1,8 +1,8 @@
 import {
+  applyItemDeltas,
   ClientStageStream,
   DataSource,
   EquipmentSlot,
-  ItemDelta,
   PrayerBook,
   PrayerSet,
   Stage,
@@ -21,6 +21,21 @@ import {
 import { ChallengeInfo } from './context';
 import logger from '../log';
 import { PlayerState, TickState, TickStateArray } from './tick-state';
+
+const EMPTY_EQUIPMENT: PlayerState['equipment'] = {
+  [EquipmentSlot.HEAD]: null,
+  [EquipmentSlot.CAPE]: null,
+  [EquipmentSlot.AMULET]: null,
+  [EquipmentSlot.AMMO]: null,
+  [EquipmentSlot.WEAPON]: null,
+  [EquipmentSlot.TORSO]: null,
+  [EquipmentSlot.SHIELD]: null,
+  [EquipmentSlot.LEGS]: null,
+  [EquipmentSlot.GLOVES]: null,
+  [EquipmentSlot.BOOTS]: null,
+  [EquipmentSlot.RING]: null,
+  [EquipmentSlot.QUIVER]: null,
+};
 
 export const enum ClientAnomaly {
   MULTIPLE_PRIMARY_PLAYERS = 'MULTIPLE_PRIMARY_PLAYERS',
@@ -457,20 +472,7 @@ export class ClientEvents {
           isDead,
           equipment: lastState?.equipment
             ? { ...lastState.equipment }
-            : {
-                [EquipmentSlot.HEAD]: null,
-                [EquipmentSlot.CAPE]: null,
-                [EquipmentSlot.AMULET]: null,
-                [EquipmentSlot.AMMO]: null,
-                [EquipmentSlot.WEAPON]: null,
-                [EquipmentSlot.TORSO]: null,
-                [EquipmentSlot.SHIELD]: null,
-                [EquipmentSlot.LEGS]: null,
-                [EquipmentSlot.GLOVES]: null,
-                [EquipmentSlot.BOOTS]: null,
-                [EquipmentSlot.RING]: null,
-                [EquipmentSlot.QUIVER]: null,
-              },
+            : { ...EMPTY_EQUIPMENT },
           attack: null,
           prayers: PrayerSet.empty(PrayerBook.NORMAL),
         };
@@ -485,37 +487,15 @@ export class ClientEvents {
               state.y = event.getYCoord();
               state.prayers = PrayerSet.fromRaw(player.getActivePrayers());
 
-              player.getEquipmentDeltasList().forEach((rawDelta) => {
-                const delta = ItemDelta.fromRaw(rawDelta);
-                const previous = state.equipment[delta.getSlot()];
-
-                if (delta.isAdded()) {
-                  if (previous?.id !== delta.getItemId()) {
-                    state.equipment[delta.getSlot()] = {
-                      id: delta.getItemId(),
-                      quantity: delta.getQuantity(),
-                    };
-                  } else {
-                    state.equipment[delta.getSlot()] = {
-                      id: delta.getItemId(),
-                      quantity: previous.quantity + delta.getQuantity(),
-                    };
-                  }
-                } else {
-                  if (previous !== null && previous.id === delta.getItemId()) {
-                    if (delta.getQuantity() < previous.quantity) {
-                      state.equipment[delta.getSlot()] = {
-                        id: delta.getItemId(),
-                        quantity: previous.quantity - delta.getQuantity(),
-                      };
-                    } else {
-                      state.equipment[delta.getSlot()] = null;
-                    }
-                  } else {
-                    state.equipment[delta.getSlot()] = null;
-                  }
-                }
-              });
+              // A snapshot carries the player's full equipment, so reconstruct
+              // from an empty container rather than the previous tick's state.
+              state.equipment = {
+                ...EMPTY_EQUIPMENT,
+                ...applyItemDeltas(
+                  player.getEquipmentDeltasList(),
+                  player.getSnapshot() ? null : state.equipment,
+                ),
+              };
               break;
             }
 

--- a/challenge-server/merging/tick-state.ts
+++ b/challenge-server/merging/tick-state.ts
@@ -366,6 +366,7 @@ export class TickState {
     }
 
     updateEvent.getPlayer()!.setEquipmentDeltasList(newDeltas);
+    updateEvent.getPlayer()!.setSnapshot(false);
   }
 
   /**

--- a/common/__tests__/item-delta.test.ts
+++ b/common/__tests__/item-delta.test.ts
@@ -1,0 +1,100 @@
+import { ItemDelta, ItemStack, applyItemDeltas } from '../item-delta';
+
+function deltas(
+  ...entries: [id: number, quantity: number, slot: number, added: boolean][]
+): number[] {
+  return entries.map(([id, quantity, slot, added]) =>
+    new ItemDelta(id, quantity, slot, added).toRaw(),
+  );
+}
+
+describe('applyItemDeltas', () => {
+  it('builds a container from scratch when previous is null', () => {
+    const result = applyItemDeltas(
+      deltas([100, 1, 0, true], [200, 1, 4, true]),
+      null,
+    );
+    expect(result).toEqual({
+      0: { id: 100, quantity: 1 },
+      4: { id: 200, quantity: 1 },
+    });
+  });
+
+  it('carries unchanged slots forward and adds new ones', () => {
+    const result = applyItemDeltas(deltas([200, 1, 4, true]), {
+      0: { id: 100, quantity: 1 },
+    });
+    expect(result).toEqual({
+      0: { id: 100, quantity: 1 },
+      4: { id: 200, quantity: 1 },
+    });
+  });
+
+  it('increments the quantity when the same item is added to a slot', () => {
+    const result = applyItemDeltas(deltas([50, 3, 3, true]), {
+      3: { id: 50, quantity: 5 },
+    });
+    expect(result).toEqual({ 3: { id: 50, quantity: 8 } });
+  });
+
+  it('replaces the slot when a different item is added', () => {
+    const result = applyItemDeltas(deltas([200, 1, 4, true]), {
+      4: { id: 100, quantity: 1 },
+    });
+    expect(result).toEqual({ 4: { id: 200, quantity: 1 } });
+  });
+
+  it('reduces the quantity on a partial removal', () => {
+    const result = applyItemDeltas(deltas([50, 2, 3, false]), {
+      3: { id: 50, quantity: 5 },
+    });
+    expect(result).toEqual({ 3: { id: 50, quantity: 3 } });
+  });
+
+  it('clears the slot when the full quantity is removed', () => {
+    const result = applyItemDeltas(deltas([100, 1, 0, false]), {
+      0: { id: 100, quantity: 1 },
+    });
+    expect(result).toEqual({});
+    expect(0 in result).toBe(false);
+  });
+
+  it('clears the slot when a removal targets a different item id', () => {
+    const result = applyItemDeltas(deltas([999, 1, 0, false]), {
+      0: { id: 100, quantity: 1 },
+    });
+    expect(result).toEqual({});
+  });
+
+  it('treats null and absent slots in previous as empty', () => {
+    const result = applyItemDeltas(deltas([100, 1, 0, true]), {
+      0: null,
+      4: { id: 200, quantity: 1 },
+    });
+    expect(result).toEqual({
+      0: { id: 100, quantity: 1 },
+      4: { id: 200, quantity: 1 },
+    });
+  });
+
+  it('does not mutate the previous container', () => {
+    const previous: Record<number, ItemStack | null> = {
+      0: { id: 100, quantity: 1 },
+      3: { id: 50, quantity: 5 },
+    };
+    applyItemDeltas(deltas([50, 2, 3, false], [200, 1, 4, true]), previous);
+    expect(previous).toEqual({
+      0: { id: 100, quantity: 1 },
+      3: { id: 50, quantity: 5 },
+    });
+  });
+
+  it('uses the item factory to enrich items', () => {
+    const result = applyItemDeltas(
+      deltas([100, 2, 0, true]),
+      null,
+      (id, quantity) => ({ id, quantity, name: `item-${id}` }),
+    );
+    expect(result).toEqual({ 0: { id: 100, quantity: 2, name: 'item-100' } });
+  });
+});

--- a/common/__tests__/json-converter.test.ts
+++ b/common/__tests__/json-converter.test.ts
@@ -107,6 +107,7 @@ describe('jsonToServerMessage', () => {
               activePrayers: 262144,
               dataSource: 1,
               partyIndex: 0,
+              snapshot: true,
             },
           },
         ],
@@ -127,6 +128,7 @@ describe('jsonToServerMessage', () => {
       expect(player?.getHitpoints()).toBe(200674294);
       expect(player?.getActivePrayers()).toBe(262144);
       expect(player?.getEquipmentDeltasList()).toEqual([1234, 5678]);
+      expect(player?.getSnapshot()).toBe(true);
     });
 
     it('converts an NPC_SPAWN event with basic NPC', () => {

--- a/common/__tests__/proto-converter.test.ts
+++ b/common/__tests__/proto-converter.test.ts
@@ -90,6 +90,7 @@ describe('protoToJsonEvent', () => {
       player.setRanged(99);
       player.setMagic(99);
       player.setEquipmentDeltasList([1234, 5678]);
+      player.setSnapshot(true);
       evt.setPlayer(player);
 
       const result = protoToJsonEvent(evt) as PlayerUpdateEvent;
@@ -103,6 +104,7 @@ describe('protoToJsonEvent', () => {
       expect(result.player.attack).toBe(99);
       expect(result.player.defence).toBe(99);
       expect(result.player.equipmentDeltas).toEqual([1234, 5678]);
+      expect(result.player.snapshot).toBe(true);
     });
 
     it('omits optional stats when not set', () => {
@@ -115,6 +117,7 @@ describe('protoToJsonEvent', () => {
       expect(result.player.hitpoints).toBeUndefined();
       expect(result.player.prayer).toBeUndefined();
       expect(result.player.equipmentDeltas).toBeUndefined();
+      expect(result.player.snapshot).toBeUndefined();
     });
 
     it('converts PLAYER_ATTACK with weapon and target', () => {

--- a/common/event.ts
+++ b/common/event.ts
@@ -438,6 +438,11 @@ export interface Player extends BasicPlayer {
   magic?: RawSkillLevel;
   prayerSet: RawPrayerSet;
   equipmentDeltas?: RawItemDelta[];
+  /**
+   * If true, this event carries the player's complete state. Delta-based fields
+   * should be applied as if the previous state was null.
+   */
+  snapshot?: boolean;
 }
 
 export type Item = {

--- a/common/index.ts
+++ b/common/index.ts
@@ -166,8 +166,12 @@ export {
   isTobStage,
 } from './challenge';
 
-export { ItemDelta } from './item-delta';
-export type { RawItemDelta } from './item-delta';
+export {
+  ItemDelta,
+  type ItemStack,
+  applyItemDeltas,
+  type RawItemDelta,
+} from './item-delta';
 
 export { Prayer, PrayerBook, PrayerSet } from './prayer-set';
 export type { RawPrayerSet } from './prayer-set';

--- a/common/item-delta.ts
+++ b/common/item-delta.ts
@@ -68,3 +68,89 @@ export class ItemDelta {
     return Number(raw);
   }
 }
+
+/** An item occupying a single container slot. */
+export type ItemStack = { id: number; quantity: number };
+
+/**
+ * Applies a list of raw item deltas on top of a previous container and returns
+ * the resulting container.
+ *
+ * Containers are sparse maps of slot keys to items, with either `null` or a
+ * nonexistent entry representing an empty slot.
+ *
+ * @param deltas The list of item deltas to apply.
+ * @param previous The previous container to start from, or `null` to start from
+ *   an empty container.
+ * @returns The resulting container.
+ */
+export function applyItemDeltas(
+  deltas: RawItemDelta[],
+  previous: Record<number, ItemStack | null> | null,
+): Record<number, ItemStack>;
+
+/**
+ * Applies a list of raw item deltas on top of a previous container and returns
+ * the resulting container.
+ *
+ * Containers are sparse maps of slot keys to items, with either `null` or a
+ * nonexistent entry representing an empty slot.
+ *
+ * @param deltas The list of item deltas to apply.
+ * @param previous The previous container to start from, or `null` to start from
+ *   an empty container.
+ * @param createItem Function to create an item object from an ID and quantity.
+ * @returns The resulting container.
+ */
+export function applyItemDeltas<T extends ItemStack>(
+  deltas: RawItemDelta[],
+  previous: Record<number, T | null> | null,
+  createItem: (id: number, quantity: number) => T,
+): Record<number, T>;
+
+export function applyItemDeltas<T extends ItemStack>(
+  deltas: RawItemDelta[],
+  previous: Record<number, T | null> | null,
+  createItem: (id: number, quantity: number) => T = (id, quantity) =>
+    ({ id, quantity }) as T,
+): Record<number, T> {
+  const container: Record<number, T> = {};
+  if (previous !== null) {
+    for (const key of Object.keys(previous)) {
+      const item = previous[Number(key)];
+      if (item !== null) {
+        container[Number(key)] = item;
+      }
+    }
+  }
+
+  for (const raw of deltas) {
+    const delta = ItemDelta.fromRaw(raw);
+    const slot = delta.getSlot();
+    const current = container[slot] ?? null;
+
+    if (delta.isAdded()) {
+      if (current?.id !== delta.getItemId()) {
+        container[slot] = createItem(delta.getItemId(), delta.getQuantity());
+      } else {
+        container[slot] = createItem(
+          delta.getItemId(),
+          current.quantity + delta.getQuantity(),
+        );
+      }
+    } else if (
+      current !== null &&
+      current.id === delta.getItemId() &&
+      delta.getQuantity() < current.quantity
+    ) {
+      container[slot] = createItem(
+        delta.getItemId(),
+        current.quantity - delta.getQuantity(),
+      );
+    } else {
+      delete container[slot];
+    }
+  }
+
+  return container;
+}

--- a/common/protocol/json-converter.ts
+++ b/common/protocol/json-converter.ts
@@ -281,6 +281,9 @@ export function jsonToProtoEvent(json: EventJson): Event {
     if (json.player.partyIndex !== undefined) {
       player.setPartyIndex(json.player.partyIndex);
     }
+    if (json.player.snapshot !== undefined) {
+      player.setSnapshot(json.player.snapshot);
+    }
     event.setPlayer(player);
   }
 

--- a/common/protocol/json-schemas.ts
+++ b/common/protocol/json-schemas.ts
@@ -194,6 +194,7 @@ export const playerSchema = z.object({
   activePrayers: z.number().int().optional(),
   dataSource: enumValueSchema.optional(),
   partyIndex: z.number().int().optional(),
+  snapshot: z.boolean().optional(),
 });
 
 // Event.Npc.MaidenCrab

--- a/common/protocol/proto-converter.ts
+++ b/common/protocol/proto-converter.ts
@@ -99,6 +99,9 @@ export function protoToJsonEvent(evt: EventProto): Event {
       if (equipmentDeltas.length > 0) {
         e.player.equipmentDeltas = equipmentDeltas;
       }
+      if (player.getSnapshot()) {
+        e.player.snapshot = true;
+      }
       break;
     }
 

--- a/web/app/utils/stage-state/__tests__/player-state.test.ts
+++ b/web/app/utils/stage-state/__tests__/player-state.test.ts
@@ -1,6 +1,8 @@
 import {
   DataSource,
+  EquipmentSlot,
   EventType,
+  ItemDelta,
   PlayerAttackEvent,
   PlayerDeathEvent,
   PlayerUpdateEvent,
@@ -10,6 +12,7 @@ import {
 
 import { buildEventMaps } from '../event-maps';
 import { PlayerStateBuilder, computePlayerState } from '../player-state';
+import { PlayerEquipment } from '../types';
 
 function playerUpdate(
   tick: number,
@@ -56,6 +59,13 @@ function playerAttack(tick: number, name: string): PlayerAttackEvent {
     },
     attack: { type: 1, distanceToTarget: 0 },
   };
+}
+
+/** Returns the slot keys holding an item, in ascending order. */
+function occupiedSlots(equipment: PlayerEquipment): number[] {
+  return Object.keys(equipment)
+    .map(Number)
+    .filter((slot) => equipment[slot as EquipmentSlot] !== null);
 }
 
 describe('computePlayerState', () => {
@@ -114,6 +124,54 @@ describe('computePlayerState', () => {
 
     expect(state[0]!.skills[Skill.HITPOINTS]?.getCurrent()).toBe(99);
     expect(state[0]!.skills[Skill.HITPOINTS]?.getBase()).toBe(99);
+  });
+
+  it('reconstructs equipment, rebuilding from empty on a snapshot', () => {
+    const added = (id: number, slot: EquipmentSlot) =>
+      new ItemDelta(id, 1, slot, true).toRaw();
+
+    const events = [
+      playerUpdate(0, 'Alice', {
+        equipmentDeltas: [
+          added(1234, EquipmentSlot.WEAPON),
+          added(5678, EquipmentSlot.RING),
+        ],
+      }),
+      playerUpdate(2, 'Alice', {
+        equipmentDeltas: [added(9012, EquipmentSlot.CAPE)],
+      }),
+      playerUpdate(4, 'Alice', {
+        equipmentDeltas: [added(3456, EquipmentSlot.BOOTS)],
+        snapshot: true,
+      }),
+    ];
+    const [byTick, byType] = buildEventMaps(events);
+    const state = computePlayerState(['Alice'], 5, byTick, byType).get(
+      'Alice',
+    )!;
+
+    expect(occupiedSlots(state[0]!.equipment)).toEqual([
+      EquipmentSlot.WEAPON,
+      EquipmentSlot.RING,
+    ]);
+    expect(state[0]!.equipment[EquipmentSlot.WEAPON]).toMatchObject({
+      id: 1234,
+      quantity: 1,
+    });
+
+    // A non-snapshot update carries the prior tick's equipment forward.
+    expect(occupiedSlots(state[2]!.equipment)).toEqual([
+      EquipmentSlot.CAPE,
+      EquipmentSlot.WEAPON,
+      EquipmentSlot.RING,
+    ]);
+
+    // A snapshot rebuilds from empty.
+    expect(occupiedSlots(state[4]!.equipment)).toEqual([EquipmentSlot.BOOTS]);
+    expect(state[4]!.equipment[EquipmentSlot.BOOTS]).toMatchObject({
+      id: 3456,
+      quantity: 1,
+    });
   });
 
   it('handles multiple players independently', () => {

--- a/web/app/utils/stage-state/player-state.ts
+++ b/web/app/utils/stage-state/player-state.ts
@@ -3,12 +3,11 @@ import {
   EquipmentSlot,
   Event,
   EventType,
-  ItemDelta,
-  RawItemDelta,
   Skill,
   SkillLevel,
   VerzikDawnEvent,
   VerzikHealEvent,
+  applyItemDeltas,
   isPlayerEvent,
 } from '@blert/common';
 
@@ -45,45 +44,6 @@ export type PlayerCursor = {
 
 function eventBelongsToPlayer(event: Event, playerName: string): boolean {
   return isPlayerEvent(event) && event.player.name === playerName;
-}
-
-function applyItemDeltas(
-  equipment: PlayerEquipment,
-  rawDeltas: RawItemDelta[],
-): void {
-  for (const rawDelta of rawDeltas) {
-    const delta = ItemDelta.fromRaw(rawDelta);
-    const previousItem = equipment[delta.getSlot()];
-
-    if (delta.isAdded()) {
-      if (previousItem?.id !== delta.getItemId()) {
-        const itemName = simpleItemCache.getItemName(delta.getItemId());
-        equipment[delta.getSlot()] = {
-          id: delta.getItemId(),
-          name: itemName,
-          quantity: delta.getQuantity(),
-        };
-      } else {
-        equipment[delta.getSlot()] = {
-          id: previousItem.id,
-          name: previousItem.name,
-          quantity: previousItem.quantity + delta.getQuantity(),
-        };
-      }
-    } else {
-      if (
-        previousItem !== null &&
-        previousItem.quantity - delta.getQuantity() > 0
-      ) {
-        equipment[delta.getSlot()] = {
-          ...previousItem,
-          quantity: previousItem.quantity - delta.getQuantity(),
-        };
-      } else {
-        equipment[delta.getSlot()] = null;
-      }
-    }
-  }
 }
 
 /**
@@ -139,11 +99,19 @@ function processPlayerTick(
       } else if (event.type === EventType.PLAYER_UPDATE) {
         const { type: _type, stage: _stage, ...rest } = event;
 
-        if (rest.player.equipmentDeltas) {
-          applyItemDeltas(
-            playerStateThisTick!.equipment,
-            rest.player.equipmentDeltas,
+        if (rest.player.snapshot || rest.player.equipmentDeltas) {
+          // A snapshot carries the player's full equipment, so reconstruct from
+          // an empty container rather than the previous tick's state.
+          const equipment = applyItemDeltas(
+            rest.player.equipmentDeltas ?? [],
+            rest.player.snapshot ? null : playerStateThisTick!.equipment,
+            (id, quantity) => ({
+              id,
+              quantity,
+              name: simpleItemCache.getItemName(id),
+            }),
           );
+          playerStateThisTick!.equipment = { ...EMPTY_EQUIPMENT, ...equipment };
         }
 
         if (rest.player.attack !== undefined) {


### PR DESCRIPTION
Defines a new snapshot flag in player updates, which allows plugins to send the full state of a player. When set, instead of applying deltas incrementally, the deltas represent the full state, applied as if the previous state was null.

Consolidates item delta application into a shared helper in common, replacing the parallel implementations in the web and challenge servers.