### PR TITLE
challenge: Restructure merger options

### DIFF
--- a/challenge-server/api.ts
+++ b/challenge-server/api.ts
@@ -502,7 +502,7 @@ async function mergeTestEvents(req: Request, res: Response): Promise<void> {
     let result;
     try {
       const merger = new Merger(mergeData.challengeInfo, stage, clients);
-      result = merger.merge(tracer, { alignMismatched: true });
+      result = merger.merge({ tracer });
     } catch (e) {
       logger.error('test_merge_error', {
         error: e instanceof Error ? e.message : String(e),

--- a/challenge-server/merge-service/__tests__/service.test.ts
+++ b/challenge-server/merge-service/__tests__/service.test.ts
@@ -100,10 +100,9 @@ describe('MergeService.merge', () => {
       Stage.TOB_MAIDEN,
       stream,
     );
-    const direct = new Merger(challengeInfo, Stage.TOB_MAIDEN, [client]).merge(
-      undefined,
-      { alignMismatched: true },
-    );
+    const direct = new Merger(challengeInfo, Stage.TOB_MAIDEN, [
+      client,
+    ]).merge();
 
     expect(events).not.toBeNull();
     expect(Array.from(events!).map((e) => e.toObject())).toEqual(

--- a/challenge-server/merge-service/__tests__/worker.test.ts
+++ b/challenge-server/merge-service/__tests__/worker.test.ts
@@ -76,10 +76,9 @@ describe('runMergeJob', () => {
       Stage.TOB_MAIDEN,
       stream,
     );
-    const direct = new Merger(challengeInfo, Stage.TOB_MAIDEN, [client]).merge(
-      undefined,
-      { alignMismatched: true },
-    );
+    const direct = new Merger(challengeInfo, Stage.TOB_MAIDEN, [
+      client,
+    ]).merge();
     expect(direct).not.toBeNull();
 
     const reply = runMergeJob(job);

--- a/challenge-server/merge-service/worker.ts
+++ b/challenge-server/merge-service/worker.ts
@@ -62,16 +62,17 @@ export function runMergeJob(job: MergeJob): MergeReply {
         }
 
         const start = process.hrtime.bigint();
-        const result = new Merger(job.challengeInfo, job.stage, clients).merge(
-          undefined,
-          { alignMismatched: true },
-        );
+        const result = new Merger(
+          job.challengeInfo,
+          job.stage,
+          clients,
+        ).merge();
         observeMergeDuration(
           job.stage,
           Number(process.hrtime.bigint() - start) / 1e6,
         );
         if (result === null) {
-          // `clients` is never empty, so a null results can only be due to
+          // `clients` is never empty, so a null result can only be due to
           // every client failing data validation.
           return { kind: 'bad_data' };
         }

--- a/challenge-server/merging/__tests__/integration.test.ts
+++ b/challenge-server/merging/__tests__/integration.test.ts
@@ -80,10 +80,9 @@ function merge(
   if (clientOrder === 'reversed') {
     clients.reverse();
   }
-  return new Merger(fixture.challengeInfo, fixture.stage, clients).merge(
+  return new Merger(fixture.challengeInfo, fixture.stage, clients).merge({
     tracer,
-    { alignMismatched: true },
-  );
+  });
 }
 
 function digest(events: MergedEvents): string {

--- a/challenge-server/merging/__tests__/merge.test.ts
+++ b/challenge-server/merging/__tests__/merge.test.ts
@@ -25,12 +25,7 @@ import {
   createPlayerDeathEvent,
 } from './fixtures';
 import { MergeConsistencyIssue, RejectionReason } from '../merge-consistency';
-import {
-  MergedEvents,
-  Merger,
-  MergeClientClassification,
-  MergeOptions,
-} from '../merge';
+import { MergedEvents, Merger, MergeClientClassification } from '../merge';
 import { MergeAlertType } from '../quality';
 import { MergeTracer } from '../trace';
 
@@ -566,8 +561,6 @@ describe('Merger', () => {
     });
   });
 
-  const ALIGN_OPTIONS: MergeOptions = { alignMismatched: true };
-
   it('merges an inaccurate target into an accurate base via alignment', () => {
     const NUM_TICKS = 10;
 
@@ -607,7 +600,7 @@ describe('Merger', () => {
 
     const merger = new Merger(fakeChallenge, Stage.TOB_MAIDEN, [base, target]);
     const tracer = new MergeTracer();
-    const result = merger.merge(tracer, ALIGN_OPTIONS);
+    const result = merger.merge({ tracer });
 
     expect(result).not.toBeNull();
     expect(result!.mergedCount).toBe(2);
@@ -692,7 +685,7 @@ describe('Merger', () => {
     );
 
     const merger = new Merger(fakeChallenge, Stage.TOB_MAIDEN, [base, target]);
-    const result = merger.merge(undefined, ALIGN_OPTIONS);
+    const result = merger.merge();
 
     expect(result).not.toBeNull();
     expect(result!.mergedCount).toBe(2);
@@ -772,7 +765,7 @@ describe('Merger', () => {
     // Client 1 (gap) is selected as base (lower ID tiebreak). The alignment
     // should INSERT target tick 7 to fill the gap in the base timeline.
     const merger = new Merger(fakeChallenge, Stage.TOB_MAIDEN, [base, target]);
-    const result = merger.merge(undefined, ALIGN_OPTIONS);
+    const result = merger.merge();
 
     expect(result).not.toBeNull();
     expect(result!.mergedCount).toBe(2);
@@ -854,7 +847,7 @@ describe('Merger', () => {
 
     // No options: default behavior.
     const merger = new Merger(fakeChallenge, Stage.TOB_MAIDEN, [base, target]);
-    const result = merger.merge();
+    const result = merger.merge({ alignMismatched: false });
 
     expect(result).not.toBeNull();
     expect(result!.mergedCount).toBe(1);
@@ -903,7 +896,7 @@ describe('Merger', () => {
 
     const merger = new Merger(fakeChallenge, Stage.TOB_MAIDEN, [base, target]);
     const tracer = new MergeTracer();
-    const result = merger.merge(tracer, ALIGN_OPTIONS);
+    const result = merger.merge({ tracer });
 
     expect(result).not.toBeNull();
     // Only the base is merged.
@@ -1099,7 +1092,7 @@ describe('Merger', () => {
         target,
       ]);
       const tracer = new MergeTracer();
-      const result = merger.merge(tracer);
+      const result = merger.merge({ tracer });
 
       expect(result).not.toBeNull();
       expect(result!.unmergedCount).toBe(1);

--- a/challenge-server/merging/merge-consistency.ts
+++ b/challenge-server/merging/merge-consistency.ts
@@ -292,7 +292,7 @@ export class MergeConsistencyChecker {
 
   private checkStreamEvents(ticks: TickStateArray): void {
     // Every `temporalWindow: null` stream event is expected to appear at most
-    // once per (type, identity). Actor-lifecycle events are handled separately
+    // once per (type, identity). Actor lifecycle events are handled separately
     // by `checkActorLifecycles` and excluded here to avoid double-reporting.
     const occurrences = new Map<StreamEventType, Map<string, number[]>>();
     const excluded: ReadonlySet<StreamEventType> = new Set([

--- a/challenge-server/merging/merge.ts
+++ b/challenge-server/merging/merge.ts
@@ -63,11 +63,9 @@ const LOW_CONFIDENCE_WARN_THRESHOLD = 0.4;
 export const enum MergeClientClassification {
   /** The client was selected as the reference client. */
   REFERENCE = 'REFERENCE',
-
-  /** The client was classified as matching. */
+  /** The client matches the tick count of the reference. */
   MATCHING = 'MATCHING',
-
-  /** The client was classified as mismatched. */
+  /** The client differs from the reference in tick count. */
   MISMATCHED = 'MISMATCHED',
 }
 
@@ -99,22 +97,23 @@ export type MergeClient = {
    */
   mergeIssues: MergeConsistencyIssue[];
   /**
-   * Lowest segment score from this client's merge-step confidence, or null for
-   * the reference client or a step with no scored segments.
+   * Lowest segment score reported by merge step's confidence check.
+   * `null` for the reference client or a merge with no scored segments.
    */
   worstSegmentScore: number | null;
 };
 
 export type MergeOptions = {
+  tracer?: MergeTracer;
   /**
    * When true, attempt alignment-based merging for mismatched clients.
-   * When false (default), mismatched clients are skipped.
+   * When false, mismatched clients are skipped.
    */
-  alignMismatched?: boolean;
+  alignMismatched: boolean;
 };
 
 const DEFAULT_MERGE_OPTIONS: MergeOptions = {
-  alignMismatched: false,
+  alignMismatched: true,
 };
 
 export type MergeResult = {
@@ -224,10 +223,17 @@ export class Merger {
     this.referenceSelection = null;
   }
 
-  public merge(
-    tracer?: MergeTracer,
-    options?: MergeOptions,
-  ): MergeResult | null {
+  /**
+   * Combines events from the input clients into a single merged event stream.
+   *
+   * Must only be called once per instance.
+   *
+   * @param options Configuration for the merge.
+   * @returns Result containing the merged stream and metadata. Returns `null`
+   *   if no clients could be merged, either because none were provided or all
+   *   failed data validation.
+   */
+  public merge(options?: Partial<MergeOptions>): MergeResult | null {
     const mergeOptions = { ...DEFAULT_MERGE_OPTIONS, ...options };
 
     if (this.clients.length === 0) {
@@ -244,7 +250,9 @@ export class Merger {
       })),
     });
 
-    // Record input clients before classification may demote accuracy.
+    const tracer = mergeOptions.tracer;
+
+    // Record input clients before classification as it may demote accuracy.
     const registeredClients = new Map<number, RegisteredClient>();
     for (const client of this.clients) {
       registeredClients.set(client.getId(), {
@@ -344,7 +352,7 @@ export class Merger {
 
       let outcome: MergeStepOutcome;
       try {
-        outcome = merged.mergeEventsFrom(client, mergeOptions);
+        outcome = merged.mergeEventsFrom(client, mergeOptions.alignMismatched);
         if (outcome.kind === 'merged') {
           ctx.tracer?.recordIntermediateSnapshot(merged.getTicks());
         } else if (outcome.kind === 'rejected') {
@@ -723,11 +731,16 @@ class MergedTimeline {
     this.initializeBaseTicks(base);
   }
 
-  [Symbol.iterator](): EventIterator {
+  *[Symbol.iterator](): Generator<Event> {
     if (!this.finalized) {
       throw new Error('Merge not finalized');
     }
-    return new EventIterator(this.ticks);
+    for (const tick of this.ticks) {
+      if (tick === null) {
+        continue;
+      }
+      yield* tick.getEvents();
+    }
   }
 
   public getTicks(): TickStateArray {
@@ -752,12 +765,12 @@ class MergedTimeline {
    * Merges events from `client` into this merged event set.
    *
    * @param client Client to merge events from.
-   * @param options Merge options controlling alignment behavior.
+   * @param alignMismatched Whether to align mismatched clients.
    * @returns A tagged outcome describing what happened.
    */
   public mergeEventsFrom(
     client: ClientEvents,
-    options: MergeOptions,
+    alignMismatched: boolean,
   ): MergeStepOutcome {
     const targetTicks = client.getTickStates();
     let mappings: Mappings;
@@ -771,7 +784,7 @@ class MergedTimeline {
         mergedTickCount: this.ticks.length,
       };
     } else {
-      if (!options.alignMismatched) {
+      if (!alignMismatched) {
         return { kind: 'unmerged', flags: [] };
       }
       alignment = this.runAlignment(client);
@@ -1022,38 +1035,5 @@ class MergedTimeline {
 
       state.addSyntheticEvents([newEvent]);
     }
-  }
-}
-
-class EventIterator implements Iterator<Event, Event | null> {
-  private readonly ticks: (TickState | null)[];
-  private tick: number;
-  private eventIndex: number;
-
-  constructor(ticks: (TickState | null)[]) {
-    this.ticks = ticks;
-    this.tick = 0;
-    this.eventIndex = 0;
-  }
-
-  public next(): IteratorResult<Event, Event | null> {
-    for (; this.tick < this.ticks.length; this.tick++) {
-      if (this.ticks[this.tick] === null) {
-        this.eventIndex = 0;
-        continue;
-      }
-
-      const tickEvents = this.ticks[this.tick]!.getEvents();
-      while (this.eventIndex < tickEvents.length) {
-        return {
-          done: false,
-          value: tickEvents[this.eventIndex++],
-        };
-      }
-
-      this.eventIndex = 0;
-    }
-
-    return { done: true, value: null };
   }
 }


### PR DESCRIPTION
Moves the tracer into the existing options struct and flips merging mismatched clients to active by default.