### PR TITLE
challenge: Use trust prefixes in challenge processing

### DIFF
--- a/challenge-server/event-processing/challenge-processor.ts
+++ b/challenge-server/event-processing/challenge-processor.ts
@@ -167,7 +167,14 @@ export default abstract class ChallengeProcessor {
   private reportedTimes: ReportedTimes | null;
   private partyChangedMidChallenge: boolean;
 
-  private splits: Map<SplitType, { ticks: number; accurate?: boolean }>;
+  private stageSplits: Map<
+    SplitType,
+    { tick: number; start: number; requiresCompletion: boolean }
+  >;
+  private challengeSplits: Map<
+    SplitType,
+    { ticks: number; accurate?: boolean }
+  >;
   private stageState: StageState;
 
   private pendingUpdates: {
@@ -333,7 +340,8 @@ export default abstract class ChallengeProcessor {
   public async finish(finishTime: Date): Promise<boolean> {
     await this.loadIds();
 
-    this.splits.clear();
+    this.stageSplits.clear();
+    this.challengeSplits.clear();
     this.stageState = this.initialStageState();
 
     if (this.totalChallengeTicks === 0) {
@@ -439,7 +447,8 @@ export default abstract class ChallengeProcessor {
   ): Promise<Partial<ModifiableChallengeFields & CustomData>> {
     await this.loadIds();
 
-    this.splits.clear();
+    this.stageSplits.clear();
+    this.challengeSplits.clear();
     this.stageState = this.initialStageState();
 
     for (const event of events) {
@@ -479,19 +488,29 @@ export default abstract class ChallengeProcessor {
       this.challengeStatus = ChallengeStatus.WIPED;
     }
 
-    const accurate = !this.partyChangedMidChallenge && events.isAccurate();
+    if (this.partyChangedMidChallenge) {
+      events.restrictAccuracyTo(0);
+    }
 
-    await this.onStageFinished(stage, events, accurate);
+    await this.onStageFinished(stage, events);
 
     await Promise.all([
       this.addStageDeaths(),
-      this.writeStageEvents(stage, this.stageState.eventsToWrite, accurate),
+      this.writeStageEvents(
+        stage,
+        this.stageState.eventsToWrite,
+        events.queryableUntil(),
+      ),
     ]);
 
-    const stageSplits = await this.createChallengeSplits(accurate);
-    if (accurate) {
-      await this.updatePersonalBests(stageSplits);
-    }
+    const splits = await Promise.all([
+      this.createStageSplits(
+        events.accurateUntil(),
+        events.getStatus() === StageStatus.COMPLETED,
+      ),
+      this.createChallengeSplits(false),
+    ]);
+    await this.updatePersonalBests(splits.flat());
 
     await this.updateAllPlayersStats();
 
@@ -940,24 +959,53 @@ export default abstract class ChallengeProcessor {
     });
   }
 
-  private async createChallengeSplits(
-    accurate: boolean,
+  private createStageSplits(
+    accurateUntil: number,
+    completed: boolean,
   ): Promise<ChallengeSplitWithId[]> {
-    if (this.splits.size === 0) {
+    const splits = this.stageSplits
+      .entries()
+      .map(([type, { tick, start, requiresCompletion }]) => ({
+        type,
+        ticks: tick - start,
+        accurate: tick < accurateUntil && (!requiresCompletion || completed),
+      }))
+      .toArray();
+
+    return this.insertSplits(splits);
+  }
+
+  private createChallengeSplits(
+    defaultAccurate: boolean,
+  ): Promise<ChallengeSplitWithId[]> {
+    const splits = this.challengeSplits
+      .entries()
+      .map(([type, { ticks, accurate }]) => ({
+        type,
+        ticks,
+        accurate: accurate ?? defaultAccurate,
+      }))
+      .toArray();
+
+    return this.insertSplits(splits);
+  }
+
+  private async insertSplits(
+    splits: Pick<ChallengeSplit, 'type' | 'ticks' | 'accurate'>[],
+  ): Promise<ChallengeSplitWithId[]> {
+    if (splits.length === 0) {
       return [];
     }
 
-    const splitsToInsert: (ChallengeSplit & { challenge_id: number })[] = [];
-
-    this.splits.forEach((entry, split) => {
-      splitsToInsert.push({
-        challenge_id: this.databaseId,
-        type: adjustSplitForMode(split, this.mode),
-        scale: this.getScale(),
-        ticks: entry.ticks,
-        accurate: entry.accurate ?? accurate,
-      });
-    });
+    const splitsToInsert: (CamelToSnakeCase<ChallengeSplit> & {
+      challenge_id: number;
+    })[] = splits.map((split) => ({
+      challenge_id: this.databaseId,
+      type: adjustSplitForMode(split.type, this.mode),
+      scale: this.getScale(),
+      ticks: split.ticks,
+      accurate: split.accurate,
+    }));
 
     try {
       const ids: { id: number }[] = await sql`
@@ -988,18 +1036,20 @@ export default abstract class ChallengeProcessor {
   /**
    * Compares the provided splits to the current personal bests for each player
    * in this challenge, updating the personal bests if the new times are better.
+   * Only splits that are accurate are considered.
    *
-   * @param splits Splits to check.
+   * @param allSplits All splits for the stage.
    */
   protected async updatePersonalBests(
-    splits: ChallengeSplitWithId[],
+    allSplits: ChallengeSplitWithId[],
   ): Promise<void> {
-    if (splits.length === 0) {
+    const accurateSplits = allSplits.filter((s) => s.accurate);
+    if (accurateSplits.length === 0) {
       return;
     }
 
     const playerIds = this.players.map((p) => p.id);
-    const splitTypes = splits.map((s) => s.type);
+    const splitTypes = accurateSplits.map((s) => s.type);
     const scale = this.getScale();
 
     const currentPbs = await sql<
@@ -1055,7 +1105,7 @@ export default abstract class ChallengeProcessor {
       updated: {},
     };
 
-    for (const split of splits) {
+    for (const split of accurateSplits) {
       playerIds.forEach((playerId, i) => {
         const currentPb = pbsByPlayer.get(playerId)!.get(split.type);
         const playerKey = `${this.party[i]}#${playerId}`;
@@ -1146,11 +1196,11 @@ export default abstract class ChallengeProcessor {
   private async writeStageEvents(
     stage: Stage,
     events: Event[],
-    accurate: boolean,
+    queryableUntil: number,
   ): Promise<void> {
     let dbEventsCount = 0;
-    if (accurate) {
-      dbEventsCount = await this.writeQueryableEvents(events);
+    if (queryableUntil > 0) {
+      dbEventsCount = await this.writeQueryableEvents(events, queryableUntil);
       recordQueryableEvents(stage, dbEventsCount);
     }
 
@@ -1170,7 +1220,7 @@ export default abstract class ChallengeProcessor {
         stage,
         totalEvents: events.length,
         queryableEvents: dbEventsCount,
-        accurate,
+        queryableUntil,
       });
     } catch (e) {
       recordRepositoryWrite('challenge', 'stage_events', 'error');
@@ -1249,7 +1299,10 @@ export default abstract class ChallengeProcessor {
     }
   }
 
-  private async writeQueryableEvents(events: Event[]): Promise<number> {
+  private async writeQueryableEvents(
+    events: Event[],
+    queryableUntil: number,
+  ): Promise<number> {
     const queryableEvents: QueryableEventRow[] = [];
 
     const baseQueryableEvent = (event: Event): QueryableEventRow => ({
@@ -1269,7 +1322,8 @@ export default abstract class ChallengeProcessor {
       custom_short_2: null,
     });
 
-    for (const event of events) {
+    const eligibleEvents = events.filter((e) => e.getTick() < queryableUntil);
+    for (const event of eligibleEvents) {
       switch (event.getType()) {
         case Event.Type.PLAYER_ATTACK: {
           const attack = event.getPlayerAttack()!;
@@ -1542,7 +1596,8 @@ export default abstract class ChallengeProcessor {
     this.stageStatus = stageStatus;
     this.party = party;
 
-    this.splits = new Map();
+    this.stageSplits = new Map();
+    this.challengeSplits = new Map();
     this.pendingUpdates = {
       database: {},
       redis: {},
@@ -1579,12 +1634,10 @@ export default abstract class ChallengeProcessor {
    * Invoked after all events have been processed for a stage.
    * @param stage The stage of the events.
    * @param events The events that were processed.
-   * @param accurate Whether the stage data is considered accurate.
    */
   protected abstract onStageFinished(
     stage: Stage,
     events: MergedEvents,
-    accurate: boolean,
   ): Promise<void>;
 
   /**
@@ -1641,14 +1694,46 @@ export default abstract class ChallengeProcessor {
     return this.reportedTimes?.overall ?? 0;
   }
 
-  protected setSplit(type: SplitType, ticks: number, accurate?: boolean): void {
-    if (ticks > 0) {
-      this.splits.set(type, { ticks, accurate });
+  /**
+   * Records a split whose timer is local to the current stage.
+   *
+   * `tick` is the tick at which the split occurred. By default, the split is
+   * counted as ticks elapsed from the start of the stage. This can be
+   * overridden by passing a different `start`.
+   *
+   * `requiresCompletion` indicates whether the split lasts until the end of the
+   * stage. When set, accuracy is contingent on stage completion.
+   */
+  protected setStageSplit(
+    type: SplitType,
+    tick: number,
+    start: number = 0,
+    requiresCompletion: boolean = false,
+  ): void {
+    if (start >= 0 && tick > start) {
+      this.stageSplits.set(type, {
+        tick,
+        start,
+        requiresCompletion,
+      });
     }
   }
 
-  protected getSplit(type: SplitType): number | undefined {
-    return this.splits.get(type)?.ticks;
+  protected getStageSplit(
+    type: SplitType,
+  ): { tick: number; start: number } | undefined {
+    return this.stageSplits.get(type);
+  }
+
+  /** Records a split whose timer is scoped across the entire challenge. */
+  protected setChallengeSplit(
+    type: SplitType,
+    ticks: number,
+    accurate?: boolean,
+  ): void {
+    if (ticks > 0) {
+      this.challengeSplits.set(type, { ticks, accurate });
+    }
   }
 
   protected isPartyUnchanged(): boolean {

--- a/challenge-server/event-processing/colosseum.ts
+++ b/challenge-server/event-processing/colosseum.ts
@@ -80,7 +80,7 @@ export default class ColosseumProcessor extends ChallengeProcessor {
   }
 
   protected override onFinish(finalChallengeTicks: number): Promise<void> {
-    this.setSplit(SplitType.COLOSSEUM_CHALLENGE, finalChallengeTicks);
+    this.setChallengeSplit(SplitType.COLOSSEUM_CHALLENGE, finalChallengeTicks);
 
     for (const username of this.getParty()) {
       const stats = this.getCurrentStageStats(username);
@@ -103,7 +103,6 @@ export default class ColosseumProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
-    _accurate: boolean,
   ): Promise<void> {
     const state = this.getStageState();
 
@@ -115,9 +114,11 @@ export default class ColosseumProcessor extends ChallengeProcessor {
       npcs: Object.fromEntries(state?.npcs ?? []),
     });
 
-    this.setSplit(
+    this.setStageSplit(
       SplitType.COLOSSEUM_WAVE_1 + waveIndex(stage),
       events.getLastTick(),
+      0,
+      true,
     );
 
     if (
@@ -126,7 +127,7 @@ export default class ColosseumProcessor extends ChallengeProcessor {
       stage < Stage.COLOSSEUM_WAVE_12 &&
       this.hasFullyRecordedUpTo(stage)
     ) {
-      this.setSplit(
+      this.setChallengeSplit(
         SplitType.COLOSSEUM_WAVE_3_START + (waveIndex(stage) - 1),
         this.getTotalChallengeTicks(),
         this.isPartyUnchanged() && events.hasPreciseServerTickCount(),

--- a/challenge-server/event-processing/inferno.ts
+++ b/challenge-server/event-processing/inferno.ts
@@ -147,8 +147,8 @@ export default class InfernoProcessor extends ChallengeProcessor {
   protected override async onFinish(
     finalChallengeTicks: number,
   ): Promise<void> {
-    this.setSplit(SplitType.INFERNO_CHALLENGE, finalChallengeTicks);
-    this.setSplit(SplitType.INFERNO_OVERALL, finalChallengeTicks);
+    this.setChallengeSplit(SplitType.INFERNO_CHALLENGE, finalChallengeTicks);
+    this.setChallengeSplit(SplitType.INFERNO_OVERALL, finalChallengeTicks);
 
     for (const username of this.getParty()) {
       const stats = this.getCurrentStageStats(username);
@@ -180,7 +180,6 @@ export default class InfernoProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
-    _accurate: boolean,
   ): Promise<void> {
     const wave = stageToWave(stage);
 
@@ -190,7 +189,7 @@ export default class InfernoProcessor extends ChallengeProcessor {
 
       const split = waveToSplit(wave);
       if (split !== null) {
-        this.setSplit(split, this.waveStartTick);
+        this.setChallengeSplit(split, this.waveStartTick);
       }
     } else {
       // The base processor has already included this wave's tick count.
@@ -198,9 +197,11 @@ export default class InfernoProcessor extends ChallengeProcessor {
       this.setTotalChallengeTicks(this.getTotalChallengeTicks() + 6);
     }
 
-    this.setSplit(
+    this.setStageSplit(
       SplitType.INFERNO_WAVE_1_TIME + (wave - 1),
       events.getLastTick(),
+      0,
+      true,
     );
 
     const state = this.getStageState();

--- a/challenge-server/event-processing/mokhaiotl.ts
+++ b/challenge-server/event-processing/mokhaiotl.ts
@@ -88,7 +88,7 @@ export default class MokhaiotlProcessor extends ChallengeProcessor {
   }
 
   protected override onFinish(finalChallengeTicks: number): Promise<void> {
-    this.setSplit(SplitType.MOKHAIOTL_CHALLENGE, finalChallengeTicks);
+    this.setChallengeSplit(SplitType.MOKHAIOTL_CHALLENGE, finalChallengeTicks);
 
     for (const username of this.getParty()) {
       const stats = this.getCurrentStageStats(username);
@@ -111,14 +111,18 @@ export default class MokhaiotlProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
-    _accurate: boolean,
   ): Promise<void> {
     if (stage !== Stage.MOKHAIOTL_DELVE_8PLUS) {
       if (stage === Stage.MOKHAIOTL_DELVE_8) {
         this.delve1To8Ticks = this.getTotalChallengeTicks();
       }
       const index = stage - Stage.MOKHAIOTL_DELVE_1;
-      this.setSplit(SplitType.MOKHAIOTL_DELVE_1 + index, events.getLastTick());
+      this.setStageSplit(
+        SplitType.MOKHAIOTL_DELVE_1 + index,
+        events.getLastTick(),
+        0,
+        true,
+      );
 
       if (
         events.getStatus() === StageStatus.COMPLETED &&
@@ -126,7 +130,7 @@ export default class MokhaiotlProcessor extends ChallengeProcessor {
         stage < Stage.MOKHAIOTL_DELVE_8 &&
         this.hasFullyRecordedUpTo(stage)
       ) {
-        this.setSplit(
+        this.setChallengeSplit(
           SplitType.MOKHAIOTL_DELVE_3_START + (index - 1),
           this.getTotalChallengeTicks(),
           this.isPartyUnchanged() && events.hasPreciseServerTickCount(),

--- a/challenge-server/event-processing/theatre.ts
+++ b/challenge-server/event-processing/theatre.ts
@@ -223,8 +223,8 @@ export default class TheatreProcessor extends ChallengeProcessor {
   }
 
   protected override onFinish(finalChallengeTicks: number): Promise<void> {
-    this.setSplit(SplitType.TOB_CHALLENGE, finalChallengeTicks);
-    this.setSplit(SplitType.TOB_OVERALL, this.getOverallTicks());
+    this.setChallengeSplit(SplitType.TOB_CHALLENGE, finalChallengeTicks);
+    this.setChallengeSplit(SplitType.TOB_OVERALL, this.getOverallTicks());
 
     for (const username of this.getParty()) {
       const stats = this.getCurrentStageStats(username);
@@ -247,7 +247,6 @@ export default class TheatreProcessor extends ChallengeProcessor {
   protected override async onStageFinished(
     stage: Stage,
     events: MergedEvents,
-    accurate: boolean,
   ): Promise<void> {
     const stageTicks = events.getLastTick();
     let stageSplit: SplitType;
@@ -263,9 +262,14 @@ export default class TheatreProcessor extends ChallengeProcessor {
     switch (stage) {
       case Stage.TOB_MAIDEN:
         stageSplit = SplitType.TOB_MAIDEN;
-        const thirties = this.getSplit(SplitType.TOB_MAIDEN_30S);
+        const thirties = this.getStageSplit(SplitType.TOB_MAIDEN_30S);
         if (thirties !== undefined) {
-          this.setSplit(SplitType.TOB_MAIDEN_30S_END, stageTicks - thirties);
+          this.setStageSplit(
+            SplitType.TOB_MAIDEN_30S_END,
+            stageTicks,
+            thirties.tick,
+            true,
+          );
         }
         this.rooms.maiden = {
           ...roomData,
@@ -284,8 +288,10 @@ export default class TheatreProcessor extends ChallengeProcessor {
         this.stageStats.bloatDeaths = this.rooms.bloat.deaths.length;
         this.stageStats.bloatDownCount = this.bloatDowns.length;
 
-        const bloatSaves: Promise<void>[] = [this.saveBloatDowns(accurate)];
-        if (accurate) {
+        const bloatSaves: Promise<void>[] = [
+          this.saveBloatDowns(events.accurateUntil()),
+        ];
+        if (events.fullyQueryable()) {
           bloatSaves.push(this.saveBloatHands());
         }
         await Promise.all(bloatSaves);
@@ -294,9 +300,14 @@ export default class TheatreProcessor extends ChallengeProcessor {
 
       case Stage.TOB_NYLOCAS: {
         stageSplit = SplitType.TOB_NYLO_ROOM;
-        const bossSpawn = this.getSplit(SplitType.TOB_NYLO_BOSS_SPAWN);
+        const bossSpawn = this.getStageSplit(SplitType.TOB_NYLO_BOSS_SPAWN);
         if (bossSpawn !== undefined) {
-          this.setSplit(SplitType.TOB_NYLO_BOSS, stageTicks - bossSpawn);
+          this.setStageSplit(
+            SplitType.TOB_NYLO_BOSS,
+            stageTicks,
+            bossSpawn.tick,
+            true,
+          );
         }
         this.rooms.nylocas = {
           ...roomData,
@@ -327,9 +338,11 @@ export default class TheatreProcessor extends ChallengeProcessor {
       case Stage.TOB_SOTETSEG:
         stageSplit = SplitType.TOB_SOTETSEG;
         if (this.soteMazes.length == 2) {
-          this.setSplit(
+          this.setStageSplit(
             SplitType.TOB_SOTETSEG_P3,
-            stageTicks - this.soteMazes[1].endTick,
+            stageTicks,
+            this.soteMazes[1].endTick,
+            true,
           );
         }
         this.rooms.sotetseg = {
@@ -345,9 +358,14 @@ export default class TheatreProcessor extends ChallengeProcessor {
 
       case Stage.TOB_XARPUS:
         stageSplit = SplitType.TOB_XARPUS;
-        const p3Start = this.getSplit(SplitType.TOB_XARPUS_SCREECH);
+        const p3Start = this.getStageSplit(SplitType.TOB_XARPUS_SCREECH);
         if (p3Start !== undefined) {
-          this.setSplit(SplitType.TOB_XARPUS_P3, stageTicks - p3Start);
+          this.setStageSplit(
+            SplitType.TOB_XARPUS_P3,
+            stageTicks,
+            p3Start.tick,
+            true,
+          );
         }
         this.rooms.xarpus = {
           ...roomData,
@@ -359,12 +377,14 @@ export default class TheatreProcessor extends ChallengeProcessor {
 
       case Stage.TOB_VERZIK:
         stageSplit = SplitType.TOB_VERZIK_ROOM;
-        const p2End = this.getSplit(SplitType.TOB_VERZIK_P2_END);
+        const p2End = this.getStageSplit(SplitType.TOB_VERZIK_P2_END);
         if (p2End !== undefined) {
           const P2_TRANSITION_TICKS = 6;
-          this.setSplit(
+          this.setStageSplit(
             SplitType.TOB_VERZIK_P3,
-            stageTicks - (p2End + P2_TRANSITION_TICKS),
+            stageTicks,
+            p2End.tick + P2_TRANSITION_TICKS,
+            true,
           );
         }
         this.rooms.verzik = {
@@ -379,7 +399,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
     await this.updateChallengeStats(this.stageStats);
     this.stageStats = {};
 
-    this.setSplit(stageSplit!, stageTicks);
+    this.setStageSplit(stageSplit!, stageTicks, 0, true);
 
     if (
       events.getStatus() === StageStatus.COMPLETED &&
@@ -387,7 +407,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
     ) {
       const nextEntry = nextStageEntrySplit(stage);
       if (nextEntry !== null) {
-        this.setSplit(
+        this.setChallengeSplit(
           nextEntry,
           this.getTotalChallengeTicks(),
           this.isPartyUnchanged() && events.hasPreciseServerTickCount(),
@@ -544,9 +564,9 @@ export default class TheatreProcessor extends ChallengeProcessor {
       case Event.Type.TOB_NYLO_WAVE_SPAWN:
         const spawnedWave = event.getNyloWave()!.getWave();
         if (spawnedWave === 20) {
-          this.setSplit(SplitType.TOB_NYLO_CAP, event.getTick());
+          this.setStageSplit(SplitType.TOB_NYLO_CAP, event.getTick());
         } else if (spawnedWave === 31) {
-          this.setSplit(SplitType.TOB_NYLO_WAVES, event.getTick());
+          this.setStageSplit(SplitType.TOB_NYLO_WAVES, event.getTick());
         }
         break;
 
@@ -556,24 +576,25 @@ export default class TheatreProcessor extends ChallengeProcessor {
         break;
 
       case Event.Type.TOB_NYLO_CLEANUP_END:
-        this.setSplit(SplitType.TOB_NYLO_CLEANUP, event.getTick());
+        this.setStageSplit(SplitType.TOB_NYLO_CLEANUP, event.getTick());
         break;
 
       case Event.Type.TOB_NYLO_BOSS_SPAWN:
-        this.setSplit(SplitType.TOB_NYLO_BOSS_SPAWN, event.getTick());
+        this.setStageSplit(SplitType.TOB_NYLO_BOSS_SPAWN, event.getTick());
         break;
 
       case Event.Type.TOB_SOTE_MAZE_PROC: {
         const maze = event.getSoteMaze()!.getMaze();
         if (maze === Maze.MAZE_66) {
-          this.setSplit(SplitType.TOB_SOTETSEG_66, event.getTick());
+          this.setStageSplit(SplitType.TOB_SOTETSEG_66, event.getTick());
         } else {
-          this.setSplit(SplitType.TOB_SOTETSEG_33, event.getTick());
+          this.setStageSplit(SplitType.TOB_SOTETSEG_33, event.getTick());
           if (this.soteMazes.length > 0) {
             const maze1End = this.soteMazes[0].endTick;
-            this.setSplit(
+            this.setStageSplit(
               SplitType.TOB_SOTETSEG_P2,
-              event.getTick() - maze1End,
+              event.getTick(),
+              maze1End,
             );
           }
         }
@@ -609,14 +630,16 @@ export default class TheatreProcessor extends ChallengeProcessor {
         }
 
         if (maze === Maze.MAZE_66) {
-          this.setSplit(
+          this.setStageSplit(
             SplitType.TOB_SOTETSEG_MAZE_1,
-            event.getTick() - activeMaze.startTick,
+            event.getTick(),
+            activeMaze.startTick,
           );
         } else {
-          this.setSplit(
+          this.setStageSplit(
             SplitType.TOB_SOTETSEG_MAZE_2,
-            event.getTick() - activeMaze.startTick,
+            event.getTick(),
+            activeMaze.startTick,
           );
         }
         return false;
@@ -634,12 +657,16 @@ export default class TheatreProcessor extends ChallengeProcessor {
       case Event.Type.TOB_XARPUS_PHASE:
         const xarpusPhase = event.getXarpusPhase();
         if (xarpusPhase === XarpusPhase.P2) {
-          this.setSplit(SplitType.TOB_XARPUS_EXHUMES, event.getTick());
+          this.setStageSplit(SplitType.TOB_XARPUS_EXHUMES, event.getTick());
         } else if (xarpusPhase === XarpusPhase.P3) {
-          this.setSplit(SplitType.TOB_XARPUS_SCREECH, event.getTick());
-          const p2Start = this.getSplit(SplitType.TOB_XARPUS_EXHUMES);
+          this.setStageSplit(SplitType.TOB_XARPUS_SCREECH, event.getTick());
+          const p2Start = this.getStageSplit(SplitType.TOB_XARPUS_EXHUMES);
           if (p2Start !== undefined) {
-            this.setSplit(SplitType.TOB_XARPUS_P2, event.getTick() - p2Start);
+            this.setStageSplit(
+              SplitType.TOB_XARPUS_P2,
+              event.getTick(),
+              p2Start.tick,
+            );
           }
         }
         break;
@@ -647,15 +674,16 @@ export default class TheatreProcessor extends ChallengeProcessor {
       case Event.Type.TOB_VERZIK_PHASE:
         const verzikPhase = event.getVerzikPhase();
         if (verzikPhase === VerzikPhase.P2) {
-          this.setSplit(SplitType.TOB_VERZIK_P1_END, event.getTick());
+          this.setStageSplit(SplitType.TOB_VERZIK_P1_END, event.getTick());
         } else if (verzikPhase === VerzikPhase.P3) {
-          this.setSplit(SplitType.TOB_VERZIK_P2_END, event.getTick());
-          const p1End = this.getSplit(SplitType.TOB_VERZIK_P1_END);
+          this.setStageSplit(SplitType.TOB_VERZIK_P2_END, event.getTick());
+          const p1End = this.getStageSplit(SplitType.TOB_VERZIK_P1_END);
           if (p1End !== undefined) {
             const P1_TRANSITION_TICKS = 13;
-            this.setSplit(
+            this.setStageSplit(
               SplitType.TOB_VERZIK_P2,
-              event.getTick() - (p1End + P1_TRANSITION_TICKS),
+              event.getTick(),
+              p1End.tick + P1_TRANSITION_TICKS,
             );
           }
         }
@@ -794,8 +822,8 @@ export default class TheatreProcessor extends ChallengeProcessor {
 
         if (attack.getType() !== PlayerAttack.TONALZTICS_AUTO) {
           const inCleanup =
-            this.getSplit(SplitType.TOB_NYLO_WAVES) !== undefined &&
-            this.getSplit(SplitType.TOB_NYLO_CLEANUP) === undefined;
+            this.getStageSplit(SplitType.TOB_NYLO_WAVES) !== undefined &&
+            this.getStageSplit(SplitType.TOB_NYLO_CLEANUP) === undefined;
 
           if (this.getStage() === Stage.TOB_NYLOCAS && inCleanup) {
             // Ok to overkill a nylo during cleanup.
@@ -895,7 +923,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
     if (Npc.isVerzikMatomenos(npc.getId())) {
       if (this.verzikRedSpawns.length === 0) {
         // First red spawn is recorded as a stage split.
-        this.setSplit(SplitType.TOB_VERZIK_REDS, event.getTick());
+        this.setStageSplit(SplitType.TOB_VERZIK_REDS, event.getTick());
         this.verzikRedSpawns.push(event.getTick());
         this.stageStats.verzikRedsCount = 1;
       } else if (
@@ -912,25 +940,27 @@ export default class TheatreProcessor extends ChallengeProcessor {
       // Record Maiden spawns as stage splits.
       switch (npc.getMaidenCrab()!.getSpawn()) {
         case MaidenCrabSpawn.SEVENTIES:
-          this.setSplit(SplitType.TOB_MAIDEN_70S, event.getTick());
+          this.setStageSplit(SplitType.TOB_MAIDEN_70S, event.getTick());
           break;
         case MaidenCrabSpawn.FIFTIES:
-          this.setSplit(SplitType.TOB_MAIDEN_50S, event.getTick());
-          const seventies = this.getSplit(SplitType.TOB_MAIDEN_70S);
+          this.setStageSplit(SplitType.TOB_MAIDEN_50S, event.getTick());
+          const seventies = this.getStageSplit(SplitType.TOB_MAIDEN_70S);
           if (seventies !== undefined) {
-            this.setSplit(
+            this.setStageSplit(
               SplitType.TOB_MAIDEN_70S_50S,
-              event.getTick() - seventies,
+              event.getTick(),
+              seventies.tick,
             );
           }
           break;
         case MaidenCrabSpawn.THIRTIES:
-          this.setSplit(SplitType.TOB_MAIDEN_30S, event.getTick());
-          const fifties = this.getSplit(SplitType.TOB_MAIDEN_50S);
+          this.setStageSplit(SplitType.TOB_MAIDEN_30S, event.getTick());
+          const fifties = this.getStageSplit(SplitType.TOB_MAIDEN_50S);
           if (fifties !== undefined) {
-            this.setSplit(
+            this.setStageSplit(
               SplitType.TOB_MAIDEN_50S_30S,
-              event.getTick() - fifties,
+              event.getTick(),
+              fifties.tick,
             );
           }
           break;
@@ -1083,7 +1113,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
     `;
   }
 
-  private async saveBloatDowns(accurate: boolean): Promise<void> {
+  private async saveBloatDowns(accurateUntil: number): Promise<void> {
     if (this.bloatDowns.length === 0) {
       return;
     }
@@ -1094,7 +1124,7 @@ export default class TheatreProcessor extends ChallengeProcessor {
       down_number: down.downNumber,
       down_tick: down.tick,
       walk_ticks: down.walkTime,
-      accurate,
+      accurate: down.tick < accurateUntil,
     }));
 
     await sql`INSERT INTO bloat_downs ${sql(rows)}`;

--- a/challenge-server/merge-service/service.ts
+++ b/challenge-server/merge-service/service.ts
@@ -216,7 +216,7 @@ export class MergeService {
     recordStageCompletion(
       stage,
       events.getStatus(),
-      events.isAccurate(),
+      events.fullyAccurate(),
       result.unmergedCount > 0,
       result.skippedCount > 0,
     );

--- a/challenge-server/merging/__tests__/merge.test.ts
+++ b/challenge-server/merging/__tests__/merge.test.ts
@@ -322,6 +322,8 @@ describe('Merger', () => {
     const events = result!.events;
     expect(events.accurateUntil()).toBe(0);
     expect(events.queryableUntil()).toBe(0);
+    expect(events.fullyAccurate()).toBe(false);
+    expect(events.fullyQueryable()).toBe(false);
     expect(events.getMissingTickCount()).toBe(0);
     const allEvents = Array.from(events);
     expect(allEvents.length).toBe(client1Events.length);
@@ -365,6 +367,8 @@ describe('Merger', () => {
     const events = result!.events;
     expect(events.accurateUntil()).toBe(3);
     expect(events.queryableUntil()).toBe(3);
+    expect(events.fullyAccurate()).toBe(true);
+    expect(events.fullyQueryable()).toBe(true);
     expect(events.hasPreciseServerTickCount()).toBe(true);
     expect(events.getMissingTickCount()).toBe(0);
     const allEvents = Array.from(events);
@@ -1201,12 +1205,13 @@ describe('MergedEvents', () => {
     expect(restored.getStatus()).toBe(original.getStatus());
     expect(restored.getLastTick()).toBe(original.getLastTick());
     expect(restored.getMissingTickCount()).toBe(original.getMissingTickCount());
-    expect(restored.isAccurate()).toBe(original.isAccurate());
     expect(restored.hasPreciseServerTickCount()).toBe(
       original.hasPreciseServerTickCount(),
     );
     expect(restored.accurateUntil()).toBe(original.accurateUntil());
     expect(restored.queryableUntil()).toBe(original.queryableUntil());
+    expect(restored.fullyAccurate()).toBe(original.fullyAccurate());
+    expect(restored.fullyQueryable()).toBe(original.fullyQueryable());
 
     expect(Array.from(restored).map((e) => e.toObject())).toEqual(
       Array.from(original).map((e) => e.toObject()),
@@ -1217,5 +1222,38 @@ describe('MergedEvents', () => {
         original.eventsForTick(tick).map((e) => e.toObject()),
       );
     }
+  });
+
+  it('restricts accuracy and queryability to the given tick', () => {
+    const client1 = ClientEvents.fromRawEvents(
+      1,
+      fakeChallenge,
+      {
+        stage: Stage.TOB_MAIDEN,
+        status: StageStatus.COMPLETED,
+        accurate: true,
+        recordedTicks: 2,
+        serverTicks: {
+          count: 2,
+          precise: true,
+        },
+      },
+      client1Events,
+    );
+    const merger = new Merger(fakeChallenge, Stage.TOB_MAIDEN, [client1]);
+    const result = merger.merge();
+    expect(result).not.toBeNull();
+
+    const events = result!.events;
+    expect(events.accurateUntil()).toBe(3);
+    expect(events.queryableUntil()).toBe(3);
+    expect(events.fullyAccurate()).toBe(true);
+    expect(events.fullyQueryable()).toBe(true);
+
+    events.restrictAccuracyTo(1);
+    expect(events.accurateUntil()).toBe(1);
+    expect(events.queryableUntil()).toBe(1);
+    expect(events.fullyAccurate()).toBe(false);
+    expect(events.fullyQueryable()).toBe(false);
   });
 });

--- a/challenge-server/merging/merge.ts
+++ b/challenge-server/merging/merge.ts
@@ -434,7 +434,6 @@ export class Merger {
       skippedCount,
       alerts: this.alerts,
       referenceSelection: this.referenceSelection,
-      accurate: mergedEvents.isAccurate(),
       accurateUntil: mergedEvents.accurateUntil(),
       queryableUntil: mergedEvents.queryableUntil(),
     });
@@ -634,11 +633,6 @@ export class MergedEvents {
     return this.metadata.missingTickCount;
   }
 
-  // TODO(frolv): remove
-  public isAccurate(): boolean {
-    return this.metadata.accurateUntil > this.metadata.lastTick;
-  }
-
   public hasPreciseServerTickCount(): boolean {
     return this.metadata.preciseServerTickCount;
   }
@@ -651,12 +645,31 @@ export class MergedEvents {
     return this.metadata.accurateUntil;
   }
 
+  /** Whether accuracy covers the entire stage. */
+  public fullyAccurate(): boolean {
+    return this.metadata.lastTick < this.metadata.accurateUntil;
+  }
+
   /**
    * The exclusive tick at which the merged event stream can no longer be fully
    * corroborated for strict analysis.
    */
   public queryableUntil(): number {
     return this.metadata.queryableUntil;
+  }
+
+  /** Whether queryability covers the entire stage. */
+  public fullyQueryable(): boolean {
+    return this.metadata.lastTick < this.metadata.queryableUntil;
+  }
+
+  /**
+   * Limits the accuracy and queryability of the event stream to the given tick.
+   * @param tick Exclusive tick to which to restrict trust.
+   */
+  public restrictAccuracyTo(tick: number): void {
+    this.metadata.accurateUntil = Math.min(this.metadata.accurateUntil, tick);
+    this.metadata.queryableUntil = Math.min(this.metadata.queryableUntil, tick);
   }
 
   public serialize(): string {
@@ -685,7 +698,7 @@ class MergedTimeline {
   private readonly ctx: MergeContext;
   private readonly reference: ReferenceSelection;
   private readonly preciseServerTickCount: boolean;
-  private accurate: boolean; // TODO(frolv): remove
+  private readonly inheritedAccurate: boolean;
   private trustedPrefixes: TrustedPrefixes | null;
   private finalized: boolean;
   private appliedOffset: number;
@@ -701,7 +714,7 @@ class MergedTimeline {
     this.preciseServerTickCount =
       reference.method === ReferenceSelectionMethod.PRECISE_SERVER ||
       reference.method === ReferenceSelectionMethod.ACCURATE_MODAL;
-    this.accurate = base.isAccurate();
+    this.inheritedAccurate = base.isAccurate();
 
     this.finalized = false;
     this.appliedOffset = 0;
@@ -750,7 +763,7 @@ class MergedTimeline {
     let mappings: Mappings;
     let alignment: AlignmentResult | null = null;
 
-    if (this.accurate && client.isAccurate()) {
+    if (this.inheritedAccurate && client.isAccurate()) {
       // Accurate clients use identity mapping.
       mappings = {
         base: TickMapping.identity(this.ticks.length),
@@ -844,7 +857,7 @@ class MergedTimeline {
     const trustedPrefixes = computeTrustedPrefixes(this.ctx, {
       totalTicks: this.ticks.length,
       offset: this.appliedOffset,
-      inheritedAccuracy: this.accurate,
+      inheritedAccuracy: this.inheritedAccurate,
       referenceMethod: this.reference.method,
     });
     this.trustedPrefixes = trustedPrefixes;

--- a/challenge-server/merging/trusted-prefixes.ts
+++ b/challenge-server/merging/trusted-prefixes.ts
@@ -40,10 +40,10 @@ export function recordContestedTicks(
 /**
  * The two trust prefixes of a finalized merged timeline.
  *
- * `accurateUntil` defines the first tick beyond which the merged timeline can
+ * `accurateUntil` defines the exclusive tick at which the merged timeline can
  * no longer be trusted to match the true server tick count.
  *
- * `queryableUntil` defines the first tick beyond which the merged event stream
+ * `queryableUntil` defines the exclusive tick at which the merged event stream
  * can no longer be trusted for strict analysis.
  */
 export type TrustedPrefixes = {


### PR DESCRIPTION
Updates challenge processors to consume the new trust prefixes when saving stage splits/PBs and queryable events instead of the legacy binary accuracy flag.