### PR TITLE
socket: Propagate definitions upload to all instances

### DIFF
--- a/socket-server/__tests__/action-definitions.test.ts
+++ b/socket-server/__tests__/action-definitions.test.ts
@@ -6,9 +6,12 @@ import { ServerMessage } from '@blert/common/generated/server_message_pb';
 jest.mock('fs/promises');
 
 import { readFile } from 'fs/promises';
+import { RedisClientType } from 'redis';
+
 import {
   ActionDefinitionsRepository,
   AttackDefinitionJson,
+  DEFINITIONS_RELOAD_PUBSUB_KEY,
   SpellDefinitionJson,
   ValidationError,
   validateAttackDefinitions,
@@ -277,6 +280,55 @@ describe('ActionDefinitionsRepository', () => {
       await repo.reloadAttacks();
 
       expect(repo.getAttackDefinitionsJson()).toHaveLength(2);
+    });
+  });
+
+  describe('reload resilience', () => {
+    it('keeps current definitions when a reload repository read fails', async () => {
+      const mockRepo = createMockRepository();
+      mockRepo.loadRaw.mockImplementation((path: string) =>
+        path.includes('attack')
+          ? Promise.resolve(encodeJson(validAttackDefinitions))
+          : Promise.resolve(encodeJson(validSpellDefinitions)),
+      );
+      // A differing bundled fallback makes a wrong fall-back detectable.
+      mockedReadFile.mockResolvedValue(JSON.stringify([validAttackDefinition]));
+
+      const repo = new ActionDefinitionsRepository({
+        repository: mockRepo,
+        attackFallbackPath: '/attacks.json',
+        spellFallbackPath: '/spells.json',
+      });
+      await repo.initialize();
+      expect(repo.getAttackDefinitionsJson()).toEqual(validAttackDefinitions);
+
+      mockRepo.loadRaw.mockRejectedValue(new Error('s3 unavailable'));
+
+      await expect(repo.reloadAttacks()).rejects.toThrow('s3 unavailable');
+
+      expect(repo.getAttackDefinitionsJson()).toEqual(validAttackDefinitions);
+      expect(mockedReadFile).not.toHaveBeenCalled();
+    });
+
+    it('falls back to bundled definitions when the repository fails at startup', async () => {
+      const mockRepo = createMockRepository();
+      mockRepo.loadRaw.mockRejectedValue(new Error('s3 unavailable'));
+      mockedReadFile.mockImplementation((path) =>
+        String(path).includes('attack')
+          ? Promise.resolve(JSON.stringify(validAttackDefinitions))
+          : Promise.resolve(JSON.stringify(validSpellDefinitions)),
+      );
+
+      const repo = new ActionDefinitionsRepository({
+        repository: mockRepo,
+        attackFallbackPath: '/attacks.json',
+        spellFallbackPath: '/spells.json',
+      });
+      await repo.initialize();
+
+      expect(repo.getAttackDefinitionsJson()).toEqual(validAttackDefinitions);
+      expect(repo.getSpellDefinitionsJson()).toEqual(validSpellDefinitions);
+      expect(mockedReadFile).toHaveBeenCalled();
     });
   });
 
@@ -588,6 +640,72 @@ describe('ActionDefinitionsRepository', () => {
 
       expect(repo.getSpellDefinitionsJson()).toHaveLength(2);
       expect(repo.getSpellDefinitionsJson()).toEqual(validSpellDefinitions);
+    });
+  });
+
+  describe('reload propagation', () => {
+    function uploadableRepo(redis?: RedisClientType) {
+      const mockRepo = createMockRepository();
+      mockRepo.loadRaw.mockImplementation((path: string) => {
+        if (path.includes('attack')) {
+          return Promise.resolve(encodeJson(validAttackDefinitions));
+        }
+        return Promise.resolve(encodeJson(validSpellDefinitions));
+      });
+      mockRepo.saveRaw.mockResolvedValue(undefined);
+      return new ActionDefinitionsRepository({
+        repository: mockRepo,
+        attackFallbackPath: '/attacks.json',
+        spellFallbackPath: '/spells.json',
+        redis,
+      });
+    }
+
+    it('publishes an attacks reload after uploading attack definitions', async () => {
+      const publish = jest.fn().mockResolvedValue(0);
+      const repo = uploadableRepo({ publish } as unknown as RedisClientType);
+      await repo.initialize();
+
+      await repo.uploadAttackDefinitions(validAttackDefinitions);
+
+      expect(publish).toHaveBeenCalledTimes(1);
+      const [channel, message] = publish.mock.calls[0] as [string, string];
+      expect(channel).toBe(DEFINITIONS_RELOAD_PUBSUB_KEY);
+      expect(JSON.parse(message)).toEqual({ type: 'attacks' });
+    });
+
+    it('publishes a spells reload after uploading spell definitions', async () => {
+      const publish = jest.fn().mockResolvedValue(0);
+      const repo = uploadableRepo({ publish } as unknown as RedisClientType);
+      await repo.initialize();
+
+      await repo.uploadSpellDefinitions(validSpellDefinitions);
+
+      expect(publish).toHaveBeenCalledTimes(1);
+      const [channel, message] = publish.mock.calls[0] as [string, string];
+      expect(channel).toBe(DEFINITIONS_RELOAD_PUBSUB_KEY);
+      expect(JSON.parse(message)).toEqual({ type: 'spells' });
+    });
+
+    it('does not publish when no redis client is configured', async () => {
+      const repo = uploadableRepo();
+      await repo.initialize();
+
+      await expect(
+        repo.uploadAttackDefinitions(validAttackDefinitions),
+      ).resolves.toEqual(validAttackDefinitions);
+    });
+
+    it('completes the upload even when publishing fails', async () => {
+      const publish = jest.fn().mockRejectedValue(new Error('redis down'));
+      const repo = uploadableRepo({ publish } as unknown as RedisClientType);
+      await repo.initialize();
+
+      await expect(
+        repo.uploadAttackDefinitions(validAttackDefinitions),
+      ).resolves.toEqual(validAttackDefinitions);
+      expect(repo.getAttackDefinitionsJson()).toEqual(validAttackDefinitions);
+      expect(publish).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/socket-server/__tests__/connection-manager.test.ts
+++ b/socket-server/__tests__/connection-manager.test.ts
@@ -1,7 +1,9 @@
 import { ServerMessage } from '@blert/common/generated/server_message_pb';
+import { RedisClientType } from 'redis';
 
 jest.mock('../users', () => ({ Users: {} }));
 
+import { DEFINITIONS_RELOAD_PUBSUB_KEY } from '../action-definitions';
 import type Client from '../client';
 import ConnectionManager from '../connection-manager';
 
@@ -14,6 +16,7 @@ class FakeClient {
   public session: { id: number; token: string } | null = null;
   public closeCode: number | null = null;
   public terminated = false;
+  public readonly sentMessages: unknown[] = [];
 
   private readonly closeCallbacks: (() => void)[] = [];
 
@@ -22,24 +25,31 @@ class FakeClient {
   public setSession(session: { id: number; token: string }): void {
     this.session = session;
   }
+
   public getSessionId(): number {
     return this.session!.id;
   }
+
   public getUserId(): number {
     return 1;
   }
+
   public getUsername(): string {
     return 'tester';
   }
+
   public getPluginVersions() {
     return { getVersion: () => '0.9.11', getRuneLiteVersion: () => '1.12.31' };
   }
+
   public onClose(cb: () => void): void {
     this.closeCallbacks.push(cb);
   }
-  public sendMessage(): void {
-    /* no-op */
+
+  public sendMessage(message?: unknown): void {
+    this.sentMessages.push(message);
   }
+
   public startGameStateRequestCycle(): void {
     /* no-op */
   }
@@ -50,6 +60,7 @@ class FakeClient {
       this.fireClose();
     }
   }
+
   public terminate(): void {
     this.terminated = true;
     this.fireClose();
@@ -136,5 +147,151 @@ describe('closeAllClients', () => {
   it('resolves immediately when there are no clients', async () => {
     const cm = makeConnectionManager();
     await expect(cm.closeAllClients()).resolves.toBeUndefined();
+  });
+});
+
+type PubSubHandler = (message: string) => void | Promise<void>;
+
+class FakePubSubClient {
+  public readonly handlers = new Map<string, PubSubHandler>();
+
+  public on(): this {
+    return this;
+  }
+
+  public async connect(): Promise<void> {
+    /* no-op */
+  }
+
+  public async subscribe(
+    channel: string,
+    handler: PubSubHandler,
+  ): Promise<void> {
+    this.handlers.set(channel, handler);
+  }
+
+  /** Simulates Redis delivering a published message to this subscriber. */
+  public async deliver(channel: string, message: string): Promise<void> {
+    const handler = this.handlers.get(channel);
+    if (handler === undefined) {
+      throw new Error(`no subscriber for ${channel}`);
+    }
+    await handler(message);
+  }
+}
+
+class FakeRedisClient {
+  public readonly pubsub = new FakePubSubClient();
+  public duplicate(): FakePubSubClient {
+    return this.pubsub;
+  }
+}
+
+/** Lets the fire-and-forget startPubsub() chain register its subscriptions. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('definitions reload pubsub', () => {
+  async function setup() {
+    const attackMessage = new ServerMessage();
+    attackMessage.setType(ServerMessage.Type.ATTACK_DEFINITIONS);
+
+    const spellMessage = new ServerMessage();
+    spellMessage.setType(ServerMessage.Type.SPELL_DEFINITIONS);
+
+    const definitionsRepository = {
+      reloadAttacks: jest.fn().mockResolvedValue(undefined),
+      reloadSpells: jest.fn().mockResolvedValue(undefined),
+      createAttackDefinitionsMessage: jest.fn(() => attackMessage),
+      createSpellDefinitionsMessage: jest.fn(() => spellMessage),
+    };
+
+    const redis = new FakeRedisClient();
+    const cm = new ConnectionManager(
+      redis as unknown as RedisClientType,
+      definitionsRepository as unknown as ConstructorParameters<
+        typeof ConnectionManager
+      >[1],
+    );
+
+    await flushMicrotasks();
+
+    const a = new FakeClient(true);
+    const b = new FakeClient(true);
+    addFakeClients(cm, a, b);
+    // Discard the messages sent during client registration so the assertions
+    // observe only what the reload broadcasts.
+    a.sentMessages.length = 0;
+    b.sentMessages.length = 0;
+
+    return { redis, definitionsRepository, attackMessage, spellMessage, a, b };
+  }
+
+  it('reloads attacks and broadcasts them to every client', async () => {
+    const { redis, definitionsRepository, attackMessage, a, b } = await setup();
+
+    await redis.pubsub.deliver(
+      DEFINITIONS_RELOAD_PUBSUB_KEY,
+      JSON.stringify({ type: 'attacks' }),
+    );
+
+    expect(definitionsRepository.reloadAttacks).toHaveBeenCalledTimes(1);
+    expect(definitionsRepository.reloadSpells).not.toHaveBeenCalled();
+    expect(a.sentMessages).toEqual([attackMessage]);
+    expect(b.sentMessages).toEqual([attackMessage]);
+  });
+
+  it('reloads spells and broadcasts them to every client', async () => {
+    const { redis, definitionsRepository, spellMessage, a, b } = await setup();
+
+    await redis.pubsub.deliver(
+      DEFINITIONS_RELOAD_PUBSUB_KEY,
+      JSON.stringify({ type: 'spells' }),
+    );
+
+    expect(definitionsRepository.reloadSpells).toHaveBeenCalledTimes(1);
+    expect(definitionsRepository.reloadAttacks).not.toHaveBeenCalled();
+    expect(a.sentMessages).toEqual([spellMessage]);
+    expect(b.sentMessages).toEqual([spellMessage]);
+  });
+
+  it('ignores a malformed notification', async () => {
+    const { redis, definitionsRepository, a, b } = await setup();
+
+    await redis.pubsub.deliver(DEFINITIONS_RELOAD_PUBSUB_KEY, 'not json');
+
+    expect(definitionsRepository.reloadAttacks).not.toHaveBeenCalled();
+    expect(definitionsRepository.reloadSpells).not.toHaveBeenCalled();
+    expect(a.sentMessages).toEqual([]);
+    expect(b.sentMessages).toEqual([]);
+  });
+
+  it('ignores a notification with an unknown definition type', async () => {
+    const { redis, definitionsRepository, a, b } = await setup();
+
+    await redis.pubsub.deliver(
+      DEFINITIONS_RELOAD_PUBSUB_KEY,
+      JSON.stringify({ type: 'runes' }),
+    );
+
+    expect(definitionsRepository.reloadAttacks).not.toHaveBeenCalled();
+    expect(definitionsRepository.reloadSpells).not.toHaveBeenCalled();
+    expect(a.sentMessages).toEqual([]);
+    expect(b.sentMessages).toEqual([]);
+  });
+
+  it('does not broadcast when the reload fails', async () => {
+    const { redis, definitionsRepository, a, b } = await setup();
+    definitionsRepository.reloadAttacks.mockRejectedValue(new Error('s3 down'));
+
+    await redis.pubsub.deliver(
+      DEFINITIONS_RELOAD_PUBSUB_KEY,
+      JSON.stringify({ type: 'attacks' }),
+    );
+
+    expect(definitionsRepository.reloadAttacks).toHaveBeenCalledTimes(1);
+    expect(a.sentMessages).toEqual([]);
+    expect(b.sentMessages).toEqual([]);
   });
 });

--- a/socket-server/action-definitions.ts
+++ b/socket-server/action-definitions.ts
@@ -11,6 +11,7 @@ import {
   SpellDefinition,
 } from '@blert/common/generated/server_message_pb';
 import { readFile } from 'fs/promises';
+import { RedisClientType } from 'redis';
 import { z } from 'zod';
 
 import logger from './log';
@@ -58,7 +59,19 @@ export function validateSpellDefinitions(data: unknown): SpellDefinitionJson[] {
   return result.data;
 }
 
-type DefinitionType = 'attacks' | 'spells';
+export type DefinitionType = 'attacks' | 'spells';
+
+/**
+ * Pubsub channel socket-server instances use to coordinate definition reloads
+ * across the fleet. After one instance accepts an upload, it broadcasts a
+ * fire-and-forget update message so the others reload the affected set from
+ * the data repository and push it to their own connected clients.
+ */
+export const DEFINITIONS_RELOAD_PUBSUB_KEY = 'definitions-reload';
+
+export type DefinitionsReloadUpdate = {
+  type: DefinitionType;
+};
 
 type DefinitionConfig = {
   repositoryPath: string;
@@ -85,6 +98,11 @@ export interface ActionDefinitionsConfig {
   attackFallbackPath: string;
   /** Path to a local JSON file for spell definitions fallback. */
   spellFallbackPath: string;
+  /**
+   * Optional Redis client used to notify other instances when definitions are
+   * uploaded. When omitted, uploads are not propagated across the fleet.
+   */
+  redis?: RedisClientType;
 }
 
 export class ActionDefinitionsRepository {
@@ -95,6 +113,7 @@ export class ActionDefinitionsRepository {
 
   private repository: DataRepository | null;
   private fallbackPaths: Record<DefinitionType, string>;
+  private redis: RedisClientType | null;
 
   constructor(config: ActionDefinitionsConfig) {
     this.repository = config.repository;
@@ -102,6 +121,7 @@ export class ActionDefinitionsRepository {
       attacks: config.attackFallbackPath,
       spells: config.spellFallbackPath,
     };
+    this.redis = config.redis ?? null;
   }
 
   /**
@@ -109,18 +129,23 @@ export class ActionDefinitionsRepository {
    * configured data repository or local fallback files.
    */
   public async initialize(): Promise<void> {
-    await this.reloadAttacks();
-    await this.reloadSpells();
+    await this.refreshAttacks(true);
+    await this.refreshSpells(true);
   }
 
   /**
-   * Reloads attack definitions from the repository, falling back to the local
-   * file if the repository is unavailable or not configured.
+   * Reloads attack definitions from the data repository without falling back
+   * to a bundled file.
    */
   public async reloadAttacks(): Promise<void> {
+    await this.refreshAttacks(false);
+  }
+
+  private async refreshAttacks(allowFallback: boolean): Promise<void> {
     const definitions = await this.loadDefinitions(
       'attacks',
       validateAttackDefinitions,
+      allowFallback,
     );
     this.attackDefinitions = definitions.map(attackDefinitionJsonToProto);
     this.attackJsonDefinitions = definitions;
@@ -152,7 +177,9 @@ export class ActionDefinitionsRepository {
    * @throws ValidationError if the definitions are invalid.
    * @throws Error if no repository is configured.
    */
-  public async uploadAttackDefinitions(definitions: unknown): Promise<void> {
+  public async uploadAttackDefinitions(
+    definitions: unknown,
+  ): Promise<AttackDefinitionJson[]> {
     const validated = await this.uploadDefinitions(
       'attacks',
       definitions,
@@ -160,16 +187,22 @@ export class ActionDefinitionsRepository {
     );
     this.attackDefinitions = validated.map(attackDefinitionJsonToProto);
     this.attackJsonDefinitions = validated;
+    return validated;
   }
 
   /**
-   * Reloads spell definitions from the repository, falling back to the local
-   * file if the repository is unavailable or not configured.
+   * Reloads spell definitions from the data repository without falling back
+   * to a bundled file.
    */
   public async reloadSpells(): Promise<void> {
+    await this.refreshSpells(false);
+  }
+
+  private async refreshSpells(allowFallback: boolean): Promise<void> {
     const definitions = await this.loadDefinitions(
       'spells',
       validateSpellDefinitions,
+      allowFallback,
     );
     this.spellDefinitions = definitions.map(spellDefinitionJsonToProto);
     this.spellJsonDefinitions = definitions;
@@ -201,7 +234,9 @@ export class ActionDefinitionsRepository {
    * @throws ValidationError if the definitions are invalid.
    * @throws Error if no repository is configured.
    */
-  public async uploadSpellDefinitions(definitions: unknown): Promise<void> {
+  public async uploadSpellDefinitions(
+    definitions: unknown,
+  ): Promise<SpellDefinitionJson[]> {
     const validated = await this.uploadDefinitions(
       'spells',
       definitions,
@@ -209,15 +244,18 @@ export class ActionDefinitionsRepository {
     );
     this.spellDefinitions = validated.map(spellDefinitionJsonToProto);
     this.spellJsonDefinitions = validated;
+    return validated;
   }
 
   /**
-   * Loads definitions from the repository, falling back to the local file if
-   * the repository is unavailable or not configured.
+   * Loads definitions from the repository. If `allowFallback` is set, falls
+   * back to reading from the local file if the repository is unavailable or
+   * unconfigured. Otherwise, keeps its last known definitions on failure.
    */
   private async loadDefinitions<T>(
     type: DefinitionType,
     validate: (data: unknown) => T[],
+    allowFallback: boolean,
   ): Promise<T[]> {
     const config = DEFINITION_CONFIGS[type];
     const fallbackPath = this.fallbackPaths[type];
@@ -241,7 +279,12 @@ export class ActionDefinitionsRepository {
             error: e instanceof Error ? e.message : String(e),
           });
         }
+        if (!allowFallback) {
+          throw e;
+        }
       }
+    } else if (!allowFallback) {
+      throw new Error(`No repository configured to reload ${type} definitions`);
     }
 
     try {
@@ -298,6 +341,29 @@ export class ActionDefinitionsRepository {
       count: validated.length,
     });
 
+    await this.publishReload(type);
+
     return validated;
+  }
+
+  /** Publishes a definitions update notification for the specified type. */
+  private async publishReload(type: DefinitionType): Promise<void> {
+    if (this.redis === null) {
+      return;
+    }
+
+    const update: DefinitionsReloadUpdate = { type };
+    try {
+      await this.redis.publish(
+        DEFINITIONS_RELOAD_PUBSUB_KEY,
+        JSON.stringify(update),
+      );
+    } catch (e) {
+      logger.error('definitions_reload_publish_failed', {
+        key: DEFINITIONS_RELOAD_PUBSUB_KEY,
+        type,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
   }
 }

--- a/socket-server/app.ts
+++ b/socket-server/app.ts
@@ -133,12 +133,10 @@ function setupHttpRoutes(
     '/admin/definitions/attacks',
     asyncHandler(async (req, res) => {
       try {
-        await definitionsRepository.uploadAttackDefinitions(req.body);
-        serverManager.broadcastMessage(
-          definitionsRepository.createAttackDefinitionsMessage(),
+        const updated = await definitionsRepository.uploadAttackDefinitions(
+          req.body,
         );
-        const definitions = definitionsRepository.getAttackDefinitionsJson();
-        res.json({ success: true, count: definitions.length });
+        res.json({ success: true, count: updated.length });
       } catch (e) {
         if (e instanceof ValidationError) {
           res.status(400).json({ error: e.message });
@@ -159,12 +157,10 @@ function setupHttpRoutes(
     '/admin/definitions/spells',
     asyncHandler(async (req, res) => {
       try {
-        await definitionsRepository.uploadSpellDefinitions(req.body);
-        serverManager.broadcastMessage(
-          definitionsRepository.createSpellDefinitionsMessage(),
+        const updated = await definitionsRepository.uploadSpellDefinitions(
+          req.body,
         );
-        const definitions = definitionsRepository.getSpellDefinitionsJson();
-        res.json({ success: true, count: definitions.length });
+        res.json({ success: true, count: updated.length });
       } catch (e) {
         if (e instanceof ValidationError) {
           res.status(400).json({ error: e.message });
@@ -250,7 +246,9 @@ async function loadValidRevisions(): Promise<Set<string>> {
 /**
  * Initializes the action definitions repository with the configured backend.
  */
-async function initializeDefinitionsRepository(): Promise<ActionDefinitionsRepository> {
+async function initializeDefinitionsRepository(
+  redisClient: RedisClientType,
+): Promise<ActionDefinitionsRepository> {
   let repository: DataRepository | null = null;
 
   const repositoryUri = process.env.BLERT_DEFINITIONS_REPOSITORY;
@@ -298,6 +296,7 @@ async function initializeDefinitionsRepository(): Promise<ActionDefinitionsRepos
     repository,
     attackFallbackPath: process.env.BLERT_ATTACK_DEFINITIONS_FALLBACK,
     spellFallbackPath: process.env.BLERT_SPELL_DEFINITIONS_FALLBACK,
+    redis: redisClient,
   });
   await definitionsRepository.initialize();
 
@@ -441,7 +440,8 @@ async function main(): Promise<void> {
     });
   });
 
-  const definitionsRepository = await initializeDefinitionsRepository();
+  const definitionsRepository =
+    await initializeDefinitionsRepository(redisClient);
 
   const connectionManager = new ConnectionManager(
     redisClient,

--- a/socket-server/connection-manager.ts
+++ b/socket-server/connection-manager.ts
@@ -6,7 +6,11 @@ import {
 import { ServerMessage } from '@blert/common/generated/server_message_pb';
 import { RedisClientType } from 'redis';
 
-import { ActionDefinitionsRepository } from './action-definitions';
+import {
+  ActionDefinitionsRepository,
+  DEFINITIONS_RELOAD_PUBSUB_KEY,
+  DefinitionsReloadUpdate,
+} from './action-definitions';
 import Client, { Session } from './client';
 import logger from './log';
 import { recordActiveClients, recordClientRegistration } from './metrics';
@@ -51,7 +55,64 @@ export default class ConnectionManager {
       this.handleNameChangeUpdate.bind(this),
     );
 
+    await this.pubsubClient.subscribe(
+      DEFINITIONS_RELOAD_PUBSUB_KEY,
+      this.handleDefinitionsUpdate.bind(this),
+    );
+
     logger.debug('connection_manager_pubsub_started');
+  }
+
+  /**
+   * Handles a definitions update notification by reloading the affected set
+   * and pushing them out to all connected clients.
+   */
+  private async handleDefinitionsUpdate(message: string): Promise<void> {
+    let update: DefinitionsReloadUpdate;
+    try {
+      update = JSON.parse(message) as DefinitionsReloadUpdate;
+    } catch (e) {
+      logger.error('definitions_reload_parse_error', {
+        key: DEFINITIONS_RELOAD_PUBSUB_KEY,
+        message: e instanceof Error ? e.message : String(e),
+      });
+      return;
+    }
+
+    try {
+      let broadcast: ServerMessage;
+      switch (update.type) {
+        case 'attacks':
+          await this.definitionsRepository.reloadAttacks();
+          broadcast =
+            this.definitionsRepository.createAttackDefinitionsMessage();
+          break;
+        case 'spells':
+          await this.definitionsRepository.reloadSpells();
+          broadcast =
+            this.definitionsRepository.createSpellDefinitionsMessage();
+          break;
+        default: {
+          const _exhaustive: never = update.type;
+          logger.warn('definitions_reload_unknown_type', { type: _exhaustive });
+          return;
+        }
+      }
+
+      for (const client of this.activeClients.values()) {
+        client.sendMessage(broadcast);
+      }
+
+      logger.info('definitions_reloaded', {
+        type: update.type,
+        clientCount: this.activeClients.size,
+      });
+    } catch (e) {
+      logger.error('definitions_reload_failed', {
+        type: update.type,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
   }
 
   private handleNameChangeUpdate(message: string): void {


### PR DESCRIPTION
Updates the socket server to subscribe to a new defitions update Redis pubsub message, which triggers a refetch of the latest attack/spell definitions from the configured repository followed by a broadcast to all connected clients.

When definitions are uploaded via the admin API to any instance, it publishes this message so that every instance can pick up the new ones.