### PR TITLE
web: Fix ambiguous columns in grouping

### DIFF
--- a/web/__tests__/actions/challenge.test.ts
+++ b/web/__tests__/actions/challenge.test.ts
@@ -1063,6 +1063,94 @@ describe('challenges', () => {
       expect(result!['2']['tob:xarpusHealing'].avg).toBe(125);
     });
 
+    it('groups a split aggregation by scale across scales', async () => {
+      const inserted = await sql`
+        INSERT INTO challenges ${sql(
+          [
+            {
+              session_id: sessionId,
+              uuid: 'a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1',
+              type: ChallengeType.TOB,
+              status: ChallengeStatus.COMPLETED,
+              start_time: new Date('2024-01-02T10:00:00Z'),
+              scale: 3,
+            },
+          ],
+          ['session_id', 'uuid', 'type', 'status', 'start_time', 'scale'],
+        )} RETURNING id
+      `;
+      const scale3Id = inserted[0].id as number;
+
+      const split = (challenge_id: number, scale: number, ticks: number) => ({
+        challenge_id,
+        type: SplitType.TOB_REG_MAIDEN,
+        scale,
+        ticks,
+        accurate: true,
+      });
+      await sql`
+        INSERT INTO challenge_splits ${sql(
+          [
+            split(challengeIds[0], 2, 100),
+            split(challengeIds[1], 2, 200),
+            split(scale3Id, 3, 300),
+          ],
+          ['challenge_id', 'type', 'scale', 'ticks', 'accurate'],
+        )}
+      `;
+
+      const field = `splits:${SplitType.TOB_REG_MAIDEN}`;
+      const result = await aggregateChallenges(
+        { type: ['==', ChallengeType.TOB] },
+        { [field]: [{ type: 'avg' }, { type: 'count' }] },
+        {},
+        'scale',
+      );
+
+      expect(result).toEqual({
+        '2': { [field]: { avg: 150, count: 2 } },
+        '3': { [field]: { avg: 300, count: 1 } },
+      });
+    });
+
+    it('groups by startTime, truncating time of day to a date', async () => {
+      await sql`
+        INSERT INTO challenges ${sql(
+          [
+            {
+              session_id: sessionId,
+              uuid: 'b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2',
+              type: ChallengeType.TOB,
+              status: ChallengeStatus.COMPLETED,
+              start_time: new Date('2026-06-28T09:00:00Z'),
+              scale: 2,
+            },
+            {
+              session_id: sessionId,
+              uuid: 'c3c3c3c3-c3c3-c3c3-c3c3-c3c3c3c3c3c3',
+              type: ChallengeType.TOB,
+              status: ChallengeStatus.COMPLETED,
+              start_time: new Date('2026-06-28T21:00:00Z'),
+              scale: 2,
+            },
+          ],
+          ['session_id', 'uuid', 'type', 'status', 'start_time', 'scale'],
+        )}
+      `;
+
+      const result = await aggregateChallenges(
+        {},
+        { '*': { type: 'count' } },
+        {},
+        'startTime',
+      );
+
+      expect(result).toEqual({
+        '2024-01-01': { '*': { count: 3 } },
+        '2026-06-28': { '*': { count: 2 } },
+      });
+    });
+
     describe('percentiles', () => {
       beforeEach(async () => {
         // Five scale-5 ToB challenges keep this distribution isolated from the

--- a/web/app/actions/challenge.ts
+++ b/web/app/actions/challenge.ts
@@ -1114,17 +1114,10 @@ export async function findChallenges(
 }
 
 type GroupField = {
-  field: string;
+  /** Output column name the grouped value is selected as. */
   renamed: string;
-  groupExpression: postgres.Fragment | null;
+  expression: postgres.Fragment;
 };
-
-function groupExpression(groupField: GroupField): postgres.Fragment {
-  if (groupField.groupExpression === null) {
-    return sql`${sql(groupField.field)}`;
-  }
-  return sql`${groupField.groupExpression} AS ${sql(groupField.renamed)}`;
-}
 
 type Aggregations = Aggregation | Aggregation[];
 
@@ -1343,25 +1336,28 @@ export async function aggregateChallenges<
     const fields: string[] = Array.isArray(grouping) ? grouping : [grouping];
     fields.forEach((field) => {
       const [f, table] = shorthandToFullField(camelToSnake(field));
-      let groupExpression = null;
-      let renamed = f;
+      const sqlTable = table === 'challenges' ? queryTable : sql(table);
 
       if (
-        table === 'challenges' ||
-        joins.find((j) => j.tableName === table) !== undefined
+        table !== 'challenges' &&
+        joins.find((j) => j.tableName === table) === undefined
       ) {
-        if (field === 'startTime') {
-          renamed = 'start_date';
-          groupExpression = sql`${sql(f)}::date`;
-        }
-      } else {
         joins.push({
           table: sql(table),
-          on: sql`challenges.id = ${sql(table)}.challenge_id`,
+          on: sql`${queryTable}.id = ${sqlTable}.challenge_id`,
           tableName: table,
         });
       }
-      groupFields.push({ field: f, renamed, groupExpression });
+
+      const column = sql`${sqlTable}.${sql(f)}`;
+      if (field === 'startTime') {
+        groupFields.push({
+          renamed: 'start_date',
+          expression: sql`${column}::date`,
+        });
+      } else {
+        groupFields.push({ renamed: f, expression: column });
+      }
     });
   }
 
@@ -1392,7 +1388,7 @@ export async function aggregateChallenges<
     SELECT
       ${
         groupFields.length > 0
-          ? sql`${groupFields.map((g) => sql`${groupExpression(g)},`)}`
+          ? sql`${groupFields.map((g) => sql`${g.expression} AS ${sql(g.renamed)},`)}`
           : sql``
       }
       ${aggregateFields.flatMap((f, i) => (i === 0 ? f : [sql`, `, f]))}
@@ -1401,7 +1397,9 @@ export async function aggregateChallenges<
     ${where(conditions)}
     ${
       groupFields.length > 0
-        ? sql`GROUP BY ${sql(groupFields.map((g) => g.renamed))}`
+        ? sql`GROUP BY ${groupFields.flatMap((g, i) =>
+            i === 0 ? g.expression : [sql`, `, g.expression],
+          )}`
         : sql``
     }
     ${sortClause}


### PR DESCRIPTION
When grouping by scale with a filter that joins a table with a scale column, the query would previously fail due to ambiguity. This corrects it to use qualified column names.