### PR TITLE
common: Standardize RSN validation

### DIFF
--- a/challenge-server/players.ts
+++ b/challenge-server/players.ts
@@ -4,6 +4,7 @@ import {
   camelToSnakeObject,
   CamelToSnakeCase,
   camelToSnake,
+  isValidRsn,
   normalizeRsn,
 } from '@blert/common';
 
@@ -13,8 +14,6 @@ import { startOfDateUtc } from './time';
 export type ModifiablePlayerStats = Omit<PlayerStats, 'date' | 'playerId'>;
 
 export class Players {
-  private static readonly USERNAME_REGEX = /^[a-zA-Z0-9 _-]{1,12}$/;
-
   public static async lookupUsername(id: number): Promise<string | null> {
     const [player] = await sql<
       [{ username: string }?]
@@ -72,7 +71,7 @@ export class Players {
       fields = camelToSnakeObject(initialFields);
     }
 
-    if (!Players.USERNAME_REGEX.test(username)) {
+    if (!isValidRsn(username)) {
       throw new Error(`Invalid RuneScape username: ${username}`);
     }
 

--- a/common/__tests__/player.test.ts
+++ b/common/__tests__/player.test.ts
@@ -1,4 +1,4 @@
-import { normalizeRsn } from '../player';
+import { isValidRsn, normalizeRsn } from '../player';
 
 describe('normalizeRsn', () => {
   it('should lowercase the name', () => {
@@ -42,5 +42,52 @@ describe('normalizeRsn', () => {
 
   it('should handle names with numbers', () => {
     expect(normalizeRsn('Player 123')).toBe('player_123');
+  });
+});
+
+describe('isValidRsn', () => {
+  it('accepts legacy single-character names', () => {
+    expect(isValidRsn('a')).toBe(true);
+    expect(isValidRsn('1')).toBe(true);
+  });
+
+  it('accepts interior spaces, hyphens, and underscores', () => {
+    expect(isValidRsn('a b')).toBe(true);
+    expect(isValidRsn('x_y-z')).toBe(true);
+    expect(isValidRsn('a b c')).toBe(true);
+    expect(isValidRsn('u  W  u')).toBe(true);
+  });
+
+  it('accepts consecutive interior separators', () => {
+    expect(isValidRsn('a  b')).toBe(true);
+    expect(isValidRsn('a _-b')).toBe(true);
+  });
+
+  it('accepts legacy leading and trailing separators', () => {
+    expect(isValidRsn('-Spooky')).toBe(true);
+    expect(isValidRsn('Spooky-')).toBe(true);
+    expect(isValidRsn('_x')).toBe(true);
+  });
+
+  it('rejects leading or trailing spaces', () => {
+    expect(isValidRsn(' a')).toBe(false);
+    expect(isValidRsn('a ')).toBe(false);
+  });
+
+  it('accepts names up to 12 characters', () => {
+    const hex = '0123456789abcdef';
+    for (let i = 1; i < hex.length; i++) {
+      const name = hex.slice(0, i);
+      const allowed = i <= 12;
+      expect(isValidRsn(name)).toBe(allowed);
+    }
+  });
+
+  it('rejects an empty name', () => {
+    expect(isValidRsn('')).toBe(false);
+  });
+
+  it('rejects disallowed characters', () => {
+    expect(isValidRsn('a@b')).toBe(false);
   });
 });

--- a/common/index.ts
+++ b/common/index.ts
@@ -9,6 +9,7 @@ export {
   type PlayerExperience,
   HiscoresRateLimitError,
   hiscoreLookup,
+  isValidRsn,
   normalizeRsn,
 } from './player';
 export {

--- a/common/player.ts
+++ b/common/player.ts
@@ -11,6 +11,21 @@ export function normalizeRsn(name: string): string {
   return name.toLowerCase().replaceAll(/[- ]/g, '_');
 }
 
+// Prior to 2020-09-07, RSNs could have leading hyphens/underscores:
+// https://secure.runescape.com/m=news/this-week-in-runescape---070920#patch-notes
+// These names are grandfathered in and must still be accepted.
+const RSN_REGEX = /^[a-zA-Z0-9_-]([a-zA-Z0-9 _-]{0,10}[a-zA-Z0-9_-])?$/;
+
+/**
+ * Whether a string is a syntactically valid OSRS username.
+ *
+ * @param name The candidate RSN.
+ * @returns True if the name is a valid RSN.
+ */
+export function isValidRsn(name: string): boolean {
+  return RSN_REGEX.test(name);
+}
+
 export type Player = {
   username: string;
   normalizedUsername: string;

--- a/web/app/actions/change-name.ts
+++ b/web/app/actions/change-name.ts
@@ -1,14 +1,17 @@
 'use server';
 
-import { NameChange, NameChangeStatus, normalizeRsn } from '@blert/common';
+import {
+  NameChange,
+  NameChangeStatus,
+  isValidRsn,
+  normalizeRsn,
+} from '@blert/common';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { sql } from './db';
 import processor from './name-change-processor';
 import { getSignedInUserId } from './users';
-
-const RSN_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9 _-]{0,11}$/;
 
 export async function submitNameChangeForm(
   _state: string | null,
@@ -17,10 +20,10 @@ export async function submitNameChangeForm(
   const oldName = formData.get('blert-old-name') as string;
   const newName = formData.get('blert-new-name') as string;
 
-  if (!RSN_REGEX.test(oldName)) {
+  if (!isValidRsn(oldName)) {
     return 'Invalid old name';
   }
-  if (!RSN_REGEX.test(newName)) {
+  if (!isValidRsn(newName)) {
     return 'Invalid new name';
   }
 


### PR DESCRIPTION
Consolidates two separate RSN validation regexes into a single function in common, improving it to handle legacy RSNs.