### PR TITLE
web: Add percentiles to aggregation APIs

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,5 @@
+name: blert
+
 services:
   postgres:
     image: postgres:16
@@ -162,8 +164,10 @@ services:
 
 volumes:
   rediscache:
+    name: blert_rediscache
     driver: local
   postgresdata:
+    name: blert_postgresdata
     driver: local
   prometheusdata:
     driver: local

--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -18,6 +18,7 @@ import {
   SessionQuery,
 } from '@/actions/challenge';
 import { sql } from '@/actions/db';
+import { InvalidQueryError } from '@/actions/errors';
 
 afterAll(async () => {
   await sql.end();
@@ -318,9 +319,14 @@ describe('sessions', () => {
       it('should aggregate count and duration for all non-hidden sessions', async () => {
         const query: SessionQuery = {};
         const result = await aggregateSessions(query, {
-          '*': 'count',
-          duration: ['sum', 'avg', 'min', 'max'],
-          challenges: ['sum', 'avg'],
+          '*': { type: 'count' },
+          duration: [
+            { type: 'sum' },
+            { type: 'avg' },
+            { type: 'min' },
+            { type: 'max' },
+          ],
+          challenges: [{ type: 'sum' }, { type: 'avg' }],
         });
 
         expect(result).not.toBeNull();
@@ -336,18 +342,40 @@ describe('sessions', () => {
         expect(result!.challenges.sum).toBe(6);
         expect(result!.challenges.avg).toBe(1.5);
       });
+
+      it('computes percentiles over session duration', async () => {
+        const result = await aggregateSessions(
+          {},
+          {
+            duration: [
+              { type: 'percentile', value: 25 },
+              { type: 'percentile', value: 50 },
+              { type: 'percentile', value: 75 },
+            ],
+          },
+        );
+
+        // Non-hidden durations sorted: 900, 1800, 2700, 3600.
+        expect(result!.duration.p25).toBeCloseTo(1575);
+        expect(result!.duration.p50).toBeCloseTo(2250);
+        expect(result!.duration.p75).toBeCloseTo(2925);
+      });
     });
 
     describe('filtering', () => {
       it('should filter by session status', async () => {
         const query: SessionQuery = { status: ['==', SessionStatus.COMPLETED] };
-        const result = await aggregateSessions(query, { '*': 'count' });
+        const result = await aggregateSessions(query, {
+          '*': { type: 'count' },
+        });
         expect(result!['*'].count).toBe(3);
       });
 
       it('should filter by challenge type', async () => {
         const query: SessionQuery = { type: ['==', ChallengeType.COLOSSEUM] };
-        const result = await aggregateSessions(query, { '*': 'count' });
+        const result = await aggregateSessions(query, {
+          '*': { type: 'count' },
+        });
         expect(result!['*'].count).toBe(1);
       });
     });
@@ -357,7 +385,7 @@ describe('sessions', () => {
         const query: SessionQuery = {};
         const result = await aggregateSessions(
           query,
-          { '*': 'count' },
+          { '*': { type: 'count' } },
           {},
           'mode',
         );
@@ -375,7 +403,7 @@ describe('sessions', () => {
         const query: SessionQuery = {};
         const result = await aggregateSessions(
           query,
-          { '*': 'count' },
+          { '*': { type: 'count' } },
           {},
           'party',
         );
@@ -393,10 +421,12 @@ describe('sessions', () => {
 
       it('should group by multiple fields', async () => {
         const query: SessionQuery = {};
-        const result = await aggregateSessions(query, { '*': 'count' }, {}, [
-          'type',
-          'scale',
-        ] as const);
+        const result = await aggregateSessions(
+          query,
+          { '*': { type: 'count' } },
+          {},
+          ['type', 'scale'] as const,
+        );
 
         expect(result).not.toBeNull();
         const tob = ChallengeType.TOB.toString();
@@ -413,7 +443,7 @@ describe('sessions', () => {
         const query: SessionQuery = {};
         const result = await aggregateSessions(
           query,
-          { duration: 'max' },
+          { duration: { type: 'max' } },
           { sort: '-duration:max', limit: 2 },
           'scale',
         );
@@ -427,7 +457,7 @@ describe('sessions', () => {
         const query: SessionQuery = {};
         const result = await aggregateSessions(
           query,
-          { '*': 'count' },
+          { '*': { type: 'count' } },
           { limit: 2 },
           'scale',
         );
@@ -987,7 +1017,15 @@ describe('challenges', () => {
     it('aggregates tob:xarpusHealing across all operations', async () => {
       const result = await aggregateChallenges(
         {},
-        { 'tob:xarpusHealing': ['avg', 'count', 'sum', 'min', 'max'] },
+        {
+          'tob:xarpusHealing': [
+            { type: 'avg' },
+            { type: 'count' },
+            { type: 'sum' },
+            { type: 'min' },
+            { type: 'max' },
+          ],
+        },
       );
 
       expect(result).not.toBeNull();
@@ -1003,7 +1041,7 @@ describe('challenges', () => {
       // still include it in the total count while its healing is null.
       const result = await aggregateChallenges(
         {},
-        { '*': 'count', 'tob:xarpusHealing': 'count' },
+        { '*': { type: 'count' }, 'tob:xarpusHealing': { type: 'count' } },
       );
 
       expect(result!['*'].count).toBe(3);
@@ -1013,7 +1051,7 @@ describe('challenges', () => {
     it('groups tob:xarpusHealing by scale', async () => {
       const result = await aggregateChallenges(
         { type: ['==', ChallengeType.TOB] },
-        { 'tob:xarpusHealing': ['avg', 'count'] },
+        { 'tob:xarpusHealing': [{ type: 'avg' }, { type: 'count' }] },
         {},
         'scale',
       );
@@ -1022,6 +1060,156 @@ describe('challenges', () => {
       // Both ToB challenges are scale 2.
       expect(result!['2']['tob:xarpusHealing'].count).toBe(2);
       expect(result!['2']['tob:xarpusHealing'].avg).toBe(125);
+    });
+
+    describe('percentiles', () => {
+      beforeEach(async () => {
+        // Five scale-5 ToB challenges keep this distribution isolated from the
+        // fixture's scale 1-3 rows. Mean: 760, Median: 500.
+        const ticks = [300, 400, 500, 600, 2000];
+        const healing = [100, null, 200, null, 900];
+        const challenges = ticks.map((challenge_ticks, i) => ({
+          session_id: sessionId,
+          uuid: `f000000${i}-0000-0000-0000-000000000000`,
+          type: ChallengeType.TOB,
+          status: ChallengeStatus.COMPLETED,
+          start_time: new Date('2024-02-01T10:00:00Z'),
+          scale: 5,
+          challenge_ticks,
+        }));
+        const inserted = await sql`
+          INSERT INTO challenges ${sql(challenges, [
+            'session_id',
+            'uuid',
+            'type',
+            'status',
+            'start_time',
+            'scale',
+            'challenge_ticks',
+          ])} RETURNING id
+        `;
+
+        const stats = inserted
+          .map((row, i) => ({
+            challenge_id: row.id as number,
+            xarpus_healing: healing[i],
+          }))
+          .filter(
+            (s): s is { challenge_id: number; xarpus_healing: number } => {
+              return s.xarpus_healing !== null;
+            },
+          );
+        await sql`
+          INSERT INTO tob_challenge_stats ${sql(stats, [
+            'challenge_id',
+            'xarpus_healing',
+          ])}
+        `;
+      });
+
+      it('computes count, mean, and percentiles on data points', async () => {
+        const result = await aggregateChallenges(
+          { scale: ['==', 5] },
+          {
+            challengeTicks: [
+              { type: 'count' },
+              { type: 'avg' },
+              { type: 'min' },
+              { type: 'max' },
+              { type: 'percentile', value: 25 },
+              { type: 'percentile', value: 50 },
+              { type: 'percentile', value: 75 },
+            ],
+          },
+        );
+
+        expect(result!.challengeTicks).toEqual({
+          count: 5,
+          avg: 760,
+          min: 300,
+          max: 2000,
+          p25: 400,
+          p50: 500,
+          p75: 600,
+        });
+      });
+
+      it('interpolates percentiles between data points', async () => {
+        const result = await aggregateChallenges(
+          { scale: ['==', 5] },
+          {
+            challengeTicks: [
+              { type: 'percentile', value: 10 },
+              { type: 'percentile', value: 90 },
+            ],
+          },
+        );
+
+        // p10 = 300 + 0.4 * (400 - 300); p90 = 600 + 0.6 * (2000 - 600).
+        expect(result!.challengeTicks.p10).toBeCloseTo(340);
+        expect(result!.challengeTicks.p90).toBeCloseTo(1440);
+      });
+
+      it('supports fractional percentiles', async () => {
+        const result = await aggregateChallenges(
+          { scale: ['==', 5] },
+          { challengeTicks: [{ type: 'percentile', value: 99.9 }] },
+        );
+
+        // 600 + 0.996 * (2000 - 600).
+        expect(result!.challengeTicks['p99.9']).toBeCloseTo(1994.4);
+      });
+
+      it('takes a percentile over a joined column, ignoring nulls', async () => {
+        const result = await aggregateChallenges(
+          { scale: ['==', 5] },
+          {
+            '*': { type: 'count' },
+            'tob:xarpusHealing': [
+              { type: 'count' },
+              { type: 'percentile', value: 50 },
+            ],
+          },
+        );
+
+        // Healing recorded on three of five rows: 100, 200, 900.
+        expect(result!['*'].count).toBe(5);
+        expect(result!['tob:xarpusHealing'].count).toBe(3);
+        expect(result!['tob:xarpusHealing'].p50).toBe(200);
+      });
+
+      it('rejects a percentile outside [0, 100]', async () => {
+        await expect(
+          aggregateChallenges(
+            { scale: ['==', 5] },
+            { challengeTicks: [{ type: 'percentile', value: 150 }] },
+          ),
+        ).rejects.toThrow(InvalidQueryError);
+      });
+
+      it('sorts grouped results by a percentile alias', async () => {
+        const result = await aggregateChallenges(
+          { scale: ['==', 5] },
+          { challengeTicks: [{ type: 'percentile', value: 50 }] },
+          { sort: '-p50' },
+          'scale',
+        );
+        expect(result!['5'].challengeTicks.p50).toBe(500);
+      });
+
+      it('rejects an aggregate sort matching multiple fields', async () => {
+        await expect(
+          aggregateChallenges(
+            { scale: ['==', 5] },
+            {
+              challengeTicks: [{ type: 'percentile', value: 50 }],
+              overallTicks: [{ type: 'percentile', value: 50 }],
+            },
+            { sort: '-p50' },
+            'scale',
+          ),
+        ).rejects.toThrow(InvalidQueryError);
+      });
     });
   });
 

--- a/web/__tests__/api/query.test.ts
+++ b/web/__tests__/api/query.test.ts
@@ -1,4 +1,9 @@
-import { numericComparatorParam } from '@/api/query';
+import {
+  normalizeSortAggregation,
+  numericComparatorParam,
+  parseAggregateParams,
+  restoreAggregateAliases,
+} from '@/api/query';
 
 describe('comparatorParam', () => {
   const params = new URLSearchParams();
@@ -126,5 +131,95 @@ describe('comparatorParam', () => {
     expect(() =>
       numericComparatorParam(searchParams, 'invalidComparator4'),
     ).toThrow();
+  });
+});
+
+describe('parseAggregateParams', () => {
+  it('parses tokens into aggregations with an implicit count', () => {
+    expect(parseAggregateParams(['challengeTicks:avg,p90'])).toEqual({
+      aggregations: {
+        '*': { type: 'count' },
+        challengeTicks: [{ type: 'avg' }, { type: 'percentile', value: 90 }],
+      },
+      aliases: {},
+    });
+  });
+
+  it('aliases p50 as median', () => {
+    expect(parseAggregateParams(['challengeTicks:median'])).toEqual({
+      aggregations: {
+        '*': { type: 'count' },
+        challengeTicks: [{ type: 'percentile', value: 50 }],
+      },
+      aliases: { challengeTicks: { p50: 'median' } },
+    });
+  });
+
+  it('parses field from ops on the last colon', () => {
+    expect(parseAggregateParams(['splits:1234:median'])).toEqual({
+      aggregations: {
+        '*': { type: 'count' },
+        'splits:1234': [{ type: 'percentile', value: 50 }],
+      },
+      aliases: { 'splits:1234': { p50: 'median' } },
+    });
+  });
+
+  it('returns null for an invalid token', () => {
+    expect(parseAggregateParams(['challengeTicks:p150'])).toBeNull();
+    expect(parseAggregateParams(['challengeTicks:nonsense'])).toBeNull();
+  });
+});
+
+describe('restoreAggregateAliases', () => {
+  it('renames result keys back to the requested token', () => {
+    const result = {
+      '*': { count: 5 },
+      challengeTicks: { avg: 760, p50: 500 },
+    };
+    restoreAggregateAliases(result, 0, { challengeTicks: { p50: 'median' } });
+    expect(result).toEqual({
+      '*': { count: 5 },
+      challengeTicks: { avg: 760, median: 500 },
+    });
+  });
+
+  it('renames within each group of a grouped result', () => {
+    const result = {
+      '2': { challengeTicks: { p50: 500 } },
+      '3': { challengeTicks: { p50: 700 } },
+    };
+    restoreAggregateAliases(result, 1, { challengeTicks: { p50: 'median' } });
+    expect(result).toEqual({
+      '2': { challengeTicks: { median: 500 } },
+      '3': { challengeTicks: { median: 700 } },
+    });
+  });
+
+  it('leaves the result untouched when there are no aliases', () => {
+    const result = { challengeTicks: { p50: 500 } };
+    restoreAggregateAliases(result, 0, {});
+    expect(result).toEqual({ challengeTicks: { p50: 500 } });
+  });
+});
+
+describe('normalizeSortAggregation', () => {
+  it('rewrites a median sort suffix to p50', () => {
+    expect(normalizeSortAggregation('-duration:median')).toBe('-duration:p50');
+  });
+
+  it('rewrites a bare median sort to p50', () => {
+    expect(normalizeSortAggregation('-median')).toBe('-p50');
+  });
+
+  it('preserves the sort direction and options', () => {
+    expect(normalizeSortAggregation('+duration:median#nl')).toBe(
+      '+duration:p50#nl',
+    );
+  });
+
+  it('leaves non-alias aggregations and plain fields untouched', () => {
+    expect(normalizeSortAggregation('-duration:max')).toBe('-duration:max');
+    expect(normalizeSortAggregation('+challengeTicks')).toBe('+challengeTicks');
   });
 });

--- a/web/app/(challenges)/activity-dashboard.tsx
+++ b/web/app/(challenges)/activity-dashboard.tsx
@@ -568,8 +568,8 @@ export default function ActivityDashboard({
       const teamPromise = fetchJsonOrNull<
         GroupedAggregationResult<
           {
-            '*': 'count';
-            duration: ('max' | 'sum')[];
+            '*': { type: 'count' };
+            duration: ({ type: 'max' } | { type: 'sum' })[];
           },
           'party'
         >

--- a/web/app/(challenges)/challenge-page.tsx
+++ b/web/app/(challenges)/challenge-page.tsx
@@ -40,40 +40,44 @@ export default async function Page({
   const statsQuery = aggregateChallenges(
     challengeFilter,
     {
-      '*': 'count',
-      challengeTicks: 'sum',
-      totalDeaths: 'sum',
+      '*': { type: 'count' },
+      challengeTicks: { type: 'sum' },
+      totalDeaths: { type: 'sum' },
     },
     {},
   );
 
   const statusQuery = aggregateChallenges(
     challengeFilter,
-    { '*': 'count' },
+    { '*': { type: 'count' } },
     {},
     'status',
   );
   const scaleQuery = aggregateChallenges(
     challengeFilter,
-    { '*': 'count' },
+    { '*': { type: 'count' } },
     {},
     'scale',
   );
   const playerQuery = aggregateChallenges(
     challengeFilter,
-    { '*': 'count' },
+    { '*': { type: 'count' } },
     { limit: 10, sort: '-count' },
     'username',
   );
   const sessionQuery = aggregateSessions(
     challengeFilter as SessionQuery,
-    { '*': 'count', duration: 'avg', challenges: 'sum' },
+    {
+      '*': { type: 'count' },
+      duration: { type: 'avg' },
+      challenges: { type: 'sum' },
+    },
     {},
     'status',
   );
   const mostActiveTeamQuery = aggregateSessions(
     challengeFilter as SessionQuery,
-    { '*': 'count', duration: ['max', 'sum'] },
+    { '*': { type: 'count' }, duration: [{ type: 'max' }, { type: 'sum' }] },
     { sort: '-duration:sum', limit: 3 },
     'party',
   );

--- a/web/app/(challenges)/query.ts
+++ b/web/app/(challenges)/query.ts
@@ -48,8 +48,8 @@ export function parseSessionStats(
 export function parseMostActiveTeam(
   result: GroupedAggregationResult<
     {
-      '*': 'count';
-      duration: ('max' | 'sum')[];
+      '*': { type: 'count' };
+      duration: ({ type: 'max' } | { type: 'sum' })[];
     },
     'party'
   > | null,

--- a/web/app/(dashboard)/page.tsx
+++ b/web/app/(dashboard)/page.tsx
@@ -60,7 +60,7 @@ async function getThisWeekActivity(
       partyMatch: 'any',
       startTime: ['>=', oneWeekAgo],
     },
-    { '*': 'count' },
+    { '*': { type: 'count' } },
     {},
     ['type', 'mode', 'scale'] as const,
   );
@@ -102,7 +102,7 @@ async function getQuickStats(usernames: string[]): Promise<QuickStats> {
   const [allStats, completedStats] = await Promise.all([
     aggregateChallenges(
       { party: usernames, partyMatch: 'any' },
-      { '*': 'count', challengeTicks: 'sum' },
+      { '*': { type: 'count' }, challengeTicks: { type: 'sum' } },
     ),
     aggregateChallenges(
       {
@@ -110,7 +110,7 @@ async function getQuickStats(usernames: string[]): Promise<QuickStats> {
         partyMatch: 'any',
         status: ['==', ChallengeStatus.COMPLETED],
       },
-      { '*': 'count' },
+      { '*': { type: 'count' } },
     ),
   ]);
 

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -47,6 +47,13 @@ import { sql } from './db';
 import dataRepository from './data-repository';
 import { InvalidQueryError } from './errors';
 import {
+  AggregateAliases,
+  aggregateAlias,
+  aggregateSelectColumns,
+  Aggregation,
+  AggregationKey,
+  aggregationKey,
+  assertValidAggregations,
   BaseOperand,
   Comparator,
   comparatorToSql,
@@ -54,6 +61,11 @@ import {
   Join,
   join,
   operator,
+  parseAggregation,
+  parseSort,
+  rowToAggregations,
+  SortDirection,
+  SortQuery,
   where,
 } from './query';
 
@@ -370,33 +382,6 @@ export type ChallengeOverview = Pick<
       Pick<InfernoChallenge, 'infernoStats'>
   >;
 
-type SortDirection = '+' | '-';
-type SortOptions = 'nf' | 'nl';
-
-/**
- * A `SortQuery` is a string that represents a field to sort by. It consists of
- * three parts:
- * - A prefix that indicates the sort order: `+` for ascending, `-` for
- *   descending.
- * - The name of the field to sort by.
- * - Optionally, a suffix specifying additional sorting options. This can be
- *   one of the following:
- *   * `#nf` to indicate that null values should be sorted first.
- *   * `#nl` to indicate that null values should be sorted last.
- */
-export type SortQuery<T> = `${SortDirection}${T extends object
-  ? keyof T & string
-  : T extends string
-    ? T
-    : never}${`#${SortOptions}` | ''}`;
-
-function isSortDirection(s: string): s is SortDirection {
-  return s === '+' || s === '-';
-}
-function isSortOptions(s: string): s is SortOptions {
-  return s === 'nf' || s === 'nl';
-}
-
 export type BasicSortableFields = keyof Omit<
   ChallengeOverview,
   'party' | 'finishTime'
@@ -452,7 +437,7 @@ export type QueryOptions = {
   fullRecordings?: boolean;
   limit?: number;
   sort?: SortQuery<
-    Omit<ChallengeOverview, 'party' | 'finishTime'> | Aggregation
+    Omit<ChallengeOverview, 'party' | 'finishTime'> | AggregationKey
   >;
 };
 
@@ -533,24 +518,6 @@ function conditionToSql(
         : sql`${columnOrLiteral(conditions[2])}`
     }
   )`;
-}
-
-function parseSort(sort: string): {
-  direction: SortDirection;
-  field: string;
-  options: SortOptions | undefined;
-} {
-  const direction = sort[0];
-  if (!isSortDirection(direction)) {
-    throw new InvalidQueryError(`Invalid sort direction: ${direction}`);
-  }
-
-  const [field, options] = sort.slice(1).split('#');
-  if (options !== undefined && !isSortOptions(options)) {
-    throw new InvalidQueryError(`Invalid sort options: ${options}`);
-  }
-
-  return { direction, field, options };
 }
 
 function order(
@@ -1143,21 +1110,16 @@ function groupExpression(groupField: GroupField): postgres.Fragment {
   return sql`${groupField.groupExpression} AS ${sql(groupField.renamed)}`;
 }
 
-export type Aggregation = 'count' | 'sum' | 'avg' | 'min' | 'max';
 type Aggregations = Aggregation | Aggregation[];
-
-function isAggregation(agg: string): agg is Aggregation {
-  return ['count', 'sum', 'avg', 'min', 'max'].includes(agg);
-}
 
 export type AggregationQuery = Record<string, Aggregations>;
 
-export type FieldAggregation<T extends string> = `${T}:${Aggregation}`;
+export type FieldAggregation<T extends string> = `${T}:${AggregationKey}`;
 
 type FieldAggregations<As extends Aggregations> = As extends Aggregation
-  ? Record<As, number>
+  ? Record<AggregationKey<As>, number>
   : As extends Aggregation[]
-    ? Record<As[number], number>
+    ? Record<AggregationKey<As[number]>, number>
     : never;
 
 export type AggregationResult<F extends AggregationQuery> = {
@@ -1191,7 +1153,7 @@ type NestedGroupedAggregationResult<
  * ```typescript
  * const results = await aggregateChallenges(
  *  { from: new Date('2021-01-01') },
- *  { '*': 'count', challengeTicks: ['sum', 'avg'] },
+ *  { '*': { type: 'count' }, challengeTicks: [{ type: 'sum' }, { type: 'avg' }] },
  * );
  *
  * // {
@@ -1221,7 +1183,7 @@ export async function aggregateChallenges<F extends AggregationQuery>(
  * ```typescript
  * const results = await aggregateChallenges(
  *  { from: new Date('2021-01-01') },
- *  { '*': 'count', challengeTicks: ['sum', 'avg'] },
+ *  { '*': { type: 'count' }, challengeTicks: [{ type: 'sum' }, { type: 'avg' }] },
  * );
  *
  * // {
@@ -1255,7 +1217,7 @@ export async function aggregateChallenges<F extends AggregationQuery>(
  * ```typescript
  * const results = await aggregateChallenges(
  *  { from: new Date('2021-01-01') },
- *  { '*': 'count', challengeTicks: ['sum', 'avg'] },
+ *  { '*': { type: 'count' }, challengeTicks: [{ type: 'sum' }, { type: 'avg' }] },
  *  'status',
  * );
  *
@@ -1305,18 +1267,12 @@ export async function aggregateChallenges<
 
   const { baseTable, queryTable, joins, conditions } = components;
 
-  const aggregateName = (
-    table: string,
-    field: string,
-    agg: Aggregation,
-  ): string => `${agg}_${table}_${field}`;
-
-  const originalFields: Record<string, string> = {};
+  const aliases: AggregateAliases = {};
   let hasCount = false;
 
   const aggregateFields = Object.entries(fields).flatMap(([field, aggs]) => {
     if (field === '*') {
-      if (aggs !== 'count') {
+      if (Array.isArray(aggs) || aggs.type !== 'count') {
         throw new InvalidQueryError(
           'Cannot aggregate all fields with non-count aggregation',
         );
@@ -1325,16 +1281,8 @@ export async function aggregateChallenges<
       return sql`COUNT(*) as count`;
     }
 
-    if (!Array.isArray(aggs)) {
-      aggs = [aggs];
-    }
-
-    const invalidAggregations = aggs.filter((agg) => !isAggregation(agg));
-    if (invalidAggregations.length > 0) {
-      throw new InvalidQueryError(
-        `Invalid aggregations: ${invalidAggregations.join(', ')}`,
-      );
-    }
+    const aggregations = Array.isArray(aggs) ? aggs : [aggs];
+    assertValidAggregations(aggregations);
 
     const [tableField, table] = shorthandToFullField(camelToSnake(field));
     const sqlTable = table === 'challenges' ? queryTable : sql(table);
@@ -1360,11 +1308,15 @@ export async function aggregateChallenges<
       });
     }
 
-    return aggs.map((agg) => {
-      const name = aggregateName(table, tableField, agg);
-      originalFields[name] = field;
-      return sql`${sql(agg)}(${sqlTable}.${sql(tableField)}) as ${sql(name)}`;
-    });
+    const column = sql`${sqlTable}.${sql(tableField)}`;
+    const [fragments, fieldAliases] = aggregateSelectColumns(
+      field,
+      `${table}_${tableField}`,
+      column,
+      aggregations,
+    );
+    Object.assign(aliases, fieldAliases);
+    return fragments;
   });
 
   const groupFields: GroupField[] = [];
@@ -1395,10 +1347,28 @@ export async function aggregateChallenges<
     });
   }
 
-  const floatOrZero = (value: string | number | null | undefined): number => {
-    const num = parseFloat(value as string);
-    return Number.isNaN(num) ? 0 : num;
-  };
+  let sortClause: postgres.Fragment = sql``;
+  if (options.sort !== undefined) {
+    const { direction, field, options: sortOptions } = parseSort(options.sort);
+    let column = field;
+    const parsedAgg = parseAggregation(field);
+    // A field aggregation is selected under a generated alias, so resolve the
+    // sort to that alias.
+    if (parsedAgg !== null && parsedAgg.type !== 'count') {
+      const aggKey = aggregationKey(parsedAgg);
+      const matches = Object.keys(aliases).filter(
+        (alias) => aliases[alias].aggKey === aggKey,
+      );
+      if (matches.length !== 1) {
+        throw new InvalidQueryError(
+          `Sort aggregation '${aggKey}' must match exactly one selected field`,
+        );
+      }
+      column = matches[0];
+    }
+    const suffix = sortOptions === undefined ? '' : `#${sortOptions}`;
+    sortClause = order(`${direction}${column}${suffix}`);
+  }
 
   const rows = await sql`
     SELECT
@@ -1416,7 +1386,7 @@ export async function aggregateChallenges<
         ? sql`GROUP BY ${sql(groupFields.map((g) => g.renamed))}`
         : sql``
     }
-    ${options.sort ? order(options.sort) : sql``}
+    ${sortClause}
     ${options.limit ? sql`LIMIT ${options.limit}` : sql``}
   `;
 
@@ -1431,51 +1401,16 @@ export async function aggregateChallenges<
   }
 
   if (groupFields.length === 0) {
-    const result = {} as AggregationResult<AggregationQuery>;
-
-    const row = rows[0];
-
-    Object.entries(row).forEach(([key, value]) => {
-      if (key === 'count') {
-        result['*'] = { count: parseInt(value as string) };
-        return;
-      }
-
-      const agg = key.split('_')[0] as Aggregation;
-      const field = originalFields[key];
-
-      result[field] ??= {} as Record<Aggregation, number>;
-      (result[field] as Record<Aggregation, number>)[agg] = floatOrZero(
-        value as string,
-      );
-    });
-
-    return result as AggregationResult<F>;
+    return rowToAggregations(rows[0], aliases) as AggregationResult<F>;
   }
 
   const result = {} as GroupedAggregationResult<AggregationQuery, string>;
 
   rows.forEach((row) => {
-    const groupResult = {} as AggregationResult<AggregationQuery>;
-
-    Object.entries(row).forEach(([key, value]) => {
-      if (key === 'count') {
-        groupResult['*'] = { count: parseInt(value as string) };
-        return;
-      }
-
-      if (groupFields.some((g) => g.renamed === key)) {
-        return;
-      }
-
-      const agg = key.split('_')[0];
-      const field = originalFields[key];
-
-      groupResult[field] ??= {} as Record<Aggregation, number>;
-      (groupResult[field] as Record<string, number>)[agg] = floatOrZero(
-        value as string,
-      );
-    });
+    const groupResult = rowToAggregations(
+      row,
+      aliases,
+    ) as AggregationResult<AggregationQuery>;
 
     let parent = result;
 
@@ -2256,9 +2191,9 @@ export async function loadSessionsPage(
       before: undefined,
       after: undefined,
     };
-    totalPromise = aggregateSessions(unfilteredQuery, { '*': 'count' }).then(
-      (r) => r?.['*']?.count ?? 0,
-    );
+    totalPromise = aggregateSessions(unfilteredQuery, {
+      '*': { type: 'count' },
+    }).then((r) => r?.['*']?.count ?? 0);
   }
 
   const [rawSessions, unfilteredTotal] = await Promise.all([
@@ -2351,7 +2286,9 @@ export type SessionAggregationOptions<
   F extends AggregationQuery = Record<string, Aggregations>,
 > = {
   limit?: number;
-  sort?: SortQuery<Aggregation | FieldAggregation<keyof Omit<F, '*'> & string>>;
+  sort?: SortQuery<
+    AggregationKey | FieldAggregation<keyof Omit<F, '*'> & string>
+  >;
 };
 
 /**
@@ -2393,15 +2330,12 @@ export async function aggregateSessions<
 ): Promise<AggregationResult<F> | GroupedAggregationResult<F, G> | null> {
   const { conditions } = sessionFilters(query);
 
-  const aggregateName = (field: string, agg: Aggregation): string =>
-    `${agg}_${field}`;
-
-  const originalFields: Record<string, string> = {};
+  const aliases: AggregateAliases = {};
   let hasCount = false;
 
   const aggregateFields = Object.entries(fields).flatMap(([field, aggs]) => {
     if (field === '*') {
-      if (aggs !== 'count') {
+      if (Array.isArray(aggs) || aggs.type !== 'count') {
         throw new InvalidQueryError(
           'Cannot aggregate all fields with non-count aggregation',
         );
@@ -2410,24 +2344,18 @@ export async function aggregateSessions<
       return sql`COUNT(*) as count`;
     }
 
-    if (!Array.isArray(aggs)) {
-      aggs = [aggs];
-    }
-
-    const invalidAggregations = aggs.filter((agg) => !isAggregation(agg));
-    if (invalidAggregations.length > 0) {
-      throw new InvalidQueryError(
-        `Invalid aggregations: ${invalidAggregations.join(', ')}`,
-      );
-    }
+    const aggregations = Array.isArray(aggs) ? aggs : [aggs];
+    assertValidAggregations(aggregations);
 
     const fieldExpression = sessionFieldToExpression(field);
-
-    return aggs.map((agg) => {
-      const name = aggregateName(field, agg);
-      originalFields[name] = field;
-      return sql`${sql(agg)}(${fieldExpression}) as ${sql(name)}`;
-    });
+    const [fragments, fieldAliases] = aggregateSelectColumns(
+      field,
+      field,
+      fieldExpression,
+      aggregations,
+    );
+    Object.assign(aliases, fieldAliases);
+    return fragments;
   });
 
   let groupFields: string[] = [];
@@ -2435,11 +2363,6 @@ export async function aggregateSessions<
     const fields = Array.isArray(grouping) ? grouping : [grouping];
     groupFields = (fields as string[]).map(sessionGroupingFieldToDb);
   }
-
-  const floatOrZero = (value: string | number | null | undefined): number => {
-    const num = parseFloat(value as string);
-    return Number.isNaN(num) ? 0 : num;
-  };
 
   let sort = undefined;
   if (options.sort) {
@@ -2451,10 +2374,12 @@ export async function aggregateSessions<
 
     if (agg === undefined) {
       sort = `${direction}${field}`;
-    } else if (isAggregation(agg)) {
-      sort = `${direction}${aggregateName(fieldName, agg)}#nl`;
     } else {
-      throw new InvalidQueryError(`Invalid aggregation: ${agg}`);
+      const parsed = parseAggregation(agg);
+      if (parsed === null) {
+        throw new InvalidQueryError(`Invalid aggregation: ${agg}`);
+      }
+      sort = `${direction}${aggregateAlias(aggregationKey(parsed), fieldName)}#nl`;
     }
   }
 
@@ -2486,23 +2411,7 @@ export async function aggregateSessions<
   }
 
   if (groupFields.length === 0) {
-    const result = {} as AggregationResult<any>;
-    const row = rows[0];
-
-    Object.entries(row).forEach(([key, value]) => {
-      if (key === 'count') {
-        result['*'] = { count: parseInt(value as string) };
-        return;
-      }
-
-      const agg = key.split('_')[0];
-      const field = originalFields[key];
-
-      result[field] ??= {};
-      result[field][agg] = floatOrZero(value as string);
-    });
-
-    return result;
+    return rowToAggregations(rows[0], aliases) as AggregationResult<F>;
   }
 
   const result = {} as GroupedAggregationResult<AggregationQuery, string>;
@@ -2557,26 +2466,10 @@ export async function aggregateSessions<
   }
 
   rows.forEach((row) => {
-    const groupResult = {} as AggregationResult<AggregationQuery>;
-
-    Object.entries(row).forEach(([key, value]) => {
-      if (key === 'count') {
-        groupResult['*'] = { count: parseInt(value as string) };
-        return;
-      }
-
-      if (groupFields.includes(key)) {
-        return;
-      }
-
-      const agg = key.split('_')[0];
-      const field = originalFields[key];
-
-      groupResult[field] ??= {} as Record<Aggregation, number>;
-      (groupResult[field] as Record<string, number>)[agg] = floatOrZero(
-        value as string,
-      );
-    });
+    const groupResult = rowToAggregations(
+      row,
+      aliases,
+    ) as AggregationResult<AggregationQuery>;
 
     let parent = result;
 

--- a/web/app/actions/query.ts
+++ b/web/app/actions/query.ts
@@ -128,6 +128,239 @@ export function comparatorToSql(
   return sql`${lhs} ${op} ${comparator[1]}`;
 }
 
+/**
+ * A `SortQuery` is a string that represents a field to sort by. It consists of
+ * three parts:
+ * - A prefix that indicates the sort order: `+` for ascending, `-` for
+ *   descending.
+ * - The name of the field to sort by.
+ * - Optionally, a suffix specifying additional sorting options. This can be
+ *   one of the following:
+ *   * `#nf` to indicate that null values should be sorted first.
+ *   * `#nl` to indicate that null values should be sorted last.
+ */
+export type SortQuery<T> = `${SortDirection}${T extends object
+  ? keyof T & string
+  : T extends string
+    ? T
+    : never}${`#${SortOptions}` | ''}`;
+
+export type SortDirection = '+' | '-';
+export type SortOptions = 'nf' | 'nl';
+
+function isSortDirection(s: string): s is SortDirection {
+  return s === '+' || s === '-';
+}
+
+function isSortOptions(s: string): s is SortOptions {
+  return s === 'nf' || s === 'nl';
+}
+
+/**
+ * Parses a sort string of the form `[+-]field[#nf|#nl]` into its parts.
+ *
+ * @throws InvalidQueryError if the direction or options are invalid.
+ */
+export function parseSort(sort: string): {
+  direction: SortDirection;
+  field: string;
+  options: SortOptions | undefined;
+} {
+  const direction = sort[0];
+  if (!isSortDirection(direction)) {
+    throw new InvalidQueryError(`Invalid sort direction: ${direction}`);
+  }
+
+  const [field, options] = sort.slice(1).split('#');
+  if (options !== undefined && !isSortOptions(options)) {
+    throw new InvalidQueryError(`Invalid sort options: ${options}`);
+  }
+
+  return { direction, field, options };
+}
+
+/**
+ * An aggregation operation.
+ *
+ * `percentile` carries the requested percentile in `[0, 100]` and is computed
+ * using `PERCENTILE_CONT`.
+ */
+export type Aggregation =
+  | { type: 'count' }
+  | { type: 'sum' }
+  | { type: 'avg' }
+  | { type: 'min' }
+  | { type: 'max' }
+  | { type: 'percentile'; value: number };
+
+/**
+ * The string key an aggregation produces in result objects and SQL aliases.
+ * Percentiles serialize to `pN` (e.g. `p50`); every other variant uses its
+ * `type`.
+ */
+export type AggregationKey<A extends Aggregation = Aggregation> = A extends {
+  type: 'percentile';
+  value: infer V;
+}
+  ? V extends number
+    ? `p${V}`
+    : never
+  : A extends { type: infer T }
+    ? T & string
+    : never;
+
+const PERCENTILE_PATTERN = /^p(\d+(?:\.\d+)?)$/;
+
+/**
+ * Parses a raw aggregation string into an {@link Aggregation}.
+ *
+ * @returns The parsed aggregation, or `null` if the input is invalid.
+ */
+export function parseAggregation(raw: string): Aggregation | null {
+  switch (raw) {
+    case 'count':
+    case 'sum':
+    case 'avg':
+    case 'min':
+    case 'max':
+      return { type: raw };
+  }
+
+  const match = PERCENTILE_PATTERN.exec(raw);
+  if (match === null) {
+    return null;
+  }
+  const value = parseFloat(match[1]);
+  if (value < 0 || value > 100) {
+    return null;
+  }
+  return { type: 'percentile', value };
+}
+
+/**
+ * Returns the string key for an aggregation.
+ */
+export function aggregationKey(agg: Aggregation): AggregationKey {
+  return agg.type === 'percentile' ? `p${agg.value}` : agg.type;
+}
+
+/**
+ * Returns the SQL fragment for an aggregation function applied to `column`.
+ */
+export function aggregationToSql(
+  agg: Aggregation,
+  column: postgres.Fragment,
+): postgres.Fragment {
+  switch (agg.type) {
+    case 'count':
+      return sql`COUNT(${column})`;
+    case 'sum':
+      return sql`SUM(${column})`;
+    case 'avg':
+      return sql`AVG(${column})`;
+    case 'min':
+      return sql`MIN(${column})`;
+    case 'max':
+      return sql`MAX(${column})`;
+    case 'percentile':
+      if (agg.value < 0 || agg.value > 100) {
+        throw new InvalidQueryError(`Invalid percentile: ${agg.value}`);
+      }
+      return sql`PERCENTILE_CONT(${
+        agg.value / 100
+      }::float8) WITHIN GROUP (ORDER BY ${column})`;
+    default: {
+      const _exhaustive: never = agg;
+      throw new InvalidQueryError(
+        `Unknown aggregation: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Throws {@link InvalidQueryError} if any aggregation is semantically invalid.
+ */
+export function assertValidAggregations(aggregations: Aggregation[]): void {
+  // Currently, the only runtime invalid case is a bad percentile value.
+  const invalid = aggregations.filter(
+    (agg): agg is { type: 'percentile'; value: number } =>
+      agg.type === 'percentile' && (agg.value < 0 || agg.value > 100),
+  );
+  if (invalid.length > 0) {
+    throw new InvalidQueryError(
+      `Invalid percentile(s): ${invalid.map((agg) => agg.value).join(', ')}`,
+    );
+  }
+}
+
+/**
+ * Maps a SQL column alias back to its original field and aggregation key
+ * from which it was produced.
+ */
+export type AggregateAliases = Record<
+  string,
+  { field: string; aggKey: AggregationKey }
+>;
+
+/** Returns the column alias for an aggregation. */
+export function aggregateAlias(aggKey: AggregationKey, suffix: string): string {
+  // A percentile key (`pN`) may contain '.', which postgres reads as an
+  // identifier separator, so it is sanitized.
+  return `${aggKey.replace(/\./g, '_')}_${suffix}`;
+}
+
+/**
+ * Builds `<aggregation> AS <alias>` SELECT fragments for `aggregations` over
+ * `column`, recording each alias.
+ */
+export function aggregateSelectColumns(
+  field: string,
+  suffix: string,
+  column: postgres.Fragment,
+  aggregations: Aggregation[],
+): [postgres.Fragment[], AggregateAliases] {
+  const aliases: AggregateAliases = {};
+  const fragments = [];
+
+  for (const agg of aggregations) {
+    const aggKey = aggregationKey(agg);
+    const alias = aggregateAlias(aggKey, suffix);
+    aliases[alias] = { field, aggKey };
+    fragments.push(sql`${aggregationToSql(agg, column)} AS ${sql(alias)}`);
+  }
+
+  return [fragments, aliases];
+}
+
+function floatOrZero(value: unknown): number {
+  const num = parseFloat(value as string);
+  return Number.isNaN(num) ? 0 : num;
+}
+
+/**
+ * Unpacks one query result row into an aggregation result of per-field
+ * aggregations using an alias mapping.
+ */
+export function rowToAggregations(
+  row: Record<string, unknown>,
+  aliases: AggregateAliases,
+): Record<string, Record<string, number>> {
+  const result: Record<string, Record<string, number>> = {};
+  for (const [column, value] of Object.entries(row)) {
+    if (column === 'count') {
+      result['*'] = { count: parseInt(value as string) };
+      continue;
+    }
+    const alias = aliases[column];
+    if (alias === undefined) {
+      continue;
+    }
+    (result[alias.field] ??= {})[alias.aggKey] = floatOrZero(value as string);
+  }
+  return result;
+}
+
 export type BaseOperand = number | string | null;
 export type Operand = BaseOperand | Condition;
 export type Condition = [Operand, Operator, Operand];

--- a/web/app/api/query.ts
+++ b/web/app/api/query.ts
@@ -1,9 +1,120 @@
-import { Aggregation } from '@/actions/challenge';
+import { AggregationQuery } from '@/actions/challenge';
 import { InvalidQueryError } from '@/actions/errors';
-import { Comparator, Operator } from '@/actions/query';
+import {
+  Aggregation,
+  aggregationKey,
+  Comparator,
+  Operator,
+  parseAggregation,
+  parseSort,
+} from '@/actions/query';
 import { NextSearchParams } from '@/utils/url';
 
-const COMPARATOR_REGEX = /^(lt|gt|le|ge|eq|ne|>|<|>=|<=|=|==|!=)(\d+)$/;
+/**
+ * Parses an aggregation token from a request, accepting convenience aliases.
+ * @returns The parsed aggregation, or `null` if the token is invalid.
+ */
+export function parseAggregationParam(token: string): Aggregation | null {
+  return parseAggregation(token === 'median' ? 'p50' : token);
+}
+
+/**
+ * Normalizes the aggregation token in a sort string to its canonical key,
+ * applying the same aliases as {@link parseAggregationParam}.
+ * Non-aggregation sort fields are left untouched.
+ */
+export function normalizeSortAggregation(sort: string): string {
+  const { direction, field, options } = parseSort(sort);
+
+  const colon = field.lastIndexOf(':');
+  const prefix = colon === -1 ? '' : field.slice(0, colon + 1);
+  const token = colon === -1 ? field : field.slice(colon + 1);
+
+  const parsed = parseAggregationParam(token);
+  const normalized = parsed === null ? token : aggregationKey(parsed);
+  const suffix = options === undefined ? '' : `#${options}`;
+  return `${direction}${prefix}${normalized}${suffix}`;
+}
+
+type RequestedKeyAliases = Record<string, Record<string, string>>;
+
+/**
+ * Parses aggregation query URL parameters into an aggregation query and an
+ * alias mapping back to the requested tokens.
+ *
+ * @param params Raw URL parameters.
+ * @returns Parsed aggregations and aliases, or `null` if any param is invalid.
+ */
+export function parseAggregateParams(
+  params: string[],
+): { aggregations: AggregationQuery; aliases: RequestedKeyAliases } | null {
+  const aggregations: AggregationQuery = { '*': { type: 'count' } };
+  const aliases: RequestedKeyAliases = {};
+
+  for (const param of params) {
+    const separator = param.lastIndexOf(':');
+    const field = param.slice(0, separator);
+    const tokens = param.slice(separator + 1).split(',');
+    const parsed = tokens.map(parseAggregationParam);
+    if (parsed.length === 0 || parsed.some((agg) => agg === null)) {
+      return null;
+    }
+
+    const aggs = parsed as Aggregation[];
+    aggregations[field] = aggs;
+    tokens.forEach((token, i) => {
+      const key = aggregationKey(aggs[i]);
+      if (key !== token) {
+        (aliases[field] ??= {})[key] = token;
+      }
+    });
+  }
+
+  return { aggregations, aliases };
+}
+
+/**
+ * Replaces canonical aggregation keys with user-requested aliases in place.
+ *
+ * @param result Aggregation result returned by the query.
+ * @param depth Number of grouping levels in the result.
+ * @param aliases User's field alias mapping.
+ */
+export function restoreAggregateAliases(
+  result: Record<string, unknown>,
+  depth: number,
+  aliases: RequestedKeyAliases,
+): void {
+  if (Object.keys(aliases).length === 0) {
+    return;
+  }
+
+  if (depth > 0) {
+    for (const group of Object.values(result)) {
+      restoreAggregateAliases(
+        group as Record<string, unknown>,
+        depth - 1,
+        aliases,
+      );
+    }
+    return;
+  }
+
+  for (const [field, renames] of Object.entries(aliases)) {
+    const aggs = result[field] as Record<string, number> | undefined;
+    if (aggs === undefined) {
+      continue;
+    }
+    for (const [key, token] of Object.entries(renames)) {
+      if (key in aggs) {
+        aggs[token] = aggs[key];
+        delete aggs[key];
+      }
+    }
+  }
+}
+
+const COMPARATOR_REGEX = /^(lt|gt|le|ge|eq|ne|>=|<=|==|!=|=|>|<)(\d+)$/;
 const SPREAD_REGEX = /^(\d+)?(\.\.)(\d+)?$/;
 const VALUE_REGEX = /^[a-zA-Z0-9_]+$/;
 
@@ -135,8 +246,8 @@ export function numericComparatorParam(
   param: string,
 ): Comparator<number> | undefined {
   return comparatorParam(searchParams, param, (v) => {
-    const value = parseInt(v);
-    if (isNaN(value)) {
+    const value = Number(v);
+    if (!Number.isFinite(value)) {
       throw new InvalidQueryError(`${param}: Invalid numeric value ${v}`);
     }
     return value;
@@ -169,16 +280,6 @@ export function expectSingle(
   }
 
   return value;
-}
-
-/**
- * Returns true if the given string is a valid aggregation.
- *
- * @param agg The string to check.
- * @returns True if the string is a valid aggregation, false otherwise.
- */
-export function isAggregation(agg: string): agg is Aggregation {
-  return ['count', 'sum', 'avg', 'min', 'max'].includes(agg);
 }
 
 /**

--- a/web/app/api/v1/challenges/query.ts
+++ b/web/app/api/v1/challenges/query.ts
@@ -1,7 +1,13 @@
 import { ChallengeMode, SplitType } from '@blert/common';
 
-import { ChallengeQuery, SortQuery, SortableFields } from '@/actions/challenge';
-import { Comparator, Condition, Operator, parseQuery } from '@/actions/query';
+import { ChallengeQuery, SortableFields } from '@/actions/challenge';
+import {
+  Comparator,
+  Condition,
+  Operator,
+  parseQuery,
+  SortQuery,
+} from '@/actions/query';
 import {
   dateComparatorParam,
   expectSingle,

--- a/web/app/api/v1/challenges/stats/route.ts
+++ b/web/app/api/v1/challenges/stats/route.ts
@@ -1,15 +1,18 @@
 import { NextRequest } from 'next/server';
 
-import { isAggregation } from '@/api/query';
+import { AggregationKey, SortQuery } from '@/actions/query';
 import {
-  Aggregation,
-  AggregationQuery,
   ChallengeQuery,
   QueryOptions,
-  SortQuery,
   aggregateChallenges,
 } from '@/actions/challenge';
 import { withApiRoute } from '@/api/handler';
+import {
+  restoreAggregateAliases,
+  parseAggregateParams,
+  parseAggregationParam,
+  normalizeSortAggregation,
+} from '@/api/query';
 
 import { parseChallengeQueryParams } from '../query';
 
@@ -64,29 +67,23 @@ export const GET = withApiRoute(
     }
 
     if (searchParams.has('sort')) {
-      const sort = searchParams.get('sort')!;
-      if (!sort.startsWith('-') && !sort.startsWith('+')) {
+      const raw = searchParams.get('sort')!;
+      if (!raw.startsWith('-') && !raw.startsWith('+')) {
         return new Response(null, { status: 400 });
       }
-      if (!isAggregation(sort.slice(1))) {
+      const sort = normalizeSortAggregation(raw);
+      if (parseAggregationParam(sort.slice(1)) === null) {
         return new Response(null, { status: 400 });
       }
 
-      options.sort = sort as SortQuery<Aggregation>;
+      options.sort = sort as SortQuery<AggregationKey>;
     }
 
-    const aggregations: AggregationQuery = { '*': 'count' };
-    for (const aggregationOption of searchParams.getAll('aggregate')) {
-      const separator = aggregationOption.lastIndexOf(':');
-      const field = aggregationOption.slice(0, separator);
-      const operations = aggregationOption.slice(separator + 1).split(',');
-
-      if (operations.length === 0 || !operations.every(isAggregation)) {
-        return new Response(null, { status: 400 });
-      }
-
-      aggregations[field] = operations;
+    const parsed = parseAggregateParams(searchParams.getAll('aggregate'));
+    if (parsed === null) {
+      return new Response(null, { status: 400 });
     }
+    const { aggregations, aliases } = parsed;
 
     const result = await aggregateChallenges(
       query,
@@ -98,6 +95,11 @@ export const GET = withApiRoute(
       return new Response(null, { status: 404 });
     }
 
+    restoreAggregateAliases(
+      result as Record<string, unknown>,
+      groupings.length,
+      aliases,
+    );
     return Response.json(result);
   },
 );

--- a/web/app/api/v1/sessions/stats/route.ts
+++ b/web/app/api/v1/sessions/stats/route.ts
@@ -1,14 +1,16 @@
 import { NextRequest } from 'next/server';
 
-import { isAggregation } from '@/api/query';
+import { AggregationKey, SortQuery } from '@/actions/query';
 import {
   aggregateSessions,
-  Aggregation,
-  AggregationQuery,
   SessionAggregationOptions,
-  SortQuery,
 } from '@/actions/challenge';
 import { withApiRoute } from '@/api/handler';
+import {
+  restoreAggregateAliases,
+  parseAggregateParams,
+  normalizeSortAggregation,
+} from '@/api/query';
 
 import { parseSessionQueryParams } from '../query';
 
@@ -28,25 +30,18 @@ export const GET = withApiRoute(
     }
 
     if (searchParams.has('sort')) {
-      const sort = searchParams.get('sort')!;
-      if (!sort.startsWith('-') && !sort.startsWith('+')) {
+      const raw = searchParams.get('sort')!;
+      if (!raw.startsWith('-') && !raw.startsWith('+')) {
         return new Response(null, { status: 400 });
       }
-      options.sort = sort as SortQuery<Aggregation>;
+      options.sort = normalizeSortAggregation(raw) as SortQuery<AggregationKey>;
     }
 
-    const aggregations: AggregationQuery = { '*': 'count' };
-    for (const aggregationOption of searchParams.getAll('aggregate')) {
-      const separator = aggregationOption.lastIndexOf(':');
-      const field = aggregationOption.slice(0, separator);
-      const operations = aggregationOption.slice(separator + 1).split(',');
-
-      if (operations.length === 0 || !operations.every(isAggregation)) {
-        return new Response(null, { status: 400 });
-      }
-
-      aggregations[field] = operations;
+    const parsed = parseAggregateParams(searchParams.getAll('aggregate'));
+    if (parsed === null) {
+      return new Response(null, { status: 400 });
     }
+    const { aggregations, aliases } = parsed;
 
     const groupings = (searchParams.get('group') ?? '')
       .split(',')
@@ -59,6 +54,13 @@ export const GET = withApiRoute(
       options,
       groupings,
     );
+    if (result !== null) {
+      restoreAggregateAliases(
+        result as Record<string, unknown>,
+        groupings.length,
+        aliases,
+      );
+    }
     return Response.json(result);
   },
 );

--- a/web/app/players/[username]/layout.tsx
+++ b/web/app/players/[username]/layout.tsx
@@ -126,7 +126,7 @@ export default async function PlayerLayout({
         {
           party: [username],
         },
-        { challengeTicks: 'sum' },
+        { challengeTicks: { type: 'sum' } },
       ),
       loadPbsForPlayer(username),
       getSignedInUserId(),

--- a/web/app/players/[username]/page.tsx
+++ b/web/app/players/[username]/page.tsx
@@ -32,11 +32,11 @@ export default async function PlayerOverview({
     topPartners,
   ] = await Promise.all([
     loadPbsForPlayer(username),
-    aggregateChallenges(query, { '*': 'count' }, {}, 'status'),
-    aggregateChallenges(query, { '*': 'count' }, {}, 'scale'),
+    aggregateChallenges(query, { '*': { type: 'count' } }, {}, 'status'),
+    aggregateChallenges(query, { '*': { type: 'count' } }, {}, 'scale'),
     aggregateChallenges(
       { ...query, startTime: ['>=', oneYearAgo] },
-      { '*': 'count' },
+      { '*': { type: 'count' } },
       {},
       'startTime',
     ),

--- a/web/app/search/challenges/context.ts
+++ b/web/app/search/challenges/context.ts
@@ -1,10 +1,7 @@
 import { ChallengeStatus, Stage } from '@blert/common';
 
-import {
-  ExtraChallengeFields,
-  SortQuery,
-  SortableFields,
-} from '@/actions/challenge';
+import { ExtraChallengeFields, SortableFields } from '@/actions/challenge';
+import { SortQuery } from '@/actions/query';
 import { Comparator } from '@/components/tick-input';
 import { NextSearchParams, UrlParam, UrlParams } from '@/utils/url';
 

--- a/web/app/search/challenges/page.tsx
+++ b/web/app/search/challenges/page.tsx
@@ -97,13 +97,16 @@ export default async function SearchPage({
         return challenges;
       },
     ),
-    aggregateChallenges(baseQuery, { '*': 'count' }, queryOptions).then(
-      (result) =>
-        result !== null
-          ? {
-              count: result['*'].count,
-            }
-          : { count: 0 },
+    aggregateChallenges(
+      baseQuery,
+      { '*': { type: 'count' } },
+      queryOptions,
+    ).then((result) =>
+      result !== null
+        ? {
+            count: result['*'].count,
+          }
+        : { count: 0 },
     ),
   ]);
 

--- a/web/app/search/challenges/table.tsx
+++ b/web/app/search/challenges/table.tsx
@@ -17,9 +17,9 @@ import {
 import {
   ChallengeOverview,
   ExtraChallengeFields,
-  SortQuery,
   SortableFields,
 } from '@/actions/challenge';
+import { SortQuery } from '@/actions/query';
 import Button from '@/components/button';
 import Input from '@/components/input';
 import Modal from '@/components/modal';

--- a/web/app/trends/challenge-stats.tsx
+++ b/web/app/trends/challenge-stats.tsx
@@ -83,7 +83,12 @@ export default function ChallengeStats({
           fetch(`/api/v1/challenges/stats?type=${challenge}&group=status`)
             .then((res) => res.json())
             .then(
-              (res: GroupedAggregationResult<{ '*': 'count' }, ['status']>) => {
+              (
+                res: GroupedAggregationResult<
+                  { '*': { type: 'count' } },
+                  ['status']
+                >,
+              ) => {
                 const completions =
                   res[ChallengeStatus.COMPLETED]?.['*'].count ?? 0;
                 const resets = res[ChallengeStatus.RESET]?.['*'].count ?? 0;
@@ -101,7 +106,7 @@ export default function ChallengeStats({
             .then(
               (
                 res: GroupedAggregationResult<
-                  { '*': 'count' },
+                  { '*': { type: 'count' } },
                   ['stage', 'status']
                 >,
               ) => {


### PR DESCRIPTION
Updates the challenge and session aggregation functions to accept percentiles as `p{N}`, alongside their corresponding REST endpoints. Extracts some duplicate aggregation parsing and result building code from the two into shared helpers.