### PR TITLE
web: Add aggregation footer to search table

### DIFF
--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -2,6 +2,7 @@ import {
   ChallengeMode,
   ChallengeStatus,
   ChallengeType,
+  SplitType,
   Stage,
   SessionStatus,
   normalizeRsn,
@@ -1209,6 +1210,67 @@ describe('challenges', () => {
             'scale',
           ),
         ).rejects.toThrow(InvalidQueryError);
+      });
+    });
+
+    describe('split aggregates', () => {
+      beforeEach(async () => {
+        const ticks = [1150, 1200, 1250, 1300];
+        const challenges = ticks.map((challenge_ticks, i) => ({
+          session_id: sessionId,
+          uuid: `e000000${i}-0000-0000-0000-000000000000`,
+          type: ChallengeType.TOB,
+          status: ChallengeStatus.COMPLETED,
+          start_time: new Date('2024-03-01T10:00:00Z'),
+          scale: 5,
+          challenge_ticks,
+        }));
+        const inserted = await sql`
+          INSERT INTO challenges ${sql(challenges, [
+            'session_id',
+            'uuid',
+            'type',
+            'status',
+            'start_time',
+            'scale',
+            'challenge_ticks',
+          ])} RETURNING id
+        `;
+        const ids = inserted.map((row) => row.id as number);
+
+        // Two accurate Bloat splits, one inaccurate, and one challenge with no
+        // split at all, so the split's sample diverges from the full four.
+        const splits = [
+          { challenge_id: ids[0], ticks: 65, accurate: true },
+          { challenge_id: ids[1], ticks: 70, accurate: true },
+          { challenge_id: ids[2], ticks: 83, accurate: false },
+        ].map((s) => ({ ...s, type: SplitType.TOB_BLOAT, scale: 5 }));
+        await sql`
+          INSERT INTO challenge_splits ${sql(splits, [
+            'challenge_id',
+            'type',
+            'scale',
+            'ticks',
+            'accurate',
+          ])}
+        `;
+      });
+
+      it('aggregates a split without restricting unrelated columns', async () => {
+        const bloat = `splits:${SplitType.TOB_BLOAT}`;
+        const result = await aggregateChallenges(
+          { scale: ['==', 5] },
+          {
+            challengeTicks: [{ type: 'count' }, { type: 'avg' }],
+            [bloat]: [{ type: 'count' }, { type: 'avg' }],
+          },
+          { accurateSplits: true },
+        );
+
+        // All four challenges count despite only three having a split and only
+        // two an accurate one.
+        expect(result!.challengeTicks).toEqual({ count: 4, avg: 1225 });
+        expect(result![bloat]).toEqual({ count: 2, avg: 67.5 });
       });
     });
   });

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -397,6 +397,22 @@ export type SortableFields =
   | TobSortableFields
   | MokhaiotlSortableFields;
 
+export type TobQueryableField = `tob:${keyof Pick<
+  TobChallengeStats,
+  | 'bloatDownCount'
+  | 'nylocasPreCapStalls'
+  | 'nylocasPostCapStalls'
+  | 'xarpusHealing'
+  | 'verzikRedsCount'
+>}`;
+export type MokhaiotlQueryableField =
+  `mok:${keyof Pick<MokhaiotlChallengeStats, 'delve' | 'maxCompletedDelve'>}`;
+export type QueryableField =
+  | BasicSortableFields
+  | SplitSortableFields
+  | TobQueryableField
+  | MokhaiotlQueryableField;
+
 export type SingleOrArray<T> = T | T[];
 
 export type TobQuery = {
@@ -1287,15 +1303,16 @@ export async function aggregateChallenges<
     const [tableField, table] = shorthandToFullField(camelToSnake(field));
     const sqlTable = table === 'challenges' ? queryTable : sql(table);
 
+    // Per-aggregate filter so a split's accuracy restriction applies only to
+    // its own aggregate rather than the whole query's WHERE clause.
+    let filter: postgres.Fragment | undefined;
+
     if (field.startsWith('splits:')) {
       const split = parseInt(field.slice(7)) as SplitType;
-      addSplitsTable(
-        split,
-        queryTable,
-        joins,
-        conditions,
-        options.accurateSplits,
-      );
+      addSplitsTable(split, queryTable, joins, conditions);
+      if (options.accurateSplits) {
+        filter = sql`${sqlTable}.accurate`;
+      }
     } else if (
       table !== 'challenges' &&
       joins.find((j) => j.tableName === table) === undefined
@@ -1314,6 +1331,7 @@ export async function aggregateChallenges<
       `${table}_${tableField}`,
       column,
       aggregations,
+      filter,
     );
     Object.assign(aliases, fieldAliases);
     return fragments;

--- a/web/app/actions/query.ts
+++ b/web/app/actions/query.ts
@@ -319,6 +319,7 @@ export function aggregateSelectColumns(
   suffix: string,
   column: postgres.Fragment,
   aggregations: Aggregation[],
+  filter?: postgres.Fragment,
 ): [postgres.Fragment[], AggregateAliases] {
   const aliases: AggregateAliases = {};
   const fragments = [];
@@ -327,7 +328,12 @@ export function aggregateSelectColumns(
     const aggKey = aggregationKey(agg);
     const alias = aggregateAlias(aggKey, suffix);
     aliases[alias] = { field, aggKey };
-    fragments.push(sql`${aggregationToSql(agg, column)} AS ${sql(alias)}`);
+    const aggregate = aggregationToSql(agg, column);
+    const filtered =
+      filter === undefined
+        ? aggregate
+        : sql`${aggregate} FILTER (WHERE ${filter})`;
+    fragments.push(sql`${filtered} AS ${sql(alias)}`);
   }
 
   return [fragments, aliases];

--- a/web/app/search/challenges/__tests__/use-aggregate-stats.test.ts
+++ b/web/app/search/challenges/__tests__/use-aggregate-stats.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment jsdom
+ */
+import { ChallengeStatus } from '@blert/common';
+import { act, renderHook } from '@testing-library/react';
+
+import { Comparator } from '@/components/tick-input';
+
+import { defaultSearchFilters } from '../context';
+import {
+  aggregateStatsQuery,
+  AggregateStats,
+  useAggregateStats,
+} from '../use-aggregate-stats';
+
+type Deferred<T> = { promise: Promise<T>; resolve: (value: T) => void };
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function jsonResponse(data: AggregateStats): Response {
+  return { ok: true, json: () => Promise.resolve(data) } as unknown as Response;
+}
+
+describe('useAggregateStats', () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    global.fetch = realFetch;
+  });
+
+  it('discards a superseded response that resolves after the query changes', async () => {
+    const debounceMs = 200;
+
+    const stale = deferred<Response>();
+    const fresh = deferred<Response>();
+    const fetchMock = jest
+      .fn()
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const filters = defaultSearchFilters();
+    const { result, rerender } = renderHook(
+      ({ fields }) => useAggregateStats(filters, fields, [], debounceMs),
+      { initialProps: { fields: ['challengeTicks'] } },
+    );
+
+    // Fire the first request, then supersede it before it resolves.
+    await act(async () => {
+      jest.advanceTimersByTime(debounceMs);
+    });
+    rerender({ fields: ['overallTicks'] });
+    await act(async () => {
+      jest.advanceTimersByTime(debounceMs);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const freshStats: AggregateStats = {
+      overallTicks: { count: 5, avg: 100, p50: 90 },
+    };
+    const staleStats: AggregateStats = {
+      challengeTicks: { count: 9, avg: 700, p50: 250 },
+    };
+
+    // The current request settles first, then the superseded one resolves last,
+    // which should be ignored.
+    await act(async () => {
+      fresh.resolve(jsonResponse(freshStats));
+    });
+    await act(async () => {
+      stale.resolve(jsonResponse(staleStats));
+    });
+
+    expect(result.current.stats).toEqual(freshStats);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(false);
+  });
+
+  it('coalesces a burst of query changes into a single request', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(jsonResponse({}));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const debounceMs = 200;
+
+    const filters = defaultSearchFilters();
+    const { rerender } = renderHook(
+      ({ fields }) => useAggregateStats(filters, fields, [], debounceMs),
+      { initialProps: { fields: ['challengeTicks'] } },
+    );
+
+    // Three changes, each landing before the previous debounce elapses.
+    for (const fields of [['overallTicks'], ['totalDeaths']]) {
+      await act(async () => {
+        jest.advanceTimersByTime(debounceMs - 100);
+      });
+      rerender({ fields });
+    }
+    await act(async () => {
+      jest.advanceTimersByTime(debounceMs - 100);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Only a single request is made.
+    await act(async () => {
+      jest.advanceTimersByTime(debounceMs);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('totalDeaths'),
+      expect.anything(),
+    );
+  });
+});
+
+describe('aggregateStatsQuery', () => {
+  it('returns an empty string when there are no fields', () => {
+    expect(aggregateStatsQuery(defaultSearchFilters(), [], [])).toBe('');
+  });
+
+  it('emits one repeated aggregate parameter per field', () => {
+    const query = aggregateStatsQuery(
+      defaultSearchFilters(),
+      ['challengeTicks', 'splits:102', 'tob:verzikRedsCount'],
+      [],
+    );
+    expect(new URLSearchParams(query).getAll('aggregate')).toEqual([
+      'challengeTicks:count,avg,p50',
+      'splits:102:count,avg,p50',
+      'tob:verzikRedsCount:count,avg,p50',
+    ]);
+  });
+
+  it('includes the active filters alongside the aggregates', () => {
+    const filters = defaultSearchFilters();
+    filters.status = [ChallengeStatus.COMPLETED];
+
+    const params = new URLSearchParams(
+      aggregateStatsQuery(filters, ['challengeTicks'], []),
+    );
+    expect(params.get('status')).toBe(String(ChallengeStatus.COMPLETED));
+    expect(params.getAll('aggregate')).toEqual([
+      'challengeTicks:count,avg,p50',
+    ]);
+  });
+
+  it('forwards the implicit split filter when sorting by a split', () => {
+    const params = new URLSearchParams(
+      aggregateStatsQuery(
+        defaultSearchFilters(),
+        ['splits:13'],
+        ['-splits:13'],
+      ),
+    );
+    expect(params.get('split:13')).toBe('ge0');
+  });
+
+  it('omits the implicit split filter when accurate splits are off', () => {
+    const filters = defaultSearchFilters();
+    filters.accurateSplits = false;
+
+    const params = new URLSearchParams(
+      aggregateStatsQuery(filters, ['splits:13'], ['-splits:13']),
+    );
+    expect(params.has('split:13')).toBe(false);
+  });
+
+  it('keeps an explicit split filter over the implicit one', () => {
+    const filters = defaultSearchFilters();
+    filters.splits.set(13, [Comparator.LESS_THAN, 100]);
+
+    const params = new URLSearchParams(
+      aggregateStatsQuery(filters, ['splits:13'], ['-splits:13']),
+    );
+    expect(params.get('split:13')).toBe('lt100');
+  });
+});

--- a/web/app/search/challenges/context.ts
+++ b/web/app/search/challenges/context.ts
@@ -291,6 +291,28 @@ export function filtersToUrlParams(filters: SearchFilters): UrlParams {
   return params;
 }
 
+/**
+ * Sorting by a split with accurate splits enabled implicitly limits results to
+ * challenges that have that split recorded. Returns the URL params encoding that
+ * filter, so results and aggregate stats summarize the same set of challenges.
+ */
+export function implicitSplitFilters(
+  filters: SearchFilters,
+  sort: SortQuery<SortableFields>[],
+): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (!filters.accurateSplits) {
+    return params;
+  }
+  for (const entry of sort) {
+    const field = entry.slice(1).split('#')[0];
+    if (field.startsWith('splits:')) {
+      params[`split:${field.slice(7)}`] = 'ge0';
+    }
+  }
+  return params;
+}
+
 export function extraFieldsToUrlParam(
   extraFields: ExtraChallengeFields,
 ): UrlParam {

--- a/web/app/search/challenges/search.tsx
+++ b/web/app/search/challenges/search.tsx
@@ -18,6 +18,7 @@ import {
   countActiveFilters,
   extraFieldsToUrlParam,
   filtersToUrlParams,
+  implicitSplitFilters,
   isDefaultSearchFilters,
 } from './context';
 import Filters, { resetChallengeFilters } from './filters';
@@ -86,7 +87,6 @@ function challengesQueryParams(
 ): [UrlParams, UrlParams] {
   const baseParams = filtersToUrlParams(context.filters);
 
-  const params: UrlParams = { ...baseParams };
   const sortParam = [];
 
   let hasTime = false;
@@ -131,19 +131,14 @@ function challengesQueryParams(
     }
   }
 
-  // When sorting by a split column with accurate splits enabled, only include
-  // challenges which have that split set.
-  if (context.filters.accurateSplits) {
-    for (const sort of sorts) {
-      const sortField = sort.slice(1).split('#')[0];
-      if (sortField.startsWith('splits:')) {
-        const splitType = sortField.slice(7);
-        if (baseParams[`split:${splitType}`] === undefined) {
-          baseParams[`split:${splitType}`] = 'ge0';
-        }
-      }
-    }
+  // Forward the implicit split filter without overriding an explicit one.
+  for (const [key, value] of Object.entries(
+    implicitSplitFilters(context.filters, sorts),
+  )) {
+    baseParams[key] ??= value;
   }
+
+  const params: UrlParams = { ...baseParams };
 
   if (action === FetchAction.LOAD) {
     params.after = context.pagination.after;

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -235,6 +235,49 @@
         }
       }
     }
+
+    tfoot.summary {
+      td {
+        background: var(--blert-surface-dark);
+        border-bottom: none;
+        padding-top: 8px;
+        padding-bottom: 8px;
+      }
+
+      tr:first-child td {
+        border-top: 2px solid rgba(var(--blert-purple-base), 0.3);
+        box-shadow: inset 0 7px 10px -8px rgba(0, 0, 0, 0.55);
+      }
+
+      .summaryLabel {
+        font-weight: 700;
+        font-size: 0.72em;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--blert-font-color-secondary);
+      }
+
+      .summarySkeleton {
+        display: inline-block;
+        width: 70%;
+        max-width: 44px;
+        height: 0.85em;
+        vertical-align: middle;
+        border-radius: 4px;
+        background: rgba(var(--blert-purple-base), 0.2);
+        animation: summaryPulse 1.2s ease-in-out infinite;
+      }
+    }
+
+    @keyframes summaryPulse {
+      0%,
+      100% {
+        opacity: 0.35;
+      }
+      50% {
+        opacity: 0.85;
+      }
+    }
   }
 
   .id {

--- a/web/app/search/challenges/table.tsx
+++ b/web/app/search/challenges/table.tsx
@@ -17,6 +17,7 @@ import {
 import {
   ChallengeOverview,
   ExtraChallengeFields,
+  QueryableField,
   SortableFields,
 } from '@/actions/challenge';
 import { SortQuery } from '@/actions/query';
@@ -36,6 +37,7 @@ import {
   PresetColumns,
   SelectedColumn,
 } from './types';
+import { ColumnAggregates, useAggregateStats } from './use-aggregate-stats';
 import { useSearchPresets } from './use-search-presets';
 
 import styles from './style.module.scss';
@@ -48,6 +50,10 @@ type ColumnExtraFieldsToggler = (
   add: boolean,
 ) => ExtraChallengeFields;
 
+type AggregateInfo = {
+  renderer: (value: number) => React.ReactNode;
+};
+
 type ColumnInfo = {
   name: string;
   fullName?: string;
@@ -55,8 +61,21 @@ type ColumnInfo = {
   toggleFields?: ColumnExtraFieldsToggler;
   align?: 'left' | 'right' | 'center';
   width?: number;
-  sortKey?: SortableFields;
+  /** The column's identity in the challenges API, if it has one. */
+  field?: QueryableField;
+  /** Whether the column can be sorted. Requires `field`. */
+  sortable?: boolean;
+  /** Whether and how the column can be aggregated. Requires `field`. */
+  aggregate?: AggregateInfo;
 };
+
+function aggregateTicks(value: number): string {
+  return ticksToFormattedSeconds(Math.round(value));
+}
+
+function aggregateNumber(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
 
 type PickType<T, U> = Pick<
   T,
@@ -122,7 +141,9 @@ function splitColumn(
     renderer: splitsRenderer(type),
     toggleFields: toggleSplitField(type),
     width,
-    sortKey: `splits:${type}`,
+    field: `splits:${type}`,
+    sortable: true,
+    aggregate: { renderer: aggregateTicks },
   };
 }
 
@@ -269,7 +290,8 @@ const COLUMNS: Record<Column, ColumnInfo> = {
       return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
     },
     width: 110,
-    sortKey: 'startTime',
+    field: 'startTime',
+    sortable: true,
   },
   [Column.TYPE]: {
     name: 'Type',
@@ -298,7 +320,8 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     name: 'Scale',
     align: 'right',
     renderer: (challenge) => challenge.party.length,
-    sortKey: 'scale',
+    field: 'scale',
+    sortable: true,
   },
   [Column.PARTY]: {
     name: 'Party',
@@ -310,7 +333,9 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Challenge Time',
     align: 'right',
     renderer: ticksRenderer('challengeTicks'),
-    sortKey: 'challengeTicks',
+    field: 'challengeTicks',
+    sortable: true,
+    aggregate: { renderer: aggregateTicks },
     width: 120,
   },
   [Column.OVERALL_TIME]: {
@@ -318,7 +343,9 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Overall Time',
     align: 'right',
     renderer: ticksRenderer('overallTicks'),
-    sortKey: 'overallTicks',
+    field: 'overallTicks',
+    sortable: true,
+    aggregate: { renderer: aggregateTicks },
     width: 100,
   },
   [Column.TOTAL_DEATHS]: {
@@ -326,7 +353,9 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Total Deaths',
     align: 'right',
     renderer: valueRenderer('totalDeaths'),
-    sortKey: 'totalDeaths',
+    field: 'totalDeaths',
+    sortable: true,
+    aggregate: { renderer: aggregateNumber },
   },
   [Column.MAIDEN_ROOM]: splitColumn(
     'Maiden',
@@ -623,6 +652,8 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Nylocas pre-cap stalls',
     align: 'right',
     renderer: (challenge) => challenge.tobStats?.nylocasPreCapStalls ?? '-',
+    field: 'tob:nylocasPreCapStalls',
+    aggregate: { renderer: aggregateNumber },
     toggleFields: includeStats,
   },
   [Column.TOB_NYLOCAS_POST_CAP_STALLS]: {
@@ -630,6 +661,8 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Nylocas post-cap stalls',
     align: 'right',
     renderer: (challenge) => challenge.tobStats?.nylocasPostCapStalls ?? '-',
+    field: 'tob:nylocasPostCapStalls',
+    aggregate: { renderer: aggregateNumber },
     toggleFields: includeStats,
   },
   [Column.TOB_VERZIK_REDS_COUNT]: {
@@ -637,6 +670,8 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Verzik reds spawns',
     align: 'right',
     renderer: (challenge) => challenge.tobStats?.verzikRedsCount ?? '-',
+    field: 'tob:verzikRedsCount',
+    aggregate: { renderer: aggregateNumber },
     toggleFields: includeStats,
   },
   [Column.TOB_XARPUS_HEALING]: {
@@ -644,7 +679,9 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Xarpus healing',
     align: 'right',
     renderer: (challenge) => challenge.tobStats?.xarpusHealing ?? '-',
-    sortKey: 'tob:xarpusHealing',
+    field: 'tob:xarpusHealing',
+    sortable: true,
+    aggregate: { renderer: aggregateNumber },
     toggleFields: includeStats,
   },
 
@@ -660,7 +697,8 @@ const COLUMNS: Record<Column, ColumnInfo> = {
     fullName: 'Mokhaiotl Completed',
     align: 'right',
     renderer: (challenge) => challenge.mokhaiotlStats?.maxCompletedDelve ?? '-',
-    sortKey: 'mok:maxCompletedDelve',
+    field: 'mok:maxCompletedDelve',
+    sortable: true,
     toggleFields: includeStats,
   },
 
@@ -803,6 +841,12 @@ export function extraFieldsForColumns(
   return extraFields;
 }
 
+const SUMMARY_ROWS: { key: keyof ColumnAggregates; label: string }[] = [
+  { key: 'p50', label: 'Median' },
+  { key: 'avg', label: 'Average' },
+  { key: 'count', label: 'n' },
+];
+
 type TableProps = {
   challenges: ChallengeOverview[];
   context: SearchContext;
@@ -889,6 +933,23 @@ export default function Table(props: TableProps) {
     setPresets,
   } = useSearchPresets();
 
+  const aggregateFields = useMemo(
+    () =>
+      selectedColumns
+        .map((c) => COLUMNS[c.column])
+        .filter(
+          (info) => info.aggregate !== undefined && info.field !== undefined,
+        )
+        .map((info) => info.field!),
+    [selectedColumns],
+  );
+  const { stats: aggregateStats, loading: aggregateLoading } =
+    useAggregateStats(
+      props.context.filters,
+      aggregateFields,
+      props.context.sort,
+    );
+
   useEffect(() => setSelectedChallenges([]), [props.challenges]);
 
   const { setContext } = props;
@@ -962,25 +1023,26 @@ export default function Table(props: TableProps) {
                 const column = COLUMNS[c.column];
                 let content;
 
-                if (props.context.sort && column.sortKey) {
+                if (props.context.sort && column.sortable && column.field) {
+                  const field = column.field as SortableFields;
                   const mainSort = props.context.sort[0];
                   let icon;
                   let nextSort: SortQuery<SortableFields>[];
                   const currentSort = mainSort.slice(1);
-                  if (currentSort === column.sortKey) {
+                  if (currentSort === field) {
                     icon = (
                       <i
                         className={`fas fa-sort-${mainSort.startsWith('+') ? 'up' : 'down'}`}
                       />
                     );
                     nextSort = mainSort.startsWith('+')
-                      ? [`-${column.sortKey}`]
+                      ? [`-${field}`]
                       : currentSort === 'startTime'
                         ? ['+startTime']
                         : ['-startTime'];
                   } else {
                     icon = <i className="fas fa-sort" />;
-                    nextSort = [`+${column.sortKey}`];
+                    nextSort = [`+${field}`];
                   }
                   content = (
                     <button
@@ -1149,6 +1211,64 @@ export default function Table(props: TableProps) {
               )
             )}
           </tbody>
+          {aggregateFields.length > 0 &&
+            props.loadError === null &&
+            props.challenges.length > 0 && (
+              <tfoot className={styles.summary}>
+                {SUMMARY_ROWS.map((row) => (
+                  <tr key={row.key}>
+                    {allColumns.map((c, idx) => {
+                      const column = COLUMNS[c.column];
+                      let width = column.width;
+                      if (width !== undefined && display.isCompact()) {
+                        width = Math.floor(width * 0.9);
+                      }
+
+                      if (idx === 0) {
+                        return (
+                          <td
+                            key={c.column}
+                            className={styles.summaryLabel}
+                            style={{ width }}
+                          >
+                            {row.label}
+                          </td>
+                        );
+                      }
+
+                      const { field, aggregate, align } = column;
+                      let content: React.ReactNode = null;
+                      if (field !== undefined && aggregate !== undefined) {
+                        const values = aggregateStats?.[field];
+                        if (values === undefined) {
+                          content = aggregateLoading ? (
+                            <span className={styles.summarySkeleton} />
+                          ) : (
+                            '-'
+                          );
+                        } else if (row.key === 'count') {
+                          content = values.count.toLocaleString();
+                        } else if (values.count === 0) {
+                          content = '-';
+                        } else {
+                          content = aggregate.renderer(values[row.key]!);
+                        }
+                      }
+
+                      return (
+                        <td
+                          key={c.column}
+                          style={{ textAlign: align ?? 'left', width }}
+                        >
+                          {content}
+                        </td>
+                      );
+                    })}
+                    <td style={{ width: 40, padding: 0 }} />
+                  </tr>
+                ))}
+              </tfoot>
+            )}
         </table>
       </div>
       {contextMenu && (
@@ -1215,14 +1335,15 @@ function ContextMenu({
     const column = COLUMNS[context.heading.column];
 
     if (column.name !== '') {
-      if (column.sortKey) {
+      if (column.sortable && column.field) {
+        const field = column.field as SortableFields;
         items.push({
           label: `Sort by ${column.fullName ?? column.name}`,
           icon: 'fas fa-arrow-up-wide-short',
           customAction: () =>
             setContext((context) => ({
               ...context,
-              sort: [`+${column.sortKey!}`],
+              sort: [`+${field}`],
               pagination: {},
             })),
         });
@@ -1232,7 +1353,7 @@ function ContextMenu({
           customAction: () =>
             setContext((context) => ({
               ...context,
-              sort: [`-${column.sortKey!}`],
+              sort: [`-${field}`],
               pagination: {},
             })),
         });

--- a/web/app/search/challenges/use-aggregate-stats.ts
+++ b/web/app/search/challenges/use-aggregate-stats.ts
@@ -1,0 +1,118 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { SortableFields } from '@/actions/challenge';
+import { SortQuery } from '@/actions/query';
+import { queryString } from '@/utils/url';
+
+import {
+  SearchFilters,
+  filtersToUrlParams,
+  implicitSplitFilters,
+} from './context';
+
+export type ColumnAggregates = {
+  count: number;
+  avg: number | null;
+  p50: number | null;
+};
+
+export type AggregateStats = Record<string, ColumnAggregates>;
+
+export type AggregateStatsState = {
+  stats: AggregateStats | null;
+  loading: boolean;
+  error: boolean;
+};
+
+/**
+ * Builds the stats query string for the given filters and aggregatable fields,
+ * fetching each field's sample size, mean, and median.
+ */
+export function aggregateStatsQuery(
+  filters: SearchFilters,
+  fields: string[],
+  sort: SortQuery<SortableFields>[],
+): string {
+  if (fields.length === 0) {
+    return '';
+  }
+  const search = new URLSearchParams(queryString(filtersToUrlParams(filters)));
+  // Match the implicit split filter the query applies so the footer
+  // summarizes the same set of challenges.
+  for (const [key, value] of Object.entries(
+    implicitSplitFilters(filters, sort),
+  )) {
+    if (!search.has(key)) {
+      search.set(key, value);
+    }
+  }
+  for (const field of fields) {
+    search.append('aggregate', `${field}:count,avg,p50`);
+  }
+  return search.toString();
+}
+
+const AGGREGATE_DEBOUNCE_MS = 500;
+
+/**
+ * Fetches summary statistics for the given fields over the current filter set.
+ */
+export function useAggregateStats(
+  filters: SearchFilters,
+  fields: string[],
+  sort: SortQuery<SortableFields>[],
+  debounceMs = AGGREGATE_DEBOUNCE_MS,
+): AggregateStatsState {
+  const [state, setState] = useState<AggregateStatsState>({
+    stats: null,
+    loading: false,
+    error: false,
+  });
+
+  const query = aggregateStatsQuery(filters, fields, sort);
+
+  useEffect(() => {
+    if (query === '') {
+      setState({ stats: null, loading: false, error: false });
+      return;
+    }
+
+    let active = true;
+    const controller = new AbortController();
+    // Show the loading state immediately so the footer never displays stale
+    // numbers during the debounce window, then defer the request itself.
+    setState({ stats: null, loading: true, error: false });
+
+    const timer = setTimeout(() => {
+      fetch(`/api/v1/challenges/stats?${query}`, { signal: controller.signal })
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`Stats request failed: ${res.status}`);
+          }
+          return res.json() as Promise<AggregateStats>;
+        })
+        .then((stats) => {
+          if (active) {
+            setState({ stats, loading: false, error: false });
+          }
+        })
+        .catch((error) => {
+          if (!active) {
+            return;
+          }
+          console.error('Failed to load aggregate stats', error);
+          setState({ stats: null, loading: false, error: true });
+        });
+    }, debounceMs);
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query, debounceMs]);
+
+  return state;
+}


### PR DESCRIPTION
Updates the search table to define columns that are meaningfully aggregatable, and if they exist, to fetch and render a footer showing count/mean/median of each relevant column.

Closes #267.