### PR TITLE
socket: Handle plugin hashes

### DIFF
--- a/socket-server/__tests__/verification.test.ts
+++ b/socket-server/__tests__/verification.test.ts
@@ -1,5 +1,6 @@
 import {
   compareRuneLiteVersions,
+  PluginVersions,
   verifyRuneLiteVersion,
   verifyRevision,
 } from '../verification';
@@ -132,25 +133,67 @@ describe('verifyRuneLiteVersion', () => {
 describe('verifyRevision', () => {
   it('should return true when revisions are empty', () => {
     const revisions = new Set<string>();
-    expect(verifyRevision(revisions, 'xyz789')).toBe(true);
-    expect(verifyRevision(revisions, undefined)).toBe(true);
+    expect(verifyRevision(revisions, 'xyz789', 'hashA')).toBe(true);
+    expect(verifyRevision(revisions, undefined, undefined)).toBe(true);
   });
 
   it('should return false when revision is undefined and revisions are not empty', () => {
-    const revisions = new Set(['abc123', 'def456']);
-    expect(verifyRevision(revisions, undefined)).toBe(false);
+    const revisions = new Set(['abc123:hashA']);
+    expect(verifyRevision(revisions, undefined, 'hashA')).toBe(false);
   });
 
-  it('should return true for valid revisions', () => {
-    const revisions = new Set(['abc123', 'def456', 'ghi789']);
-    expect(verifyRevision(revisions, 'abc123')).toBe(true);
-    expect(verifyRevision(revisions, 'def456')).toBe(true);
-    expect(verifyRevision(revisions, 'ghi789')).toBe(true);
+  it('should match an exact revision and jar hash pair', () => {
+    const revisions = new Set(['abc123:hashA', 'def456:hashB']);
+    expect(verifyRevision(revisions, 'abc123', 'hashA')).toBe(true);
+    expect(verifyRevision(revisions, 'def456', 'hashB')).toBe(true);
   });
 
-  it('should return false for invalid revisions', () => {
-    const revisions = new Set(['abc123', 'def456']);
-    expect(verifyRevision(revisions, 'xyz789')).toBe(false);
-    expect(verifyRevision(revisions, 'invalid')).toBe(false);
+  it('should reject a matching revision with the wrong jar hash', () => {
+    const revisions = new Set(['abc123:hashA']);
+    expect(verifyRevision(revisions, 'abc123', 'hashB')).toBe(false);
+    expect(verifyRevision(revisions, 'abc123', undefined)).toBe(false);
+  });
+
+  it('should reject an unknown revision', () => {
+    const revisions = new Set(['abc123:hashA', 'def456:*']);
+    expect(verifyRevision(revisions, 'xyz789', 'hashA')).toBe(false);
+  });
+
+  it('should allow any jar hash for a wildcard revision', () => {
+    const revisions = new Set(['abc123:*']);
+    expect(verifyRevision(revisions, 'abc123', 'hashA')).toBe(true);
+    expect(verifyRevision(revisions, 'abc123', 'hashZ')).toBe(true);
+    expect(verifyRevision(revisions, 'abc123', undefined)).toBe(true);
+  });
+
+  it('should not treat a literal jar hash as a wildcard match', () => {
+    const revisions = new Set(['abc123:hashA']);
+    expect(verifyRevision(revisions, 'abc123', '*')).toBe(false);
+  });
+});
+
+describe('PluginVersions', () => {
+  const validHeaders = {
+    'blert-version': '0.9.12-RUNELITE',
+    'blert-revision': 'abc12345:0',
+    'blert-jar-hash': '1213141516171819',
+    'blert-runelite-version': '1.11.10.1',
+  };
+
+  it('parses all fields and strips the revision suffix', () => {
+    const versions = PluginVersions.fromHeaders(validHeaders);
+    expect(versions).not.toBeNull();
+    expect(versions!.getVersion()).toBe('0.9.12-RUNELITE');
+    expect(versions!.getRevision()).toBe('abc12345');
+    expect(versions!.getJarHash()).toBe('1213141516171819');
+    expect(versions!.getRuneLiteVersion()).toBe('1.11.10.1');
+  });
+
+  it('should reject when any required header is missing', () => {
+    for (const key of Object.keys(validHeaders)) {
+      const { [key as keyof typeof validHeaders]: _omit, ...headers } =
+        validHeaders;
+      expect(PluginVersions.fromHeaders(headers)).toBeNull();
+    }
   });
 });

--- a/socket-server/app.ts
+++ b/socket-server/app.ts
@@ -407,6 +407,7 @@ async function main(): Promise<void> {
           logger.warn('websocket_auth_plugin_not_allowed', {
             pluginVersion: pluginVersions.getVersion(),
             pluginRevision: pluginVersions.getRevision(),
+            pluginJarHash: pluginVersions.getJarHash(),
             runeLiteVersion: pluginVersions.getRuneLiteVersion(),
           });
           reject('HTTP/1.1 403 Forbidden', 'plugin_not_allowed');
@@ -487,6 +488,7 @@ async function main(): Promise<void> {
       sessionToken: client.getSessionToken(),
       pluginVersion: pluginVersions.getVersion(),
       pluginRevision: pluginVersions.getRevision(),
+      pluginJarHash: pluginVersions.getJarHash(),
       runeLiteVersion: pluginVersions.getRuneLiteVersion(),
       messageFormat: client.getMessageFormat(),
     });

--- a/socket-server/client.ts
+++ b/socket-server/client.ts
@@ -470,6 +470,7 @@ export default class Client {
       validated: this.validated,
       pluginVersion: this.pluginVersions.getVersion(),
       pluginRevision: this.pluginVersions.getRevision(),
+      pluginJarHash: this.pluginVersions.getJarHash(),
       runeLiteVersion: this.pluginVersions.getRuneLiteVersion(),
       challengeUuid: this.activeChallenge?.uuid ?? undefined,
       messageFormat: this.messageFormat,

--- a/socket-server/config.ts
+++ b/socket-server/config.ts
@@ -45,7 +45,11 @@ export class ConfigManager {
       ) !== null;
     return (
       isVersionValid &&
-      verifyRevision(config.allowedRevisions, pluginVersions.getRevision()) &&
+      verifyRevision(
+        config.allowedRevisions,
+        pluginVersions.getRevision(),
+        pluginVersions.getJarHash(),
+      ) &&
       verifyRuneLiteVersion(
         pluginVersions.getRuneLiteVersion(),
         config.minRuneLiteVersion,

--- a/socket-server/verification.ts
+++ b/socket-server/verification.ts
@@ -6,6 +6,7 @@ import { IncomingHttpHeaders } from 'http';
 export class PluginVersions {
   private static readonly VERSION_HEADER = 'blert-version';
   private static readonly REVISION_HEADER = 'blert-revision';
+  private static readonly JAR_HASH_HEADER = 'blert-jar-hash';
   private static readonly RUNELITE_VERSION_HEADER = 'blert-runelite-version';
 
   public static fromHeaders(
@@ -18,15 +19,18 @@ export class PluginVersions {
       | string
       | undefined;
     revision = revision?.split(':')[0];
+    const jarHash = headers[PluginVersions.JAR_HASH_HEADER] as
+      | string
+      | undefined;
     const runeLiteVersion = headers[PluginVersions.RUNELITE_VERSION_HEADER] as
       | string
       | undefined;
 
-    if (!revision || !version || !runeLiteVersion) {
+    if (!revision || !version || !jarHash || !runeLiteVersion) {
       return null;
     }
 
-    return new PluginVersions(version, revision, runeLiteVersion);
+    return new PluginVersions(version, revision, jarHash, runeLiteVersion);
   }
 
   public getVersion(): string {
@@ -35,6 +39,10 @@ export class PluginVersions {
 
   public getRevision(): string {
     return this.revision;
+  }
+
+  public getJarHash(): string {
+    return this.jarHash;
   }
 
   public getRuneLiteVersion(): string {
@@ -50,6 +58,7 @@ export class PluginVersions {
   private constructor(
     public readonly version: string,
     public readonly revision: string,
+    public readonly jarHash: string,
     public readonly runeLiteVersion: string,
   ) {}
 }
@@ -136,16 +145,18 @@ export function verifyRuneLiteVersion(
 }
 
 /**
- * Verify that a revision is in the set of valid revisions.
+ * Verifies that a plugin revision and jar hash are allowed.
  *
- * @param validRevisions The set of valid revisions.
+ * @param validRevisions The set of allowed revision entries.
  * @param revision The revision to verify.
- * @returns True if the revision is in the set of valid revisions. If the set
- * is empty, the revision is always considered valid.
+ * @param jarHash The jar hash to verify.
+ * @returns True if the revision/jar hash pair is allowed. If the set is empty,
+ * any revision is considered valid.
  */
 export function verifyRevision(
   validRevisions: Set<string>,
   revision: string | undefined,
+  jarHash: string | undefined,
 ): boolean {
   if (validRevisions.size === 0) {
     return true;
@@ -155,5 +166,9 @@ export function verifyRevision(
     return false;
   }
 
-  return validRevisions.has(revision);
+  if (jarHash !== undefined && validRevisions.has(`${revision}:${jarHash}`)) {
+    return true;
+  }
+
+  return validRevisions.has(`${revision}:*`);
 }


### PR DESCRIPTION
New plugin builds send the hash of their compiled jar. This updates the socket server to read and record these, as well as optionally validating them if configured.