### PR TITLE
challenge: Restrict queryability with corrections

### DIFF
--- a/challenge-server/merge-service/__tests__/policy.test.ts
+++ b/challenge-server/merge-service/__tests__/policy.test.ts
@@ -99,6 +99,7 @@ describe('captureReasons', () => {
       ClientAnomaly.EVENTS_BEYOND_RECORDED_TICKS,
       CaptureReason.EVENTS_BEYOND_RECORDED_TICKS,
     ],
+    [ClientAnomaly.GAME_CORRECTION_APPLIED, CaptureReason.GAME_CORRECTION],
   ])('maps a %s anomaly to %s', (anomaly, reason) => {
     const result = makeResult({
       clients: [makeClient({ anomalies: [anomaly] })],

--- a/challenge-server/merge-service/policy.ts
+++ b/challenge-server/merge-service/policy.ts
@@ -23,6 +23,8 @@ export const enum CaptureReason {
   QUALITY_FLAGS = 'quality_flags',
   /** The merged timeline was offset to the end of the stage. */
   TIMELINE_OFFSET = 'timeline_offset',
+  /** A game correction was applied to a client's events. */
+  GAME_CORRECTION = 'game_correction',
   /**
    * The merge failed outright; the captured streams are its reproduction case.
    */
@@ -49,6 +51,7 @@ const CAPTURE_RATES: Record<CaptureReason, number> = {
   [CaptureReason.UNMERGED_CLIENTS]: 0.25,
   [CaptureReason.QUALITY_FLAGS]: 0.25,
   [CaptureReason.TIMELINE_OFFSET]: 0.05,
+  [CaptureReason.GAME_CORRECTION]: 0.1,
   [CaptureReason.MERGE_FAILED]: 1,
   [CaptureReason.BASELINE]: 0.005,
   [CaptureReason.DEVELOPMENT]: 1,
@@ -121,6 +124,9 @@ export function captureReasons(result: MergeResultMetadata): CaptureReason[] {
           break;
         case ClientAnomaly.EVENTS_BEYOND_RECORDED_TICKS:
           reasons.add(CaptureReason.EVENTS_BEYOND_RECORDED_TICKS);
+          break;
+        case ClientAnomaly.GAME_CORRECTION_APPLIED:
+          reasons.add(CaptureReason.GAME_CORRECTION);
           break;
         // Consistency issues are almost exclusively client lag, and missing
         // stage metadata is routine disconnect noise; neither warrants a

--- a/challenge-server/merging/__tests__/client-events.test.ts
+++ b/challenge-server/merging/__tests__/client-events.test.ts
@@ -488,6 +488,19 @@ describe('ClientEvents', () => {
       expect(spawn).not.toBeNull();
       expect(spawn!.x).toBe(13);
       expect(spawn!.y).toBe(10);
+
+      expect(client.hasAnomaly(ClientAnomaly.GAME_CORRECTION_APPLIED)).toBe(
+        true,
+      );
+      expect(client.getCorrections()).toEqual([
+        {
+          type: 'osrs_238_nylocas',
+          applied: [
+            { action: 'rewrite_spawn', tick: 4, roomId: NYLO_ROOM },
+            { action: 'rewrite_death', tick: 3, roomId: NYLO_ROOM },
+          ],
+        },
+      ]);
     });
 
     it('drops a spurious death when the implied move is ambiguous', () => {
@@ -502,6 +515,15 @@ describe('ClientEvents', () => {
 
       expect(deathCount(client)).toBe(1);
       expect(client.getTickState(3)?.getNpcState(NYLO_ROOM)).toBeNull();
+      expect(client.getCorrections()).toEqual([
+        {
+          type: 'osrs_238_nylocas',
+          applied: [
+            { action: 'rewrite_spawn', tick: 4, roomId: NYLO_ROOM },
+            { action: 'drop_death', tick: 3, roomId: NYLO_ROOM },
+          ],
+        },
+      ]);
     });
 
     it('drops rather than interpolates when the boundary shows lag', () => {
@@ -549,6 +571,10 @@ describe('ClientEvents', () => {
         client.getTickState(3)?.getEventsByType(ProtoEvent.Type.NPC_DEATH)
           .length,
       ).toBe(1);
+      expect(client.getCorrections()).toEqual([]);
+      expect(client.hasAnomaly(ClientAnomaly.GAME_CORRECTION_APPLIED)).toBe(
+        false,
+      );
     });
 
     it('does not correct stages other than Nylocas', () => {
@@ -565,6 +591,10 @@ describe('ClientEvents', () => {
       );
 
       expect(deathCount(client)).toBe(2);
+      expect(client.getCorrections()).toEqual([]);
+      expect(client.hasAnomaly(ClientAnomaly.GAME_CORRECTION_APPLIED)).toBe(
+        false,
+      );
     });
   });
 });

--- a/challenge-server/merging/__tests__/trusted-prefixes.test.ts
+++ b/challenge-server/merging/__tests__/trusted-prefixes.test.ts
@@ -18,6 +18,7 @@ type ClientSpec = {
   spectator?: boolean;
   presentUntil?: number;
   firstIssueTick?: number;
+  firstCorrectionTick?: number;
 };
 
 function buildClients(specs: ClientSpec[]): Map<number, RegisteredClient> {
@@ -33,11 +34,28 @@ function buildClients(specs: ClientSpec[]): Map<number, RegisteredClient> {
             },
           ]
         : [];
+    const corrections =
+      spec.firstCorrectionTick !== undefined
+        ? [
+            {
+              type: 'osrs_238_nylocas' as const,
+              applied: [
+                {
+                  action: 'drop_death' as const,
+                  tick: spec.firstCorrectionTick,
+                  roomId: 1,
+                  npcId: 1,
+                },
+              ],
+            },
+          ]
+        : [];
     clients.set(spec.id, {
       status: MergeClientStatus.MERGED,
       client: {
         getId: () => spec.id,
         getConsistencyIssues: () => issues,
+        getCorrections: () => corrections,
         isSpectator: () => spec.spectator ?? false,
       } as unknown as ClientEvents,
     });
@@ -179,6 +197,26 @@ describe('computeTrustedPrefixes', () => {
     expect(computeTrustedPrefixes(ctx, inherited(10))).toEqual({
       accurateUntil: 10,
       queryableUntil: 6,
+    });
+  });
+
+  it('tightens only queryableUntil at a corrected tick', () => {
+    const ctx = buildContext([{ id: 1 }, { id: 2, firstCorrectionTick: 6 }]);
+    expect(computeTrustedPrefixes(ctx, inherited(10))).toEqual({
+      accurateUntil: 10,
+      queryableUntil: 6,
+    });
+  });
+
+  it('does not tighten queryableUntil when corrections leave two clean clients', () => {
+    const ctx = buildContext([
+      { id: 1 },
+      { id: 2 },
+      { id: 3, firstCorrectionTick: 6 },
+    ]);
+    expect(computeTrustedPrefixes(ctx, inherited(10))).toEqual({
+      accurateUntil: 10,
+      queryableUntil: 10,
     });
   });
 

--- a/challenge-server/merging/client-events.ts
+++ b/challenge-server/merging/client-events.ts
@@ -55,8 +55,18 @@ export const enum ClientAnomaly {
   MISSING_STAGE_METADATA = 'MISSING_STAGE_METADATA',
   CONSISTENCY_ISSUES = 'CONSISTENCY_ISSUES',
   EVENTS_BEYOND_RECORDED_TICKS = 'EVENTS_BEYOND_RECORDED_TICKS',
+  GAME_CORRECTION_APPLIED = 'GAME_CORRECTION_APPLIED',
   BAD_DATA = 'BAD_DATA',
 }
+
+export type ClientGameCorrection = {
+  type: 'osrs_238_nylocas';
+  applied: {
+    action: 'rewrite_spawn' | 'rewrite_death' | 'drop_death';
+    tick: number;
+    roomId: number;
+  }[];
+};
 
 export type ServerTicks = {
   count: number;
@@ -133,7 +143,7 @@ type StageInfo = {
 function tryApplyOsrs238NylocasCorrection(
   events: Event[],
   context: { challengeUuid: string; clientId: number },
-): Event[] {
+): { events: Event[]; correction: ClientGameCorrection | null } {
   const lifecycleById = new Map<number, Event[]>();
   // Ticks where a player moved more than 2 tiles, signalling lost ticks.
   const laggedTicks = new Set<number>();
@@ -214,16 +224,40 @@ function tryApplyOsrs238NylocasCorrection(
   }
 
   if (respawns.size === 0) {
-    return events;
+    return { events, correction: null };
   }
+
+  const correction: ClientGameCorrection = {
+    type: 'osrs_238_nylocas',
+    applied: [],
+  };
 
   for (const respawn of respawns) {
     respawn.setType(Event.Type.NPC_UPDATE);
+    correction.applied.push({
+      action: 'rewrite_spawn',
+      tick: respawn.getTick(),
+      roomId: respawn.getNpc()!.getRoomId(),
+    });
   }
+
   for (const { event, x, y } of interpolatedDeaths) {
     event.setType(Event.Type.NPC_UPDATE);
     event.setXCoord(x);
     event.setYCoord(y);
+    correction.applied.push({
+      action: 'rewrite_death',
+      tick: event.getTick(),
+      roomId: event.getNpc()!.getRoomId(),
+    });
+  }
+
+  for (const death of droppedDeaths) {
+    correction.applied.push({
+      action: 'drop_death',
+      tick: death.getTick(),
+      roomId: death.getNpc()!.getRoomId(),
+    });
   }
 
   logger.warn('osrs_238_nylocas_correction', {
@@ -232,12 +266,17 @@ function tryApplyOsrs238NylocasCorrection(
     respawnsRewritten: respawns.size,
     deathsInterpolated: interpolatedDeaths.length,
     deathsDropped: droppedDeaths.size,
+    corrections: correction.applied,
   });
   recordGameCorrection('osrs238_nylocas');
 
-  return droppedDeaths.size === 0
-    ? events
-    : events.filter((e) => !droppedDeaths.has(e));
+  return {
+    events:
+      droppedDeaths.size === 0
+        ? events
+        : events.filter((e) => !droppedDeaths.has(e)),
+    correction,
+  };
 }
 
 export class ClientEvents {
@@ -250,6 +289,7 @@ export class ClientEvents {
   private readonly primaryPlayer: string | null;
   private readonly invalidTickCount: boolean;
   private readonly anomalies: Set<ClientAnomaly>;
+  private readonly corrections: ClientGameCorrection[];
   private accurate: boolean;
   private consistencyIssues: ConsistencyIssue[];
 
@@ -350,17 +390,26 @@ export class ClientEvents {
     anomaliesParam?: Set<ClientAnomaly>,
   ): ClientEvents {
     const anomalies = anomaliesParam ?? new Set<ClientAnomaly>();
+    const corrections: ClientGameCorrection[] = [];
 
     const sortedEvents = rawEvents.toSorted(
       (a, b) => a.getTick() - b.getTick(),
     );
-    const events =
-      stageInfo.stage === Stage.TOB_NYLOCAS
-        ? tryApplyOsrs238NylocasCorrection(sortedEvents, {
-            challengeUuid: challenge.uuid,
-            clientId,
-          })
-        : sortedEvents;
+
+    let events = sortedEvents;
+    if (stageInfo.stage === Stage.TOB_NYLOCAS) {
+      const { events: correctedEvents, correction } =
+        tryApplyOsrs238NylocasCorrection(sortedEvents, {
+          challengeUuid: challenge.uuid,
+          clientId,
+        });
+      events = correctedEvents;
+      if (correction !== null) {
+        corrections.push(correction);
+        anomalies.add(ClientAnomaly.GAME_CORRECTION_APPLIED);
+      }
+    }
+
     if (stageInfo.recordedTicks === 0 && events.length > 0) {
       stageInfo.recordedTicks = events[events.length - 1].getTick();
     }
@@ -515,6 +564,7 @@ export class ClientEvents {
       primaryPlayer ?? null,
       invalidTickCount,
       anomalies,
+      corrections,
     );
   }
 
@@ -650,6 +700,10 @@ export class ClientEvents {
     return this.anomalies.has(anomaly);
   }
 
+  public getCorrections(): ClientGameCorrection[] {
+    return [...this.corrections];
+  }
+
   /**
    * Performs a cursory check for consistency in the client's recorded events,
    * looking for obvious indications of tick loss.
@@ -721,6 +775,7 @@ export class ClientEvents {
     primaryPlayer: string | null,
     invalidTickCount: boolean,
     anomalies: Set<ClientAnomaly>,
+    corrections: ClientGameCorrection[],
   ) {
     this.clientId = clientId;
     this.challenge = challenge;
@@ -731,6 +786,7 @@ export class ClientEvents {
     this.primaryPlayer = primaryPlayer;
     this.invalidTickCount = invalidTickCount;
     this.anomalies = anomalies;
+    this.corrections = corrections;
     this.consistencyIssues = [];
 
     const ok = this.checkForConsistency();

--- a/challenge-server/merging/merge.ts
+++ b/challenge-server/merging/merge.ts
@@ -268,6 +268,7 @@ export class Merger {
         client.getReportedAccurate(),
         client.getTickStates(),
         client.getStageData(),
+        client.getCorrections(),
       );
     }
 

--- a/challenge-server/merging/trace.ts
+++ b/challenge-server/merging/trace.ts
@@ -3,7 +3,11 @@ import { Event } from '@blert/common/generated/event_pb';
 
 import { AlignmentEntry, AlignmentRange, AlignmentResult } from './alignment';
 import { ReferenceSelection } from './classification';
-import { ClientMetadata, StageData } from './client-events';
+import {
+  ClientGameCorrection,
+  ClientMetadata,
+  StageData,
+} from './client-events';
 import { StepConfidence } from './confidence';
 import { MergeClientStatus } from './context';
 import { EventType } from './event';
@@ -80,6 +84,7 @@ export type InputClientInfo = {
   reportedAccurate: boolean;
   ticks: TickSummary[];
   stageData: StageData;
+  corrections: ClientGameCorrection[];
 };
 
 export type ClassificationInfo = {
@@ -360,6 +365,7 @@ export class MergeTracer {
     reportedAccurate: boolean,
     ticks: TickStateArray,
     stageData: StageData,
+    corrections: ClientGameCorrection[],
   ): void {
     this.inputClients.push({
       clientId,
@@ -370,6 +376,7 @@ export class MergeTracer {
       reportedAccurate,
       ticks: serializeTicks(ticks),
       stageData,
+      corrections,
     });
   }
 

--- a/challenge-server/merging/trusted-prefixes.ts
+++ b/challenge-server/merging/trusted-prefixes.ts
@@ -58,12 +58,15 @@ type Contributor = {
    * or `Infinity` if none.
    */
   firstIssueTick: number;
+  firstCorrectionTick: number;
   isParticipant: boolean;
 };
 
 type TickSupport = {
   /** Number of internally contiguous clients contributing to this tick. */
   contiguousCount: number;
+  /** Subset of internally contiguous clients without game corrections. */
+  cleanCount: number;
   /** Whether any contiguous contributor is a participant. */
   hasParticipant: boolean;
   /** Whether any contributor's data was contested by other clients. */
@@ -72,9 +75,20 @@ type TickSupport = {
 
 const NO_SUPPORT: TickSupport = {
   contiguousCount: 0,
+  cleanCount: 0,
   hasParticipant: false,
   contested: false,
 };
+
+function minTick<T extends { tick: number }>(items: T[]): number {
+  let min = Infinity;
+  for (const item of items) {
+    if (item.tick < min) {
+      min = item.tick;
+    }
+  }
+  return min;
+}
 
 function collectContributors(ctx: MergeContext): Contributor[] {
   const contributors: Contributor[] = [];
@@ -82,11 +96,12 @@ function collectContributors(ctx: MergeContext): Contributor[] {
     if (status !== MergeClientStatus.MERGED) {
       continue;
     }
-    const issues = client.getConsistencyIssues();
     contributors.push({
       id: client.getId(),
-      firstIssueTick:
-        issues.length > 0 ? Math.min(...issues.map((i) => i.tick)) : Infinity,
+      firstIssueTick: minTick(client.getConsistencyIssues()),
+      firstCorrectionTick: minTick(
+        client.getCorrections().flatMap((c) => c.applied),
+      ),
       isParticipant: !client.isSpectator(),
     });
   }
@@ -103,6 +118,7 @@ function supportAtTick(
   contested: ReadonlyMap<number, ReadonlySet<number>>,
 ): TickSupport {
   let contiguousCount = 0;
+  let cleanCount = 0;
   let hasParticipant = false;
   let isContested = false;
 
@@ -111,18 +127,28 @@ function supportAtTick(
     if (localTick === undefined) {
       continue;
     }
+
     if (contested.get(c.id)?.has(localTick)) {
       isContested = true;
     }
+
     if (c.firstIssueTick > localTick) {
       contiguousCount++;
       if (c.isParticipant) {
         hasParticipant = true;
       }
+      if (c.firstCorrectionTick > localTick) {
+        cleanCount++;
+      }
     }
   }
 
-  return { contiguousCount, hasParticipant, contested: isContested };
+  return {
+    contiguousCount,
+    cleanCount,
+    hasParticipant,
+    contested: isContested,
+  };
 }
 
 /**
@@ -169,11 +195,15 @@ export function computeTrustedPrefixes(
     if (accurateUntil < 0 && lacksSufficientContributors) {
       accurateUntil = m;
     }
-    if (
-      queryableUntil < 0 &&
-      ((!inheritedAccuracy && lacksSufficientContributors) || support.contested)
-    ) {
-      queryableUntil = m;
+
+    if (queryableUntil < 0) {
+      const hasTimingIssues = !inheritedAccuracy && lacksSufficientContributors;
+      const lacksUncorrectedClients =
+        support.cleanCount < Math.min(2, support.contiguousCount);
+      const hasDataIssues = support.contested || lacksUncorrectedClients;
+      if (hasTimingIssues || hasDataIssues) {
+        queryableUntil = m;
+      }
     }
 
     if (accurateUntil >= 0 && queryableUntil >= 0) {


### PR DESCRIPTION
Tracks when game corrections such as the Nylocas spawn fix are applied to client input, and uses this to restrict event queryability following a merge, requiring at least two uncorrected clients (or one if recording solo).