### PR TITLE
web: Only show aggregates with meaningful filters

### DIFF
--- a/web/app/search/challenges/__tests__/context.test.ts
+++ b/web/app/search/challenges/__tests__/context.test.ts
@@ -11,6 +11,7 @@ import { NextSearchParams, queryString } from '@/utils/url';
 
 import {
   SearchFilters,
+  aggregatesAreMeaningful,
   contextFromUrlParams,
   countActiveFilters,
   defaultSearchFilters,
@@ -232,5 +233,57 @@ describe('countActiveFilters', () => {
       },
     };
     expect(countActiveFilters(filters)).toBe(2);
+  });
+});
+
+describe('aggregatesAreMeaningful', () => {
+  function withFilters(
+    type: ChallengeType[],
+    scale: number[],
+    mode: ChallengeMode[] = [],
+  ): SearchFilters {
+    return { ...defaultSearchFilters(), type, scale, mode };
+  }
+
+  it('is false without a single type', () => {
+    expect(aggregatesAreMeaningful(defaultSearchFilters())).toBe(false);
+    expect(
+      aggregatesAreMeaningful(
+        withFilters([ChallengeType.TOB, ChallengeType.COLOSSEUM], [3]),
+      ),
+    ).toBe(false);
+  });
+
+  it('requires a single scale and mode for a variable-scale type', () => {
+    expect(aggregatesAreMeaningful(withFilters([ChallengeType.TOB], []))).toBe(
+      false,
+    );
+    expect(
+      aggregatesAreMeaningful(withFilters([ChallengeType.TOB], [3, 4])),
+    ).toBe(false);
+    expect(
+      aggregatesAreMeaningful(
+        withFilters(
+          [ChallengeType.TOB],
+          [3],
+          [ChallengeMode.TOB_REGULAR, ChallengeMode.TOB_HARD],
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      aggregatesAreMeaningful(
+        withFilters([ChallengeType.TOB], [5], [ChallengeMode.TOB_HARD]),
+      ),
+    ).toBe(true);
+  });
+
+  it('needs no scale for solo-only types', () => {
+    for (const type of [
+      ChallengeType.COLOSSEUM,
+      ChallengeType.INFERNO,
+      ChallengeType.MOKHAIOTL,
+    ]) {
+      expect(aggregatesAreMeaningful(withFilters([type], []))).toBe(true);
+    }
   });
 });

--- a/web/app/search/challenges/__tests__/summary-footer.test.tsx
+++ b/web/app/search/challenges/__tests__/summary-footer.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+
+import SummaryFooter, { SummaryColumn } from '../summary-footer';
+import { AggregateStats } from '../use-aggregate-stats';
+
+// First column is the label slot; col 3 has no field, so it stays blank.
+const COLUMNS: SummaryColumn[] = [
+  { key: 0 },
+  { key: 1, field: 'challengeTicks', render: (v) => `${v}t`, align: 'right' },
+  { key: 2, field: 'deaths', render: (v) => `${v}d`, align: 'right' },
+  { key: 3 },
+  { key: 4, field: 'reds', render: (v) => `${v}r`, align: 'right' },
+];
+
+const STATS: AggregateStats = {
+  challengeTicks: { count: 1234, avg: 700.4, p50: 259 },
+  deaths: { count: 5, avg: 0, p50: 0 },
+  reds: { count: 0, avg: 0, p50: 0 },
+};
+
+function rowText(container: HTMLElement): string[][] {
+  return Array.from(container.querySelectorAll('tfoot tr')).map((row) =>
+    Array.from(row.querySelectorAll('td')).map((td) => td.textContent ?? ''),
+  );
+}
+
+describe('SummaryFooter', () => {
+  it('renders a hint instead of stats when the cohort is not comparable', () => {
+    const { container } = render(
+      <table>
+        <SummaryFooter
+          columns={COLUMNS}
+          stats={null}
+          loading={false}
+          meaningful={false}
+        />
+      </table>,
+    );
+
+    expect(
+      screen.getByText(/Filter to a single challenge type and scale/),
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll('tfoot tr')).toHaveLength(1);
+    expect(screen.queryByText('Median')).not.toBeInTheDocument();
+  });
+
+  it('formats each aggregable column, distinguishing a real 0 from no data', () => {
+    const { container } = render(
+      <table>
+        <SummaryFooter
+          columns={COLUMNS}
+          stats={STATS}
+          loading={false}
+          meaningful
+        />
+      </table>,
+    );
+
+    // count uses toLocaleString; median/average go through the column renderer.
+    // `deaths` has a genuine 0 avg so it renders; `reds` has no data.
+    expect(rowText(container)).toEqual([
+      ['Median', '259t', '0d', '', '-', ''],
+      ['Average', '700.4t', '0d', '', '-', ''],
+      ['n', '1,234', '5', '', '0', ''],
+    ]);
+  });
+
+  it('shows skeletons in aggregable cells while loading before data arrives', () => {
+    const { container } = render(
+      <table>
+        <SummaryFooter columns={COLUMNS} stats={null} loading meaningful />
+      </table>,
+    );
+
+    // Three aggregable columns across three rows, no data yet.
+    expect(container.querySelectorAll('tfoot td span')).toHaveLength(9);
+  });
+});

--- a/web/app/search/challenges/context.ts
+++ b/web/app/search/challenges/context.ts
@@ -1,4 +1,4 @@
-import { ChallengeStatus, Stage } from '@blert/common';
+import { ChallengeStatus, ChallengeType, Stage } from '@blert/common';
 
 import { ExtraChallengeFields, SortableFields } from '@/actions/challenge';
 import { SortQuery } from '@/actions/query';
@@ -214,6 +214,33 @@ export function defaultSearchFilters(): SearchFilters {
  */
 export function isDefaultSearchFilters(filters: SearchFilters): boolean {
   return filters.accurateSplits && countActiveFilters(filters) === 1;
+}
+
+/**
+ * Whether the filters define a result set over which aggregates are meaningful.
+ */
+export function aggregatesAreMeaningful(filters: SearchFilters): boolean {
+  if (filters.type.length !== 1) {
+    return false;
+  }
+  const [type] = filters.type;
+
+  switch (type) {
+    case ChallengeType.TOB:
+    case ChallengeType.COX:
+    case ChallengeType.TOA:
+      return filters.mode.length === 1 && filters.scale.length === 1;
+
+    // Solo challenges.
+    case ChallengeType.COLOSSEUM:
+    case ChallengeType.INFERNO:
+    case ChallengeType.MOKHAIOTL:
+      return true;
+
+    default:
+      const _exhaustive: never = type;
+      return false;
+  }
 }
 
 export type SearchContext = {

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -267,6 +267,19 @@
         background: rgba(var(--blert-purple-base), 0.2);
         animation: summaryPulse 1.2s ease-in-out infinite;
       }
+
+      .summaryHint {
+        text-align: center;
+        font-size: 0.85em;
+        font-style: italic;
+        color: var(--blert-font-color-secondary);
+
+        i {
+          margin: 0 6px 0 0;
+          font-style: normal;
+          color: var(--blert-purple);
+        }
+      }
     }
 
     @keyframes summaryPulse {

--- a/web/app/search/challenges/summary-footer.tsx
+++ b/web/app/search/challenges/summary-footer.tsx
@@ -1,0 +1,99 @@
+import { ReactNode } from 'react';
+
+import { AggregateStats, ColumnAggregates } from './use-aggregate-stats';
+
+import styles from './style.module.scss';
+
+export type SummaryColumn = {
+  key: number;
+  field?: string;
+  render?: (value: number) => ReactNode;
+  align?: 'left' | 'right' | 'center';
+  width?: number;
+};
+
+const ROWS: { key: keyof ColumnAggregates; label: string }[] = [
+  { key: 'p50', label: 'Median' },
+  { key: 'avg', label: 'Average' },
+  { key: 'count', label: 'n' },
+];
+
+type SummaryFooterProps = {
+  columns: SummaryColumn[];
+  stats: AggregateStats | null;
+  loading: boolean;
+  meaningful: boolean;
+};
+
+/**
+ * Renders the search table's summary rows from pre-resolved column descriptors.
+ */
+export default function SummaryFooter({
+  columns,
+  stats,
+  loading,
+  meaningful,
+}: SummaryFooterProps) {
+  if (!meaningful) {
+    return (
+      <tfoot className={styles.summary}>
+        <tr>
+          <td colSpan={columns.length + 1} className={styles.summaryHint}>
+            <i className="fas fa-circle-info" />
+            Filter to a single challenge type and scale to see aggregate stats.
+          </td>
+        </tr>
+      </tfoot>
+    );
+  }
+
+  return (
+    <tfoot className={styles.summary}>
+      {ROWS.map((row) => (
+        <tr key={row.key}>
+          {columns.map((col, idx) => {
+            if (idx === 0) {
+              return (
+                <td
+                  key={col.key}
+                  className={styles.summaryLabel}
+                  style={{ width: col.width }}
+                >
+                  {row.label}
+                </td>
+              );
+            }
+
+            let content: ReactNode = null;
+            if (col.field !== undefined && col.render !== undefined) {
+              const values = stats?.[col.field];
+              if (values === undefined) {
+                content = loading ? (
+                  <span className={styles.summarySkeleton} />
+                ) : (
+                  '-'
+                );
+              } else if (row.key === 'count') {
+                content = values.count.toLocaleString();
+              } else if (values.count === 0) {
+                content = '-';
+              } else {
+                content = col.render(values[row.key]!);
+              }
+            }
+
+            return (
+              <td
+                key={col.key}
+                style={{ textAlign: col.align ?? 'left', width: col.width }}
+              >
+                {content}
+              </td>
+            );
+          })}
+          <td style={{ width: 40, padding: 0 }} />
+        </tr>
+      ))}
+    </tfoot>
+  );
+}

--- a/web/app/search/challenges/table.tsx
+++ b/web/app/search/challenges/table.tsx
@@ -30,14 +30,19 @@ import { modeNameAndColor, statusNameAndColor } from '@/utils/challenge';
 import { ticksToFormattedSeconds } from '@/utils/tick';
 import { challengeUrl } from '@/utils/url';
 
-import { defaultSearchFilters, SearchContext } from './context';
+import {
+  aggregatesAreMeaningful,
+  defaultSearchFilters,
+  SearchContext,
+} from './context';
 import {
   Column,
   DEFAULT_SELECTED_COLUMNS,
   PresetColumns,
   SelectedColumn,
 } from './types';
-import { ColumnAggregates, useAggregateStats } from './use-aggregate-stats';
+import SummaryFooter, { SummaryColumn } from './summary-footer';
+import { useAggregateStats } from './use-aggregate-stats';
 import { useSearchPresets } from './use-search-presets';
 
 import styles from './style.module.scss';
@@ -841,12 +846,6 @@ export function extraFieldsForColumns(
   return extraFields;
 }
 
-const SUMMARY_ROWS: { key: keyof ColumnAggregates; label: string }[] = [
-  { key: 'p50', label: 'Median' },
-  { key: 'avg', label: 'Average' },
-  { key: 'count', label: 'n' },
-];
-
 type TableProps = {
   challenges: ChallengeOverview[];
   context: SearchContext;
@@ -943,10 +942,16 @@ export default function Table(props: TableProps) {
         .map((info) => info.field!),
     [selectedColumns],
   );
+
+  // Only request aggregates if the selected filters define a meaningful
+  // result set.
+  const showAggregates =
+    aggregateFields.length > 0 &&
+    aggregatesAreMeaningful(props.context.filters);
   const { stats: aggregateStats, loading: aggregateLoading } =
     useAggregateStats(
       props.context.filters,
-      aggregateFields,
+      showAggregates ? aggregateFields : [],
       props.context.sort,
     );
 
@@ -1003,6 +1008,21 @@ export default function Table(props: TableProps) {
   );
 
   const allColumns = [UUID_COLUMN, ...selectedColumns];
+
+  const summaryColumns: SummaryColumn[] = allColumns.map((c) => {
+    const column = COLUMNS[c.column];
+    let width = column.width;
+    if (width !== undefined && display.isCompact()) {
+      width = Math.floor(width * 0.9);
+    }
+    return {
+      key: c.column,
+      field: column.field,
+      render: column.aggregate?.renderer,
+      align: column.align,
+      width,
+    };
+  });
 
   return (
     <>
@@ -1214,60 +1234,12 @@ export default function Table(props: TableProps) {
           {aggregateFields.length > 0 &&
             props.loadError === null &&
             props.challenges.length > 0 && (
-              <tfoot className={styles.summary}>
-                {SUMMARY_ROWS.map((row) => (
-                  <tr key={row.key}>
-                    {allColumns.map((c, idx) => {
-                      const column = COLUMNS[c.column];
-                      let width = column.width;
-                      if (width !== undefined && display.isCompact()) {
-                        width = Math.floor(width * 0.9);
-                      }
-
-                      if (idx === 0) {
-                        return (
-                          <td
-                            key={c.column}
-                            className={styles.summaryLabel}
-                            style={{ width }}
-                          >
-                            {row.label}
-                          </td>
-                        );
-                      }
-
-                      const { field, aggregate, align } = column;
-                      let content: React.ReactNode = null;
-                      if (field !== undefined && aggregate !== undefined) {
-                        const values = aggregateStats?.[field];
-                        if (values === undefined) {
-                          content = aggregateLoading ? (
-                            <span className={styles.summarySkeleton} />
-                          ) : (
-                            '-'
-                          );
-                        } else if (row.key === 'count') {
-                          content = values.count.toLocaleString();
-                        } else if (values.count === 0) {
-                          content = '-';
-                        } else {
-                          content = aggregate.renderer(values[row.key]!);
-                        }
-                      }
-
-                      return (
-                        <td
-                          key={c.column}
-                          style={{ textAlign: align ?? 'left', width }}
-                        >
-                          {content}
-                        </td>
-                      );
-                    })}
-                    <td style={{ width: 40, padding: 0 }} />
-                  </tr>
-                ))}
-              </tfoot>
+              <SummaryFooter
+                columns={summaryColumns}
+                stats={aggregateStats}
+                loading={aggregateLoading}
+                meaningful={showAggregates}
+              />
             )}
         </table>
       </div>


### PR DESCRIPTION
Updates the search page to not fetch and display aggregate stats unless the user has selected a set of filters that would produce meaningful results. This avoids noise and reduces load on the database.