### PR TITLE
web: Clear setup editor alt state on window blur

### DIFF
--- a/web/app/hooks/__tests__/modifier-key.test.ts
+++ b/web/app/hooks/__tests__/modifier-key.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { useModifierKey } from '../modifier-key';
+
+function keydown(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key }));
+}
+
+function keyup(key: string) {
+  window.dispatchEvent(new KeyboardEvent('keyup', { key }));
+}
+
+function blur() {
+  window.dispatchEvent(new Event('blur'));
+}
+
+describe('useModifierKey', () => {
+  it('starts unheld', () => {
+    const { result } = renderHook(() => useModifierKey('Alt'));
+    expect(result.current).toBe(false);
+  });
+
+  it('reports the key as held between keydown and keyup', () => {
+    const { result } = renderHook(() => useModifierKey('Alt'));
+
+    act(() => keydown('Alt'));
+    expect(result.current).toBe(true);
+
+    act(() => keyup('Alt'));
+    expect(result.current).toBe(false);
+  });
+
+  it('resets on window blur while held', () => {
+    const { result } = renderHook(() => useModifierKey('Alt'));
+
+    act(() => keydown('Alt'));
+    expect(result.current).toBe(true);
+
+    act(() => blur());
+    expect(result.current).toBe(false);
+  });
+
+  it('only tracks the requested key', () => {
+    const { result } = renderHook(() => useModifierKey('Alt'));
+
+    act(() => keydown('Shift'));
+    expect(result.current).toBe(false);
+
+    act(() => keydown('Alt'));
+    expect(result.current).toBe(true);
+
+    act(() => keyup('Shift'));
+    expect(result.current).toBe(true);
+  });
+
+  it('ignores keydown while disabled', () => {
+    const { result } = renderHook(() => useModifierKey('Alt', false));
+
+    act(() => keydown('Alt'));
+    expect(result.current).toBe(false);
+  });
+
+  it('still clears a held key after being disabled mid-press', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useModifierKey('Alt', enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    act(() => keydown('Alt'));
+    expect(result.current).toBe(true);
+
+    // Disabling does not retroactively clear an already-held key...
+    rerender({ enabled: false });
+    expect(result.current).toBe(true);
+
+    // ...but keyup still does.
+    act(() => keyup('Alt'));
+    expect(result.current).toBe(false);
+  });
+});

--- a/web/app/hooks/modifier-key.ts
+++ b/web/app/hooks/modifier-key.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+/** A modifier key, identified by its KeyboardEvent `key` value. */
+export type ModifierKey = 'Alt' | 'Control' | 'Meta' | 'Shift';
+
+/**
+ * Tracks whether a modifier key is currently held down.
+ *
+ * The held state is reset on window blur to handle switching to a different
+ * window before the `keyup` is delivered.
+ *
+ * @param key The modifier key to track.
+ * @param enabled If `false`, key presses are ignored, so the state never
+ *   transitions to true. A previously held state is maintained and still
+ *   cleared by `keyup`/`blur`.
+ * @returns Whether the modifier key is currently held.
+ */
+export function useModifierKey(
+  key: ModifierKey,
+  enabled: boolean = true,
+): boolean {
+  const [held, setHeld] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (enabled && e.key === key) {
+        setHeld(true);
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === key) {
+        setHeld(false);
+      }
+    };
+
+    const handleBlur = () => {
+      setHeld(false);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [key, enabled]);
+
+  return held;
+}

--- a/web/app/setups/slot.tsx
+++ b/web/app/setups/slot.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 
 import Item from '@/components/item';
 import ItemSearchInput from '@/components/item-search';
+import { useModifierKey } from '@/hooks/modifier-key';
 import {
   ExtendedItemData,
   extendedItemCache,
@@ -35,8 +36,10 @@ export function Slot(props: SlotProps) {
   const { highlightedItemId } = useContext(SetupViewingContext);
   const slotRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-  const [altHeld, setAltHeld] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+
+  // Outside of placement mode, Alt-click selects the slot's item.
+  const altHeld = useModifierKey('Alt', !context?.isPlacementMode);
 
   const id = slotIdToString({
     playerIndex: props.playerIndex,
@@ -90,18 +93,9 @@ export function Slot(props: SlotProps) {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!context?.isPlacementMode && e.key === 'Alt') {
-        setAltHeld(true);
-      }
       if (isSearchActive && e.key === 'Escape') {
         context?.setActiveSearchSlot(null);
         searchRef.current?.blur();
-      }
-    };
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.key === 'Alt') {
-        setAltHeld(false);
       }
     };
 
@@ -128,11 +122,9 @@ export function Slot(props: SlotProps) {
     }
 
     window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('keyup', handleKeyUp);
     window.addEventListener('click', handleClick);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('keyup', handleKeyUp);
       window.removeEventListener('click', handleClick);
     };
   }, [isSearchActive, context, id]);


### PR DESCRIPTION
Replaces the inline event listeners in setup slots with a shared held modifier hook that clears when the window is unfocused.