### PR TITLE
socket: Add voluntary rebalancing system

### DIFF
--- a/socket-server/__tests__/server-manager.test.ts
+++ b/socket-server/__tests__/server-manager.test.ts
@@ -4,10 +4,25 @@ import type Client from '../client';
 import type ConnectionManager from '../connection-manager';
 import ServerManager, { ServerStatus } from '../server-manager';
 
-const DRAINING = ServerMessage.ServerStatus.Status.DRAINING;
-
 class FakeClient {
   public readonly sent: ServerMessage[] = [];
+
+  constructor(
+    public readonly sessionId: number = 0,
+    private activeChallengeId: string | null = null,
+  ) {}
+
+  public getSessionId(): number {
+    return this.sessionId;
+  }
+
+  public getActiveChallengeId(): string | null {
+    return this.activeChallengeId;
+  }
+
+  public setActiveChallenge(challengeId: string | null): void {
+    this.activeChallengeId = challengeId;
+  }
 
   public sendMessage(message: ServerMessage): void {
     this.sent.push(message);
@@ -20,6 +35,10 @@ class FakeConnectionManager {
 
   public clients(): readonly FakeClient[] {
     return this.list;
+  }
+
+  public getClient(sessionId: number): FakeClient | undefined {
+    return this.list.find((c) => c.getSessionId() === sessionId);
   }
 
   public closeAllClients(): void {
@@ -39,6 +58,8 @@ function makeManager(clients: FakeClient[] = []): {
 }
 
 describe('draining', () => {
+  const DRAINING = ServerMessage.ServerStatus.Status.DRAINING;
+
   beforeEach(() => jest.useFakeTimers());
   afterEach(() => {
     jest.clearAllTimers();
@@ -211,5 +232,200 @@ describe('draining', () => {
 
     await jest.advanceTimersByTimeAsync(30_000);
     expect(manager.getStatus().status).toBe(ServerStatus.DRAINING);
+  });
+});
+
+describe('rebalancing', () => {
+  const REBALANCING = ServerMessage.ServerStatus.Status.REBALANCING;
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  const rebalanceStatus = (client: FakeClient): number | undefined =>
+    client.sent[0]?.getServerStatus()?.getStatus();
+
+  const signaledClients = (clients: FakeClient[]): FakeClient[] =>
+    clients.filter((c) => rebalanceStatus(c) === REBALANCING);
+
+  it('signals only idle clients', () => {
+    const idle = [new FakeClient(1), new FakeClient(2), new FakeClient(3)];
+    const busy = [new FakeClient(4, 'c-a'), new FakeClient(5, 'c-b')];
+    const { manager } = makeManager([...idle, ...busy]);
+
+    const result = manager.startRebalance({ target: 2 });
+
+    expect(result).toEqual({
+      started: true,
+      total: 5,
+      idle: 3,
+      target: 2,
+      selected: 3,
+    });
+
+    for (const client of idle) {
+      expect(client.sent).toHaveLength(1);
+      expect(client.sent[0].getType()).toBe(ServerMessage.Type.SERVER_STATUS);
+      expect(rebalanceStatus(client)).toBe(REBALANCING);
+      expect(client.sent[0].getServerStatus()?.hasShutdownTime()).toBe(false);
+    }
+    for (const client of busy) {
+      expect(client.sent).toHaveLength(0);
+    }
+
+    // The server stays healthy.
+    expect(manager.getStatus().status).toBe(ServerStatus.RUNNING);
+  });
+
+  it('caps the selected count at the idle count', () => {
+    const clients = [
+      new FakeClient(1),
+      new FakeClient(2, 'c-a'),
+      new FakeClient(3, 'c-b'),
+      new FakeClient(4, 'c-c'),
+    ];
+    const { manager } = makeManager(clients);
+
+    const result = manager.startRebalance({ target: 0 });
+
+    expect(result.selected).toBe(1);
+    expect(signaledClients(clients)).toEqual([clients[0]]);
+  });
+
+  it('does nothing when already at or below the target', () => {
+    const clients = [new FakeClient(1), new FakeClient(2)];
+    const { manager } = makeManager(clients);
+
+    const result = manager.startRebalance({ target: 5 });
+
+    expect(result).toEqual({
+      started: true,
+      total: 2,
+      idle: 2,
+      target: 5,
+      selected: 0,
+    });
+    expect(signaledClients(clients)).toEqual([]);
+  });
+
+  it('spreads notifications across batches with the batch interval', () => {
+    const clients = [1, 2, 3, 4, 5].map((id) => new FakeClient(id));
+    const { manager } = makeManager(clients);
+
+    manager.startRebalance({ target: 0, batchSize: 2, batchIntervalMs: 1000 });
+
+    // First batch fires synchronously.
+    expect(signaledClients(clients)).toHaveLength(2);
+
+    jest.advanceTimersByTime(1000);
+    expect(signaledClients(clients)).toHaveLength(4);
+
+    jest.advanceTimersByTime(1000);
+    expect(signaledClients(clients)).toHaveLength(5);
+
+    expect(clients.every((c) => c.sent.length === 1)).toBe(true);
+  });
+
+  it('skips a selected client that entered a challenge before its batch', () => {
+    const clients = [1, 2, 3, 4].map((id) => new FakeClient(id));
+    const { manager } = makeManager(clients);
+
+    manager.startRebalance({ target: 0, batchSize: 2, batchIntervalMs: 1000 });
+
+    expect(signaledClients(clients)).toEqual([clients[0], clients[1]]);
+
+    clients[2].setActiveChallenge('c-late');
+    jest.advanceTimersByTime(1000);
+
+    expect(signaledClients(clients)).toEqual([
+      clients[0],
+      clients[1],
+      clients[3],
+    ]);
+    expect(clients[2].sent).toHaveLength(0);
+  });
+
+  it('skips a selected client that disconnected before its batch', () => {
+    const clients = [1, 2, 3, 4].map((id) => new FakeClient(id));
+    const { manager, cm } = makeManager(clients);
+
+    manager.startRebalance({ target: 0, batchSize: 2, batchIntervalMs: 1000 });
+
+    cm.list = cm.list.filter((c) => c.getSessionId() !== 3);
+    jest.advanceTimersByTime(1000);
+
+    expect(clients[2].sent).toHaveLength(0);
+    expect(clients[3].sent).toHaveLength(1);
+    expect(rebalanceStatus(clients[3])).toBe(REBALANCING);
+  });
+
+  it('is rejected while the instance is draining', () => {
+    const clients = [new FakeClient(1), new FakeClient(2)];
+    const { manager } = makeManager(clients);
+
+    manager.startDrain(jest.fn(), { settleDelay: 30_000, gracePeriod: 60_000 });
+    const result = manager.startRebalance({ target: 0 });
+
+    expect(result.started).toBe(false);
+    expect(result.selected).toBe(0);
+    expect(signaledClients(clients)).toEqual([]);
+    expect(manager.getStatus().status).toBe(ServerStatus.DRAINING);
+  });
+
+  it('is rejected while a rebalance is already in progress', () => {
+    const clients = [1, 2, 3].map((id) => new FakeClient(id));
+    const { manager } = makeManager(clients);
+
+    const first = manager.startRebalance({
+      target: 0,
+      batchSize: 1,
+      batchIntervalMs: 1000,
+    });
+    expect(first.started).toBe(true);
+    expect(signaledClients(clients)).toHaveLength(1);
+
+    const second = manager.startRebalance({ target: 0 });
+    expect(second.started).toBe(false);
+
+    // The second request notified no new clients.
+    expect(signaledClients(clients)).toHaveLength(1);
+  });
+
+  it('aborts a rebalance when a drain begins', () => {
+    const clients = [1, 2, 3, 4].map((id) => new FakeClient(id));
+    const { manager } = makeManager(clients);
+
+    manager.startRebalance({ target: 0, batchSize: 1, batchIntervalMs: 1000 });
+    expect(signaledClients(clients)).toHaveLength(1);
+
+    manager.startDrain(jest.fn(), { settleDelay: 30_000, gracePeriod: 60_000 });
+
+    jest.advanceTimersByTime(10_000);
+    expect(signaledClients(clients)).toHaveLength(1);
+  });
+
+  it('falls back to the default batch size when given a nonpositive one', () => {
+    const clients = [1, 2, 3].map((id) => new FakeClient(id));
+    const { manager } = makeManager(clients);
+
+    manager.startRebalance({ target: 0, batchSize: 0, batchIntervalMs: 1000 });
+    expect(signaledClients(clients)).toHaveLength(3);
+
+    jest.advanceTimersByTime(5000);
+    expect(signaledClients(clients)).toHaveLength(3);
+  });
+
+  it('does not change the server status or fire status callbacks', () => {
+    const updates: ServerStatus[] = [];
+    const { manager } = makeManager([new FakeClient(1)]);
+    manager.onStatusUpdate(({ status }) => updates.push(status));
+
+    manager.startRebalance({ target: 0 });
+
+    expect(manager.getStatus().status).toBe(ServerStatus.RUNNING);
+    expect(manager.getStatus().shutdownTime).toBeNull();
+    expect(updates).toEqual([]);
   });
 });

--- a/socket-server/app.ts
+++ b/socket-server/app.ts
@@ -56,6 +56,12 @@ type DrainRequest = {
   cancel?: boolean;
 };
 
+type RebalanceRequest = {
+  target?: number;
+  batchSize?: number;
+  batchIntervalMs?: number;
+};
+
 function setupHttpRoutes(
   app: express.Express,
   serverManager: ServerManager,
@@ -126,6 +132,38 @@ function setupHttpRoutes(
       serverManager.startDrain(onDrainComplete, { gracePeriod, settleDelay });
     }
     res.json(serverManager.getStatus());
+  });
+
+  app.post('/admin/rebalance', (req, res) => {
+    const { target, batchSize, batchIntervalMs } = req.body as RebalanceRequest;
+    if (typeof target !== 'number' || !Number.isFinite(target) || target < 0) {
+      res.status(400).json({ error: 'target must be a nonnegative number' });
+      return;
+    }
+    if (
+      batchSize !== undefined &&
+      (!Number.isInteger(batchSize) || batchSize < 1)
+    ) {
+      res.status(400).json({ error: 'batchSize must be a positive integer' });
+      return;
+    }
+    if (
+      batchIntervalMs !== undefined &&
+      (typeof batchIntervalMs !== 'number' ||
+        !Number.isFinite(batchIntervalMs) ||
+        batchIntervalMs < 0)
+    ) {
+      res
+        .status(400)
+        .json({ error: 'batchIntervalMs must be a nonnegative number' });
+      return;
+    }
+    const result = serverManager.startRebalance({
+      target,
+      batchSize,
+      batchIntervalMs,
+    });
+    res.json(result);
   });
 
   // Admin endpoint to upload new attack definitions.

--- a/socket-server/connection-manager.ts
+++ b/socket-server/connection-manager.ts
@@ -256,6 +256,11 @@ export default class ConnectionManager {
     return Array.from(this.activeClients.values());
   }
 
+  /** Returns the client with the given session ID if it is connected. */
+  public getClient(sessionId: number): Client | undefined {
+    return this.activeClients.get(sessionId);
+  }
+
   private newSession(): Session {
     return {
       // 2**53 session IDs ought to be enough for anybody.

--- a/socket-server/metrics.ts
+++ b/socket-server/metrics.ts
@@ -164,6 +164,12 @@ const shutdownBroadcastsCounter = new Counter({
   registers: [register],
 });
 
+const rebalanceShedCounter = new Counter({
+  name: 'socket_server_rebalance_shed_total',
+  help: 'Clients asked to reconnect for load rebalancing',
+  registers: [register],
+});
+
 const SERVER_STATUSES = [
   'RUNNING',
   'SHUTDOWN_PENDING',
@@ -284,6 +290,12 @@ export const setServerStatusMetric = (status: ServerStatus): void => {
 
 export const recordShutdownBroadcast = (status: ServerStatus): void => {
   shutdownBroadcastsCounter.inc({ status });
+};
+
+export const recordRebalanceShed = (count: number): void => {
+  if (count > 0) {
+    rebalanceShedCounter.inc(count);
+  }
 };
 
 export async function timeRemoteOperation<T>(

--- a/socket-server/server-manager.ts
+++ b/socket-server/server-manager.ts
@@ -4,7 +4,11 @@ import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 import Client from './client';
 import ConnectionManager from './connection-manager';
 import logger from './log';
-import { recordShutdownBroadcast, setServerStatusMetric } from './metrics';
+import {
+  recordRebalanceShed,
+  recordShutdownBroadcast,
+  setServerStatusMetric,
+} from './metrics';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -36,6 +40,47 @@ type DrainState = {
   onComplete: () => void;
 };
 
+export type RebalanceOptions = {
+  /**
+   * The number of clients this instance should aim to retain. The number to
+   * shed is fixed when the rebalance begins as `(connected - target)`, so new
+   * connections arriving mid-rebalance neither inflate the shed count nor keep
+   * the target perpetually out of reach.
+   */
+  target: number;
+  /** Number of clients to ask to move per batch. */
+  batchSize?: number;
+  /** Delay between batches. */
+  batchIntervalMs?: number;
+};
+
+export type RebalanceResult = {
+  /** Whether a rebalance was initiated. `false` if rejected. */
+  started: boolean;
+  /** Total number of connected clients when the rebalance was requested. */
+  total: number;
+  /** Idle clients when the rebalance was requested. */
+  idle: number;
+  /** The requested retained client count. */
+  target: number;
+  /**
+   * Number of clients selected to reconnect. Capped by the idle count as
+   * clients in an active challenge are never disturbed, so a target below the
+   * number of busy clients cannot be fully reached.
+   */
+  selected: number;
+};
+
+type RebalanceState = {
+  /** Session IDs of selected clients still waiting to be signaled. */
+  queue: number[];
+  batchSize: number;
+  batchInterval: number;
+  batchTimer: NodeJS.Timeout | null;
+  /** Running total of clients signaled (excluding those skipped). */
+  shed: number;
+};
+
 export type ServerStatusUpdate = {
   status: ServerStatus;
   shutdownTime: Date | null;
@@ -65,6 +110,11 @@ export default class ServerManager {
   // How often the drain monitor checks whether all clients have left.
   private static DRAIN_TICK_MS = 5 * 1000;
 
+  // How many clients a rebalance asks to reconnect per batch, and how long it
+  // waits between batches, to control connection load on other instances.
+  public static DEFAULT_REBALANCE_BATCH_SIZE = 25;
+  public static DEFAULT_REBALANCE_BATCH_INTERVAL_MS = 1000;
+
   private connectionManager: ConnectionManager;
   private status: ServerStatus;
   private shutdownTime: Date | null;
@@ -74,6 +124,7 @@ export default class ServerManager {
   private shutdownMessageTimer: NodeJS.Timeout | null = null;
 
   private drain: DrainState | null = null;
+  private rebalance: RebalanceState | null = null;
 
   public constructor(connectionManager: ConnectionManager) {
     this.connectionManager = connectionManager;
@@ -218,6 +269,9 @@ export default class ServerManager {
       this.shutdownMessageTimer = null;
     }
 
+    // A drain supersedes a rebalance; the instance is leaving.
+    this.stopRebalance();
+
     const gracePeriod =
       options.gracePeriod ?? ServerManager.DEFAULT_DRAIN_GRACE_PERIOD_MS;
     const settleDelay =
@@ -321,6 +375,137 @@ export default class ServerManager {
 
     this.updateStatus(ServerStatus.OFFLINE);
     onComplete();
+  }
+
+  /**
+   * Voluntarily moves a subset of this instance's clients to other instances
+   * to even out load.
+   *
+   * Unlike a drain, the instance stays healthy and in service. It simply asks a
+   * selected set of clients not recording a challenge to reconnect, which the
+   * load balancer then spreads across the healthy pool.
+   */
+  public startRebalance(options: RebalanceOptions): RebalanceResult {
+    const clients = this.connectionManager.clients();
+    const idle = clients.filter((c) => c.getActiveChallengeId() === null);
+
+    const result: RebalanceResult = {
+      started: false,
+      total: clients.length,
+      idle: idle.length,
+      target: options.target,
+      selected: 0,
+    };
+
+    if (this.status !== ServerStatus.RUNNING || this.rebalance !== null) {
+      logger.info('server_rebalance_ignored', {
+        status: this.status,
+        inProgress: this.rebalance !== null,
+      });
+      return result;
+    }
+
+    const toShed = Math.max(0, clients.length - options.target);
+    const selected = idle.slice(0, toShed).map((c) => c.getSessionId());
+    result.started = true;
+    result.selected = selected.length;
+
+    logger.info('server_rebalance_started', {
+      total: clients.length,
+      idle: idle.length,
+      target: options.target,
+      toShed,
+      selected: selected.length,
+    });
+
+    if (selected.length === 0) {
+      return result;
+    }
+
+    const batchSize =
+      options.batchSize !== undefined && options.batchSize >= 1
+        ? Math.floor(options.batchSize)
+        : ServerManager.DEFAULT_REBALANCE_BATCH_SIZE;
+
+    this.rebalance = {
+      queue: selected,
+      batchSize,
+      batchInterval:
+        options.batchIntervalMs ??
+        ServerManager.DEFAULT_REBALANCE_BATCH_INTERVAL_MS,
+      batchTimer: null,
+      shed: 0,
+    };
+
+    // Send the first batch immediately; the rest follow on the batch interval.
+    this.sendRebalanceBatch();
+
+    return result;
+  }
+
+  private sendRebalanceBatch(): void {
+    if (this.rebalance === null) {
+      return;
+    }
+
+    const message = this.rebalanceMessage();
+    const batch = this.rebalance.queue.splice(0, this.rebalance.batchSize);
+
+    let sent = 0;
+    for (const sessionId of batch) {
+      const client = this.connectionManager.getClient(sessionId);
+      if (client === undefined) {
+        continue;
+      }
+      // Skip clients who have since started a challenge.
+      if (client.getActiveChallengeId() !== null) {
+        continue;
+      }
+      client.sendMessage(message);
+      sent += 1;
+    }
+
+    this.rebalance.shed += sent;
+    recordRebalanceShed(sent);
+    logger.info('server_rebalance_batch', {
+      sent,
+      remaining: this.rebalance.queue.length,
+    });
+
+    if (this.rebalance.queue.length === 0) {
+      logger.info('server_rebalance_complete', { shed: this.rebalance.shed });
+      this.rebalance = null;
+      return;
+    }
+
+    this.rebalance.batchTimer = setTimeout(
+      () => this.sendRebalanceBatch(),
+      this.rebalance.batchInterval,
+    );
+  }
+
+  private stopRebalance(): void {
+    if (this.rebalance === null) {
+      return;
+    }
+
+    if (this.rebalance.batchTimer !== null) {
+      clearTimeout(this.rebalance.batchTimer);
+    }
+    logger.info('server_rebalance_stopped', {
+      shed: this.rebalance.shed,
+      remaining: this.rebalance.queue.length,
+    });
+    this.rebalance = null;
+  }
+
+  private rebalanceMessage(): ServerMessage {
+    const message = new ServerMessage();
+    message.setType(ServerMessage.Type.SERVER_STATUS);
+    const serverStatus = new ServerMessage.ServerStatus();
+    serverStatus.setStatus(ServerMessage.ServerStatus.Status.REBALANCING);
+    message.setServerStatus(serverStatus);
+    return message;
   }
 
   private updateStatus(newStatus: ServerStatus): void {


### PR DESCRIPTION
Adds an admin rebalancing flow to socket servers which can be triggered ask clients to voluntarily reconnect to another instance, if they are free. This is done by sending a new REBALANCING message to a subset of connected clients who are not in a challenge to attempt to reach a target client count. Clients are notified in batches to reduce reconnection load. Rebalancing is done best-effort; the selected set of clients is notified once, and no further action is taken.