### PR TITLE
challenge: Carry forward NPC IDs into a 0

### DIFF
--- a/challenge-server/merging/tick-state.ts
+++ b/challenge-server/merging/tick-state.ts
@@ -218,9 +218,17 @@ export function buildNpcsForTick(
     }
     const npc = tagged.event.getNpc()!;
     const roomId = npc.getRoomId();
+
+    // An NPC ID should never be 0 when it is initially reported; it can only
+    // become 0 if its cached object is later hollowed out client-side.
+    // Therefore, this should always result in a valid ID carried forward.
+    const id =
+      npc.getId() === 0 ? (previous?.get(roomId)?.id ?? 0) : npc.getId();
+
     const fresh = extractNpcSubtype(npc);
+
     npcs.set(roomId, {
-      id: npc.getId(),
+      id,
       x: tagged.event.getXCoord(),
       y: tagged.event.getYCoord(),
       hitpoints: SkillLevel.fromRaw(npc.getHitpoints()),
@@ -309,6 +317,21 @@ export function resynchronizeTicks(stage: Stage, ticks: TickStateArray): void {
       deadNpcs,
     });
 
+    // Mark actor deaths starting from the following tick.
+    for (const death of tick.getEventsByType(Event.Type.PLAYER_DEATH)) {
+      const name = death.getPlayer()?.getName();
+      if (name) {
+        deadPlayers.add(name);
+      }
+    }
+    for (const death of tick.getEventsByType(Event.Type.NPC_DEATH)) {
+      const npc = death.getNpc()!;
+      deadNpcs.add(npc.getRoomId());
+      if (npc.getId() === 0) {
+        npc.setId(previousNpcs.get(npc.getRoomId())?.id ?? 0);
+      }
+    }
+
     for (const [player, state] of tick.getPlayerStates()) {
       if (state !== null) {
         previousPlayers.set(player, state);
@@ -318,20 +341,6 @@ export function resynchronizeTicks(stage: Stage, ticks: TickStateArray): void {
       previousNpcs.set(roomId, state);
     }
     previousGraphics = tick.getGraphics();
-
-    // Mark actor deaths starting from the following tick.
-    for (const death of tick.getEventsByType(Event.Type.PLAYER_DEATH)) {
-      const name = death.getPlayer()?.getName();
-      if (name) {
-        deadPlayers.add(name);
-      }
-    }
-    for (const death of tick.getEventsByType(Event.Type.NPC_DEATH)) {
-      const roomId = death.getNpc()?.getRoomId();
-      if (roomId !== undefined) {
-        deadNpcs.add(roomId);
-      }
-    }
   }
 }
 

--- a/common/__tests__/json-converter.test.ts
+++ b/common/__tests__/json-converter.test.ts
@@ -163,6 +163,33 @@ describe('jsonToServerMessage', () => {
       expect(npc?.hasNylo()).toBe(false);
     });
 
+    it('normalizes an NPC id of -1 to 0', () => {
+      const json: ServerMessageJson = {
+        type: ServerMessage.Type.EVENT_STREAM,
+        challengeEvents: [
+          {
+            type: Event.Type.NPC_UPDATE,
+            stage: 12,
+            tick: 28,
+            xCoord: 3292,
+            yCoord: 4244,
+            npc: {
+              id: -1,
+              roomId: 59422,
+              hitpoints: 589833,
+              basic: {},
+            },
+          },
+        ],
+      };
+
+      const proto = jsonToServerMessage(json);
+      const npc = proto.getChallengeEventsList()[0].getNpc();
+
+      expect(npc?.getId()).toBe(0);
+      expect(npc?.getRoomId()).toBe(59422);
+    });
+
     it('converts an NPC_SPAWN event with nylo data', () => {
       const json: ServerMessageJson = {
         type: ServerMessage.Type.EVENT_STREAM,
@@ -871,27 +898,6 @@ describe('jsonToServerMessage', () => {
     it('throws on invalid message type', () => {
       const json = {
         type: 'invalid',
-      };
-
-      expect(() => jsonToServerMessage(json)).toThrow(z.ZodError);
-    });
-
-    it('throws on negative NPC id', () => {
-      const json = {
-        type: ServerMessage.Type.EVENT_STREAM,
-        challengeEvents: [
-          {
-            type: Event.Type.NPC_SPAWN,
-            stage: 12,
-            tick: 28,
-            xCoord: 0,
-            yCoord: 0,
-            npc: {
-              id: -1,
-              roomId: 100,
-            },
-          },
-        ],
       };
 
       expect(() => jsonToServerMessage(json)).toThrow(z.ZodError);

--- a/common/protocol/json-converter.ts
+++ b/common/protocol/json-converter.ts
@@ -587,7 +587,8 @@ export function jsonToProtoEvent(json: EventJson): Event {
 
 function npcJsonToProto(json: z.infer<typeof npcSchema>): Event.Npc {
   const npc = new Event.Npc();
-  npc.setId(json.id);
+  // Normalize RuneLite's -1 NPC IDs to 0 as proto stores them unsigned.
+  npc.setId(json.id < 0 ? 0 : json.id);
   npc.setRoomId(json.roomId);
   if (json.hitpoints !== undefined) {
     npc.setHitpoints(json.hitpoints);

--- a/common/protocol/json-schemas.ts
+++ b/common/protocol/json-schemas.ts
@@ -221,7 +221,7 @@ export const verzikCrabSchema = z.object({
 
 // Event.Npc
 export const npcSchema = z.object({
-  id: z.number().int().nonnegative(),
+  id: z.number().int(),
   roomId: z.number().int(),
   hitpoints: z.number().int().optional(),
   activePrayers: z.number().int().optional(),


### PR DESCRIPTION
If an event has an NPC with an ID of 0, populates it with the last known ID for that NPC before sending it downstream.