### PR TITLE
challenge: Correct for Nylocas event bugs

### DIFF
--- a/challenge-server/merging/__tests__/client-events.test.ts
+++ b/challenge-server/merging/__tests__/client-events.test.ts
@@ -19,7 +19,13 @@ import {
 
 import { ClientEvents, ClientAnomaly } from '../client-events';
 import { ChallengeInfo } from '../context';
-import { createEvent, createPlayerUpdateEvent } from './fixtures';
+import {
+  createEvent,
+  createNpcDeathEvent,
+  createNpcSpawnEvent,
+  createNpcUpdateEvent,
+  createPlayerUpdateEvent,
+} from './fixtures';
 
 type ProtoEventType = ProtoEvent.TypeMap[keyof ProtoEvent.TypeMap];
 type ProtoStage = StageMap[keyof StageMap];
@@ -391,6 +397,174 @@ describe('ClientEvents', () => {
       });
       // The snapshot rebuilds from empty, dropping the tick 0 weapon.
       expect(tick1State?.equipment[EquipmentSlot.WEAPON]).toBeNull();
+    });
+  });
+
+  describe('OSRS 238 Nylocas correction', () => {
+    const NYLO_ROOM = 100;
+
+    function nyloStage(stage = Stage.TOB_NYLOCAS) {
+      return {
+        stage,
+        status: StageStatus.STARTED,
+        accurate: true,
+        recordedTicks: 0,
+        serverTicks: null,
+      };
+    }
+
+    function nyloSpawn(
+      tick: number,
+      x: number,
+      y: number,
+      stage = Stage.TOB_NYLOCAS,
+    ) {
+      return createNpcSpawnEvent({
+        tick,
+        roomId: NYLO_ROOM,
+        npcId: 8342,
+        x,
+        y,
+        hitpointsCurrent: 8,
+        nylo: { wave: 1, parentRoomId: 0, big: false, style: 0, spawnType: 3 },
+        stage,
+      });
+    }
+
+    function nyloUpdate(tick: number, x: number, y: number) {
+      return createNpcUpdateEvent({
+        tick,
+        roomId: NYLO_ROOM,
+        npcId: 8342,
+        x,
+        y,
+        hitpointsCurrent: 8,
+        stage: Stage.TOB_NYLOCAS,
+      });
+    }
+
+    function nyloDeath(
+      tick: number,
+      x: number,
+      y: number,
+      stage = Stage.TOB_NYLOCAS,
+    ) {
+      return createNpcDeathEvent({
+        tick,
+        roomId: NYLO_ROOM,
+        npcId: 8342,
+        x,
+        y,
+        stage,
+      });
+    }
+
+    function deathCount(client: ClientEvents): number {
+      let count = 0;
+      for (const tickState of client.getTickStates()) {
+        count +=
+          tickState?.getEventsByType(ProtoEvent.Type.NPC_DEATH).length ?? 0;
+      }
+      return count;
+    }
+
+    it('interpolates a spurious death across an unambiguous straight-line move', () => {
+      const client = ClientEvents.fromRawEvents(1, challengeInfo, nyloStage(), [
+        nyloSpawn(1, 10, 10),
+        nyloUpdate(2, 11, 10),
+        nyloDeath(3, 11, 10), // frozen at the tick 2 tile
+        nyloSpawn(4, 13, 10), // respawn one tick later, two tiles east
+        nyloUpdate(5, 14, 10),
+        nyloDeath(6, 15, 10), // real death
+      ]);
+
+      // Only the terminal death survives; the spurious one becomes an update.
+      expect(deathCount(client)).toBe(1);
+      const corrected = client.getTickState(3)?.getNpcState(NYLO_ROOM);
+      expect(corrected).not.toBeNull();
+      expect(corrected!.x).toBe(12);
+      expect(corrected!.y).toBe(10);
+      const spawn = client.getTickState(4)?.getNpcState(NYLO_ROOM);
+      expect(spawn).not.toBeNull();
+      expect(spawn!.x).toBe(13);
+      expect(spawn!.y).toBe(10);
+    });
+
+    it('drops a spurious death when the implied move is ambiguous', () => {
+      const client = ClientEvents.fromRawEvents(1, challengeInfo, nyloStage(), [
+        nyloSpawn(1, 10, 10),
+        nyloUpdate(2, 11, 10),
+        nyloDeath(3, 11, 10),
+        nyloSpawn(4, 13, 11), // L-shaped move with no unique midpoint
+        nyloUpdate(5, 14, 11),
+        nyloDeath(6, 15, 11),
+      ]);
+
+      expect(deathCount(client)).toBe(1);
+      expect(client.getTickState(3)?.getNpcState(NYLO_ROOM)).toBeNull();
+    });
+
+    it('drops rather than interpolates when the boundary shows lag', () => {
+      const client = ClientEvents.fromRawEvents(1, challengeInfo, nyloStage(), [
+        nyloSpawn(1, 10, 10),
+        nyloUpdate(2, 11, 10),
+        nyloDeath(3, 11, 10),
+        nyloSpawn(4, 13, 10),
+        nyloUpdate(5, 14, 10),
+        nyloDeath(6, 15, 10),
+        createPlayerUpdateEvent({ tick: 3, name: 'player1', x: 0, y: 0 }),
+        createPlayerUpdateEvent({ tick: 4, name: 'player1', x: 4, y: 0 }),
+      ]);
+
+      expect(deathCount(client)).toBe(1);
+      expect(client.getTickState(3)?.getNpcState(NYLO_ROOM)).toBeNull();
+    });
+
+    it('collapses multiple spurious lifecycle events', () => {
+      const client = ClientEvents.fromRawEvents(1, challengeInfo, nyloStage(), [
+        nyloSpawn(1, 10, 10),
+        nyloDeath(2, 10, 10),
+        nyloSpawn(3, 10, 10),
+        nyloDeath(4, 10, 10),
+        nyloSpawn(5, 10, 10),
+        nyloDeath(6, 10, 10),
+      ]);
+
+      expect(deathCount(client)).toBe(1);
+      expect(
+        client.getTickState(6)?.getEventsByType(ProtoEvent.Type.NPC_DEATH)
+          .length,
+      ).toBe(1);
+    });
+
+    it('leaves a normal spawn/death lifecycle untouched', () => {
+      const client = ClientEvents.fromRawEvents(1, challengeInfo, nyloStage(), [
+        nyloSpawn(1, 10, 10),
+        nyloUpdate(2, 11, 10),
+        nyloDeath(3, 12, 10),
+      ]);
+
+      expect(deathCount(client)).toBe(1);
+      expect(
+        client.getTickState(3)?.getEventsByType(ProtoEvent.Type.NPC_DEATH)
+          .length,
+      ).toBe(1);
+    });
+
+    it('does not correct stages other than Nylocas', () => {
+      const client = ClientEvents.fromRawEvents(
+        1,
+        challengeInfo,
+        nyloStage(Stage.TOB_MAIDEN),
+        [
+          nyloSpawn(1, 10, 10, Stage.TOB_MAIDEN),
+          nyloDeath(2, 10, 10, Stage.TOB_MAIDEN),
+          nyloSpawn(3, 10, 10, Stage.TOB_MAIDEN),
+          nyloDeath(4, 10, 10, Stage.TOB_MAIDEN),
+        ],
+      );
+
+      expect(deathCount(client)).toBe(2);
     });
   });
 });

--- a/challenge-server/merging/__tests__/derivation.test.ts
+++ b/challenge-server/merging/__tests__/derivation.test.ts
@@ -121,13 +121,17 @@ describe('NylocasDerivedEvents', () => {
   it('emits stalls every 4 ticks after the natural stall, until next wave', () => {
     // Wave 1's natural stall is 4. Wave 2 spawns at tick 14, before what
     // would be the 4th stall.
-    const ticks = buildTimeline(
-      [
-        { tick: 0, events: [createNyloWaveSpawnEvent(0, 1)] },
-        { tick: 14, events: [createNyloWaveSpawnEvent(14, 2)] },
-      ],
-      20,
-    );
+    const timeline: { tick: number; events: ProtoEvent[] }[] = [];
+    for (let t = 0; t <= 18; t++) {
+      const events: ProtoEvent[] = [nyloUpdate(t, 1)];
+      if (t === 0) {
+        events.unshift(createNyloWaveSpawnEvent(0, 1, { roomCap: 1 }));
+      } else if (t === 14) {
+        events.unshift(createNyloWaveSpawnEvent(14, 2, { roomCap: 1 }));
+      }
+      timeline.push({ tick: t, events });
+    }
+    const ticks = buildTimeline(timeline, 20);
 
     new NylocasDerivedEvents(ChallengeMode.TOB_REGULAR).derive(ticks);
 
@@ -283,10 +287,9 @@ describe('NylocasDerivedEvents', () => {
         {
           tick: 0,
           events: [
-            createNyloWaveSpawnEvent(0, 1, { roomCap: 12 }),
+            createNyloWaveSpawnEvent(0, 1, { roomCap: 2 }),
             nyloUpdate(0, 1),
             nyloUpdate(0, 2),
-            nyloUpdate(0, 3),
           ],
         },
         {
@@ -306,7 +309,7 @@ describe('NylocasDerivedEvents', () => {
     const wave = stalls[0].getNyloWave()!;
     expect(wave.getWave()).toBe(1);
     expect(wave.getNylosAlive()).toBe(2);
-    expect(wave.getRoomCap()).toBe(12);
+    expect(wave.getRoomCap()).toBe(2);
   });
 
   it('populates coords on boss_spawn events', () => {
@@ -328,29 +331,42 @@ describe('NylocasDerivedEvents', () => {
     expect(bossEvents[0].getYCoord()).toBe(4248);
   });
 
-  it('synthesizes a tick state when a stall lands on a null tick', () => {
+  it('does not emit a stall on a null tick', () => {
     const ticks: TickStateArray = [
       createTickState(0, [], [createNyloWaveSpawnEvent(0, 1)]),
       null,
       null,
       null,
-      null, // tick 4: stall would fire here, but the tick is null
+      null, // would-be stall tick
       null,
       null,
       null,
     ];
 
     new NylocasDerivedEvents(ChallengeMode.TOB_REGULAR).derive(ticks);
+    expect(ticks[4]).toBeNull();
+  });
 
-    expect(ticks[4]).not.toBeNull();
+  it('does not emit a stall while below room capacity', () => {
+    const ticks = buildTimeline(
+      [
+        {
+          tick: 0,
+          events: [
+            createNyloWaveSpawnEvent(0, 1, { roomCap: 3 }),
+            nyloUpdate(0, 1),
+          ],
+        },
+        { tick: 4, events: [nyloUpdate(4, 1)] }, // one nylo alive, cap 3
+      ],
+      6,
+    );
+
+    new NylocasDerivedEvents(ChallengeMode.TOB_REGULAR).derive(ticks);
+
     expect(
-      ticks[4]!.getEventsByType(ProtoEvent.Type.TOB_NYLO_WAVE_STALL),
-    ).toHaveLength(1);
-    expect(
-      ticks[4]!
-        .getEventsByType(ProtoEvent.Type.TOB_NYLO_WAVE_STALL)[0]
-        .getTick(),
-    ).toBe(4);
+      tickEventsByTick(ticks, ProtoEvent.Type.TOB_NYLO_WAVE_STALL),
+    ).toEqual([]);
   });
 });
 

--- a/challenge-server/merging/client-events.ts
+++ b/challenge-server/merging/client-events.ts
@@ -24,6 +24,7 @@ import { ChallengeInfo } from './context';
 import logger from '../log';
 import { DERIVED_EVENT_TYPES } from './event';
 import { buildGraphicsStates } from './graphics';
+import { recordGameCorrection } from '../metrics';
 import {
   buildNpcStates,
   PlayerState,
@@ -32,6 +33,7 @@ import {
   TickStateArray,
   WithProvenance,
 } from './tick-state';
+import { chebyshev } from './world';
 
 const EMPTY_EQUIPMENT: PlayerState['equipment'] = {
   [EquipmentSlot.HEAD]: null,
@@ -91,6 +93,152 @@ type StageInfo = {
   recordedTicks: number;
   serverTicks: ServerTicks | null;
 };
+
+/**
+ * OSRS cache version 238 (2026-05-06) introduced some regressions into
+ * RuneLite's NPC tracking, where RuneLite's NPC map sometimes drops an NPC
+ * from its local world state. Since RuneLite emits spawn and respawn events
+ * based on deltas in its local state, this results in spurious events being
+ * fired, which the plugin then picks up.
+ *
+ * A plugin-side mitigation for this is not viable as it would require holding
+ * and delaying events. Instead, we correct the events on ingestion here. This
+ * is deliberately scoped to only Nylocas, as that is so far the only stage
+ * where issues have been observed.
+ *
+ * Specifically, this looks for intermediate death/spawn pairs for a specific
+ * room ID within its full lifecycle, and applies the following corrections:
+ *
+ * - Rewrites the spurious spawn event as an `NPC_UPDATE` as the two events
+ *   carry the same information, differing only by whether it was the first
+ *   time the NPC was seen.
+ *
+ * - Deletes the spurious death event, leaving a gap in the NPC's timeline, or:
+ *
+ * - If possible, rewrites the death event as an `NPC_UPDATE` at an interpolated
+ *   midpoint tile. This requires three conditions:
+ *
+ *   1. The death and respawn must occur on consecutive ticks.
+ *   2. The implied movement between the death and respawn must be unambiguous.
+ *      Nylos move 1 tile per tick, so this requires a straight line two tile
+ *      move in any direction.
+ *   3. No lag (impossible player movement) is detected at the boundary, since a
+ *      stall can leave the recorded tick numbers consecutive while losing real
+ *      ticks, which would invalidate the midpoint.
+ *
+ * @param events Client events for a Nylocas stage, sorted by tick.
+ * @param context Identifying information for logging.
+ * @returns The corrected event list.
+ */
+function tryApplyOsrs238NylocasCorrection(
+  events: Event[],
+  context: { challengeUuid: string; clientId: number },
+): Event[] {
+  const lifecycleById = new Map<number, Event[]>();
+  // Ticks where a player moved more than 2 tiles, signalling lost ticks.
+  const laggedTicks = new Set<number>();
+  const lastPlayer = new Map<string, { tick: number; x: number; y: number }>();
+
+  for (const event of events) {
+    const type = event.getType();
+    if (type === Event.Type.NPC_SPAWN || type === Event.Type.NPC_DEATH) {
+      const roomId = event.getNpc()!.getRoomId();
+      const list = lifecycleById.get(roomId);
+      if (list === undefined) {
+        lifecycleById.set(roomId, [event]);
+      } else {
+        list.push(event);
+      }
+    } else if (type === Event.Type.PLAYER_UPDATE) {
+      const name = event.getPlayer()!.getName();
+      const tick = event.getTick();
+      const position = { x: event.getXCoord(), y: event.getYCoord() };
+      const last = lastPlayer.get(name);
+      if (
+        last !== undefined &&
+        chebyshev(position, last) > 2 * (tick - last.tick)
+      ) {
+        laggedTicks.add(tick);
+      }
+      lastPlayer.set(name, { tick, ...position });
+    }
+  }
+
+  // Identify corrections without mutating, so the spawn/death scan below sees
+  // original event types.
+  const respawns = new Set<Event>();
+  const interpolatedDeaths: { event: Event; x: number; y: number }[] = [];
+  const droppedDeaths = new Set<Event>();
+
+  for (const lifecycle of lifecycleById.values()) {
+    for (let i = 0; i < lifecycle.length; i++) {
+      const death = lifecycle[i];
+      if (death.getType() !== Event.Type.NPC_DEATH) {
+        continue;
+      }
+      const respawn = lifecycle
+        .slice(i + 1)
+        .find((e) => e.getType() === Event.Type.NPC_SPAWN);
+      if (respawn === undefined) {
+        // Terminal death.
+        continue;
+      }
+      respawns.add(respawn);
+
+      // A stalled death on tick t freezes at the t-1 tile, and the spurious
+      // respawn carries the real t+1 tile. The intermediate (t) tile is only
+      // unique when the two-tick move is a straight line of length 2.
+      const dx = respawn.getXCoord() - death.getXCoord();
+      const dy = respawn.getYCoord() - death.getYCoord();
+      const consecutive = respawn.getTick() === death.getTick() + 1;
+      const unambiguous =
+        dx % 2 === 0 &&
+        dy % 2 === 0 &&
+        Math.abs(dx) <= 2 &&
+        Math.abs(dy) <= 2 &&
+        (dx !== 0 || dy !== 0);
+
+      const lagFree =
+        !laggedTicks.has(death.getTick()) &&
+        !laggedTicks.has(respawn.getTick());
+      if (consecutive && unambiguous && lagFree) {
+        interpolatedDeaths.push({
+          event: death,
+          x: death.getXCoord() + dx / 2,
+          y: death.getYCoord() + dy / 2,
+        });
+      } else {
+        droppedDeaths.add(death);
+      }
+    }
+  }
+
+  if (respawns.size === 0) {
+    return events;
+  }
+
+  for (const respawn of respawns) {
+    respawn.setType(Event.Type.NPC_UPDATE);
+  }
+  for (const { event, x, y } of interpolatedDeaths) {
+    event.setType(Event.Type.NPC_UPDATE);
+    event.setXCoord(x);
+    event.setYCoord(y);
+  }
+
+  logger.warn('osrs_238_nylocas_correction', {
+    challengeUuid: context.challengeUuid,
+    clientId: context.clientId,
+    respawnsRewritten: respawns.size,
+    deathsInterpolated: interpolatedDeaths.length,
+    deathsDropped: droppedDeaths.size,
+  });
+  recordGameCorrection('osrs238_nylocas');
+
+  return droppedDeaths.size === 0
+    ? events
+    : events.filter((e) => !droppedDeaths.has(e));
+}
 
 export class ClientEvents {
   private readonly clientId: number;
@@ -203,7 +351,16 @@ export class ClientEvents {
   ): ClientEvents {
     const anomalies = anomaliesParam ?? new Set<ClientAnomaly>();
 
-    const events = [...rawEvents].sort((a, b) => a.getTick() - b.getTick());
+    const sortedEvents = rawEvents.toSorted(
+      (a, b) => a.getTick() - b.getTick(),
+    );
+    const events =
+      stageInfo.stage === Stage.TOB_NYLOCAS
+        ? tryApplyOsrs238NylocasCorrection(sortedEvents, {
+            challengeUuid: challenge.uuid,
+            clientId,
+          })
+        : sortedEvents;
     if (stageInfo.recordedTicks === 0 && events.length > 0) {
       stageInfo.recordedTicks = events[events.length - 1].getTick();
     }

--- a/challenge-server/merging/derivation.ts
+++ b/challenge-server/merging/derivation.ts
@@ -105,12 +105,13 @@ export class NylocasDerivedEvents extends DerivedEventGenerator {
         }
       } else if (t === nextStallTick) {
         nextStallTick += NYLO_WAVE_CYCLE;
-        let target = tick;
+        const target = tick;
         if (target === null) {
-          target = new TickState(t, [], new Map(), new Map(), new Map());
-          ticks[t] = target;
+          continue;
         }
-        this.emit(target, this.stallEvent(target, wave, roomCap));
+        if (countNylosAlive(target) >= roomCap) {
+          this.emit(target, this.stallEvent(target, wave, roomCap));
+        }
       }
     }
   }

--- a/challenge-server/metrics.ts
+++ b/challenge-server/metrics.ts
@@ -199,6 +199,20 @@ export const recordClientReconnect = (
   });
 };
 
+/** A class of game data correction applied to a client's events on ingestion. */
+export type GameCorrectionType = 'osrs238_nylocas';
+
+const gameCorrections = new Counter({
+  name: 'challenge_server_game_corrections_total',
+  help: 'Game data corrections applied to client events during ingestion',
+  labelNames: ['type'] as const,
+  registers: [register],
+});
+
+export const recordGameCorrection = (type: GameCorrectionType): void => {
+  gameCorrections.inc({ type });
+};
+
 type ChallengeLifecycleState = 'active' | 'cleanup';
 
 const activeChallenges = new Gauge({


### PR DESCRIPTION
OSRS update 238 broke RuneLite's NPC state under certain conditions, causing some NPCs to randomly not appear in its world state. This results in RuneLite sending delayed and/or spurious NPC spawn/death events when it loses track of them. In practice, this is observed to occasionally happen at Nylocas.

This applies a correction to mitigate this issue on client ingestion. When constructing Nylocas events, it looks for additional death and spawn pairs on each Nylo ID and removes them, keeping only the first spawn and last death. If possible, it also attempts to interpolate a Nylo's position on a spurious death tick.

Additionally, delayed spawn events can cause the plugin to fail to identify waves, so this adds a guard to Nylocas event derivation to check how many Nylos are alive when emitting stall events instead of using timing alone.