### PR TITLE
challenge: Ignore attacks on dead players in consistency check

### DIFF
--- a/challenge-server/merging/__tests__/merge-consistency.test.ts
+++ b/challenge-server/merging/__tests__/merge-consistency.test.ts
@@ -853,6 +853,52 @@ describe('MergeConsistencyChecker', () => {
       });
     });
 
+    it('ignores when an NPC targets a dead player', () => {
+      const ticks: TickStateArray = [
+        createTickState(
+          0,
+          [createPlayerState({ username: 'player1', clientId: 1 })],
+          [
+            createPlayerDeathEvent({
+              tick: 0,
+              name: 'player1',
+            }),
+            createNpcUpdateEvent({
+              tick: 0,
+              roomId: ROOM_ID_A,
+              npcId: NPC_ID,
+              x: 0,
+              y: 0,
+              hitpointsCurrent: 100,
+            }),
+          ],
+        ),
+        createTickState(
+          1,
+          [],
+          [
+            createNpcUpdateEvent({
+              tick: 1,
+              roomId: ROOM_ID_A,
+              npcId: NPC_ID,
+              x: 0,
+              y: 0,
+              hitpointsCurrent: 100,
+            }),
+            createNpcAttackEvent({
+              tick: 1,
+              roomId: ROOM_ID_A,
+              npcId: NPC_ID,
+              attackType: NpcAttack.TOB_VERZIK_P3_AUTO,
+              target: 'player1',
+            }),
+          ],
+        ),
+      ];
+
+      expect(runChecker(ticks)).toEqual([]);
+    });
+
     it('emits no issue when an attack has a null target', () => {
       const ticks: TickStateArray = [
         createTickState(

--- a/challenge-server/merging/merge-consistency.ts
+++ b/challenge-server/merging/merge-consistency.ts
@@ -413,14 +413,19 @@ export class MergeConsistencyChecker {
 
   private checkAttackTargetPresence(ticks: TickStateArray): void {
     // When an attack carries a non-null target, the target must be present in
-    // the same tick's state map. The plugin only sets a target it can
-    // observe, so passthrough preserves this. The merger combines attack and
-    // target data across multiple clients, so a merge bug could drop the
-    // target's state while keeping the attack's reference to it.
+    // the same tick's state map. The merger combines attack and target data
+    // across multiple clients, so a merge bug could drop the target's state
+    // while keeping the attack's reference to it.
+    //
+    // The exception to this is players who have died; some boss NPC attack
+    // have long wind-up times and can target a player who has recently died.
+    const deadPlayers = new Set<string>();
+
     for (const tickState of ticks) {
       if (tickState === null) {
         continue;
       }
+
       const tick = tickState.getTick();
       const npcs = tickState.getNpcs();
       const players = tickState.getPlayerStates();
@@ -450,6 +455,14 @@ export class MergeConsistencyChecker {
         if (targetName === null || targetName === undefined) {
           continue;
         }
+        if (deadPlayers.has(targetName)) {
+          // Ignore NPC attacks on dead players.
+          // TODO(frolv): This would ideally be smarter, but that requires
+          // investigating what exact patterns attacks on dead players take.
+          // Duplicate player deaths might also throw this off, but those are
+          // a hard rejection anyway so it doesn't affect the outcome.
+          continue;
+        }
         if (!players.get(targetName)) {
           this.issues.push({
             kind: 'ATTACK_TARGET_MISSING',
@@ -461,6 +474,10 @@ export class MergeConsistencyChecker {
           });
         }
       }
+
+      tickState.getEventsByType(Event.Type.PLAYER_DEATH).forEach((event) => {
+        deadPlayers.add(event.getPlayer()!.getName());
+      });
     }
   }
 


### PR DESCRIPTION
Changes the post-merge consistency actor presence check to not flag NPC attacks that target a missing player who has died earlier, as some NPC attacks have long wind-up times and can legitimately target a player who has recently died.