### PR TITLE
web: Planning system for historic name changes

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -178,7 +178,11 @@ export {
 export { Prayer, PrayerBook, PrayerSet } from './prayer-set';
 export type { RawPrayerSet } from './prayer-set';
 
-export { type NameChange, NameChangeStatus } from './name-change';
+export {
+  type NameChange,
+  NameChangeKind,
+  NameChangeStatus,
+} from './name-change';
 
 export {
   type CamelToSnakeCase,

--- a/common/migrations/20260628212248-add-historic-name-changes.ts
+++ b/common/migrations/20260628212248-add-historic-name-changes.ts
@@ -1,0 +1,58 @@
+import { TransactionSql } from 'postgres';
+
+export async function migrate(sql: TransactionSql) {
+  await sql`
+    ALTER TABLE name_changes
+    ADD COLUMN kind SMALLINT NOT NULL DEFAULT 0,
+    ADD COLUMN effective_from TIMESTAMPTZ,
+    ADD COLUMN effective_to TIMESTAMPTZ,
+    ADD COLUMN sequence_id UUID,
+    ADD COLUMN hidden_from_profile BOOLEAN NOT NULL DEFAULT FALSE
+  `;
+
+  await sql`
+    ALTER TABLE name_changes RENAME COLUMN hidden TO hidden_from_feed
+  `;
+
+  // The old `hidden` column hid a name change from both the feed and player
+  // profiles. Preserve that for existing rows: anything hidden before stays
+  // hidden from profiles too, rather than reappearing under the new default.
+  await sql`
+    UPDATE name_changes
+    SET hidden_from_profile = TRUE
+    WHERE hidden_from_feed = TRUE
+  `;
+
+  await sql`
+    UPDATE name_changes
+    SET effective_from = COALESCE(processed_at, submitted_at)
+    WHERE effective_from IS NULL
+  `;
+
+  await sql`
+    ALTER TABLE name_changes ALTER COLUMN effective_from SET NOT NULL
+  `;
+
+  await sql`
+    ALTER TABLE name_changes ADD CONSTRAINT name_changes_kind_columns_valid
+    CHECK (
+      (effective_to IS NULL OR effective_from < effective_to)
+      AND (
+        (kind = 0 AND sequence_id IS NULL)
+        OR (kind = 1
+          AND effective_to IS NOT NULL
+          AND sequence_id IS NOT NULL)
+      )
+    )
+  `;
+
+  await sql`
+    CREATE INDEX idx_name_changes_sequence_id
+      ON name_changes (sequence_id) WHERE sequence_id IS NOT NULL
+  `;
+
+  await sql`
+    CREATE INDEX idx_name_changes_effective_from
+      ON name_changes (effective_from DESC)
+  `;
+}

--- a/common/name-change.ts
+++ b/common/name-change.ts
@@ -5,12 +5,23 @@ export enum NameChangeStatus {
   NEW_DOES_NOT_EXIST,
   DECREASED_EXPERIENCE,
   DEFERRED,
+  FAILED,
+}
+
+export enum NameChangeKind {
+  STANDARD = 0,
+  HISTORIC = 1,
 }
 
 export type NameChange = {
+  id: number;
   status: NameChangeStatus;
   oldName: string;
   newName: string;
   submittedAt: Date;
   processedAt: Date | null;
+  kind: NameChangeKind;
+  effectiveFrom: Date;
+  effectiveTo: Date | null;
+  sequenceId: string | null;
 };

--- a/compose.yaml
+++ b/compose.yaml
@@ -67,6 +67,7 @@ services:
       BLERT_TEST_DATA_REPOSITORY: file:///app/.data/testing_data
       BLERT_LOG_LEVEL: debug
       BLERT_REDIS_URI: redis://redis:6379
+      BLERT_MERGE_WORKERS: 1
       BLERT_STRUCTURED_LOGS: ${BLERT_STRUCTURED_LOGS:-false}
     working_dir: /app
     command: npm run -w challenge-server dev

--- a/socket-server/players.ts
+++ b/socket-server/players.ts
@@ -112,6 +112,7 @@ export class Players {
         player_id,
         status,
         submitted_at,
+        effective_from,
         skip_checks
       )
       VALUES (
@@ -119,6 +120,7 @@ export class Players {
         ${newName},
         ${playerId},
         ${NameChangeStatus.PENDING},
+        NOW(),
         NOW(),
         ${skipChecks}
       )

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,6 +1,7 @@
 BLERT_DATABASE_URI=postgres://blert:blert@localhost:5433/blert
 BLERT_REDIS_URI=redis://localhost:6379
 BLERT_DISCORD_BOT_SECRET=blert
+BLERT_ADMIN_SECRET=blert
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
 BETTER_AUTH_SECRET=blert
 BETTER_AUTH_URL=http://localhost:3000

--- a/web/__tests__/actions/name-change-processor.test.ts
+++ b/web/__tests__/actions/name-change-processor.test.ts
@@ -10,12 +10,20 @@ import {
 
 import { sql } from '@/actions/db';
 import {
+  ChainTransition,
   NameChangeProcessor,
+  belongsToChainTarget,
+  decide,
+  deriveNameWindows,
+  dryRunHistoricNameChange,
+  formatPlan,
+  nameInWindowsAt,
   processNameChange,
   recomputePbHistoryFrom,
   updateApiKeys,
   updatePersonalBestHistory,
   updatePlayerStats,
+  validateChain,
 } from '@/actions/name-change-processor';
 import redis from '@/actions/redis';
 
@@ -1021,12 +1029,14 @@ async function createNameChangeRequest(
       old_name,
       new_name,
       status,
-      submitted_at
+      submitted_at,
+      effective_from
     ) VALUES (
       ${playerId},
       ${oldName},
       ${newName},
       ${NameChangeStatus.PENDING},
+      NOW(),
       NOW()
     ) RETURNING id;
   `;
@@ -1051,6 +1061,10 @@ async function loadNameChangeRequest(id: number): Promise<FullNameChange> {
     status: nameChange.status,
     submittedAt: nameChange.submitted_at,
     processedAt: nameChange.processed_at,
+    kind: nameChange.kind,
+    effectiveFrom: nameChange.effective_from,
+    effectiveTo: nameChange.effective_to,
+    sequenceId: nameChange.sequence_id,
     playerId: nameChange.player_id,
     submitterId: nameChange.submitter_id,
     migratedDocuments: nameChange.migrated_documents,
@@ -1158,8 +1172,8 @@ describe('NameChangeProcessor.processBatch', () => {
       });
 
     await sql`
-      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at)
-      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.PENDING}, NOW())
+      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at, effective_from)
+      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.PENDING}, NOW(), NOW())
     `;
 
     const result = await processor.processBatch();
@@ -1194,8 +1208,8 @@ describe('NameChangeProcessor.processBatch', () => {
       });
 
     await sql`
-      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at)
-      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.PENDING}, NOW())
+      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at, effective_from)
+      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.PENDING}, NOW(), NOW())
     `;
 
     const result = await processor.processBatch();
@@ -1212,8 +1226,8 @@ describe('NameChangeProcessor.processBatch', () => {
 
   it('promotes DEFERRED entries when player is no longer in active challenge', async () => {
     await sql`
-      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at)
-      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.DEFERRED}, NOW())
+      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at, effective_from)
+      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.DEFERRED}, NOW(), NOW())
     `;
 
     // Mock Redis to indicate player is not in active challenge.
@@ -1237,8 +1251,8 @@ describe('NameChangeProcessor.processBatch', () => {
 
   it('does not promote DEFERRED entries when player is still in active challenge', async () => {
     await sql`
-      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at)
-      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.DEFERRED}, NOW())
+      INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at, effective_from)
+      VALUES (${playerId}, 'BatchPlayer', 'NewBatch', ${NameChangeStatus.DEFERRED}, NOW(), NOW())
     `;
 
     // Mock Redis to indicate player is in an active challenge.
@@ -1282,8 +1296,8 @@ describe('NameChangeProcessor.processBatch', () => {
         RETURNING id
       `;
       await sql`
-        INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at)
-        VALUES (${pid}, ${'Bp' + i}, ${'Nn' + i}, ${NameChangeStatus.PENDING}, NOW())
+        INSERT INTO name_changes (player_id, old_name, new_name, status, submitted_at, effective_from)
+        VALUES (${pid}, ${'Bp' + i}, ${'Nn' + i}, ${NameChangeStatus.PENDING}, NOW(), NOW())
       `;
     }
 
@@ -1565,8 +1579,8 @@ describe('updateApiKeys', () => {
 
   it('reassigns keys with last_used > fromDate when toDate is null', async () => {
     await seedKeys(sourcePlayerId, [
-      { key: 'pre-fromdate', lastUsed: '2026-01-01' },
-      { key: 'post-fromdate', lastUsed: '2026-03-01' },
+      { key: 'pre-from-date', lastUsed: '2026-01-01' },
+      { key: 'post-from-date', lastUsed: '2026-03-01' },
       { key: 'unused', lastUsed: null },
     ]);
 
@@ -1580,11 +1594,11 @@ describe('updateApiKeys', () => {
     const rows = await loadKeys();
     expect(rows).toEqual([
       expect.objectContaining({
-        key: 'post-fromdate',
+        key: 'post-from-date',
         player_id: targetPlayerId,
       }),
       expect.objectContaining({
-        key: 'pre-fromdate',
+        key: 'pre-from-date',
         player_id: sourcePlayerId,
       }),
       expect.objectContaining({ key: 'unused', player_id: sourcePlayerId }),
@@ -1620,8 +1634,8 @@ describe('updateApiKeys', () => {
 
   it('does not touch keys whose last_used is exactly fromDate or toDate boundaries', async () => {
     await seedKeys(sourcePlayerId, [
-      { key: 'at-fromdate', lastUsed: '2026-02-01' },
-      { key: 'at-todate', lastUsed: '2026-04-01' },
+      { key: 'at-from-date', lastUsed: '2026-02-01' },
+      { key: 'at-to-date', lastUsed: '2026-04-01' },
     ]);
 
     await updateApiKeys(
@@ -1633,10 +1647,10 @@ describe('updateApiKeys', () => {
     );
 
     const rows = await loadKeys();
-    expect(rows.find((r) => r.key === 'at-fromdate')?.player_id).toBe(
+    expect(rows.find((r) => r.key === 'at-from-date')?.player_id).toBe(
       sourcePlayerId,
     );
-    expect(rows.find((r) => r.key === 'at-todate')?.player_id).toBe(
+    expect(rows.find((r) => r.key === 'at-to-date')?.player_id).toBe(
       targetPlayerId,
     );
   });
@@ -2313,6 +2327,579 @@ describe('updatePersonalBestHistory', () => {
 
       const newRows = await pbHistoryFor(newPlayerId);
       expect(newRows.map((r) => r.challenge_split_id)).toEqual([post.splitId]);
+    });
+  });
+});
+
+describe('historic name changes', () => {
+  let createdPlayerIds: number[] = [];
+  let userId: number;
+  let keyCounter = 0;
+
+  beforeAll(async () => {
+    const [{ id }] = await sql<{ id: number }[]>`
+      INSERT INTO users (username, email, password)
+      VALUES ('Historic User', 'historic@b.com', 'password')
+      RETURNING id
+    `;
+    userId = id;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM users WHERE id = ${userId}`;
+  });
+
+  async function makePlayer(username: string): Promise<number> {
+    const [{ id }] = await sql<{ id: number }[]>`
+      INSERT INTO players (username, normalized_username)
+      VALUES (${username}, ${normalizeRsn(username)})
+      RETURNING id
+    `;
+    createdPlayerIds.push(id);
+    return id;
+  }
+
+  async function makeChallenge(
+    playerId: number,
+    username: string,
+    startTime: string,
+  ): Promise<number> {
+    const [{ id }] = await sql<{ id: number }[]>`
+      INSERT INTO challenges (uuid, start_time, finish_time, type, scale)
+      VALUES (gen_random_uuid(), ${startTime}, ${startTime}, ${ChallengeType.TOB}, 1)
+      RETURNING id
+    `;
+    await sql`
+      INSERT INTO challenge_players (challenge_id, player_id, username, orb, primary_gear)
+      VALUES (${id}, ${playerId}, ${username}, 0, 1)
+    `;
+    return id;
+  }
+
+  async function makeStats(
+    playerId: number,
+    ...dates: string[]
+  ): Promise<void> {
+    if (dates.length === 0) {
+      return;
+    }
+    await sql`
+      INSERT INTO player_stats ${sql(
+        dates.map((date) => ({ player_id: playerId, date })),
+      )}
+    `;
+  }
+
+  async function makeKeys(
+    playerId: number,
+    ...lastUsed: string[]
+  ): Promise<void> {
+    if (lastUsed.length === 0) {
+      return;
+    }
+    await sql`
+      INSERT INTO api_keys ${sql(
+        lastUsed.map((last_used) => {
+          keyCounter += 1;
+          return {
+            user_id: userId,
+            player_id: playerId,
+            key: `hist-key-${keyCounter}`,
+            last_used,
+          };
+        }),
+      )}
+    `;
+  }
+
+  afterEach(async () => {
+    if (createdPlayerIds.length > 0) {
+      await sql`
+        DELETE FROM challenges
+        WHERE id IN (
+          SELECT challenge_id
+          FROM challenge_players
+          WHERE player_id = ANY(${createdPlayerIds})
+        )
+      `;
+      await sql`DELETE FROM players WHERE id = ANY(${createdPlayerIds})`;
+      createdPlayerIds = [];
+    }
+  });
+
+  // Renames are spaced > 30 days apart, mirroring the OSRS username hold so
+  // each name's challenges fall unambiguously in one window.
+  const FEB = '2026-02-01';
+  const APR = '2026-04-01';
+  const JUN = '2026-06-01';
+
+  function transition(
+    oldName: string,
+    newName: string,
+    effectiveFrom: string,
+  ): ChainTransition {
+    return {
+      oldName,
+      newName,
+      effectiveFrom: new Date(effectiveFrom),
+    };
+  }
+
+  describe('name change chains', () => {
+    describe('nameInWindowsAt', () => {
+      const windows = deriveNameWindows([
+        transition('Foo', 'Bar', FEB),
+        transition('Bar', 'Baz', APR),
+      ]);
+
+      it('returns the original name before the first breakpoint', () => {
+        expect(nameInWindowsAt(windows, new Date('2026-01-01'))).toBe('foo');
+      });
+
+      it('attributes the first breakpoint instant to the original name', () => {
+        expect(nameInWindowsAt(windows, new Date(FEB))).toBe('foo');
+      });
+
+      it('returns the intermediate name within its window', () => {
+        expect(nameInWindowsAt(windows, new Date('2026-03-01'))).toBe('bar');
+      });
+
+      it('attributes a later breakpoint instant to the preceding name', () => {
+        expect(nameInWindowsAt(windows, new Date(APR))).toBe('bar');
+      });
+
+      it('returns the current name after the last breakpoint', () => {
+        expect(nameInWindowsAt(windows, new Date('2026-05-01'))).toBe('baz');
+      });
+
+      it('returns the reverted name in its later window for a revert chain', () => {
+        const revert = deriveNameWindows([
+          transition('foo', 'bar', FEB),
+          transition('bar', 'foo', APR),
+        ]);
+        expect(nameInWindowsAt(revert, new Date('2026-01-01'))).toBe('foo');
+        expect(nameInWindowsAt(revert, new Date('2026-03-01'))).toBe('bar');
+        expect(nameInWindowsAt(revert, new Date('2026-05-01'))).toBe('foo');
+      });
+    });
+
+    describe('deriveNameWindows', () => {
+      it('produces an open-ended first and last window for a single transition', () => {
+        const windows = deriveNameWindows([transition('foo', 'bar', FEB)]);
+        expect(windows).toEqual([
+          { normalizedRsn: 'foo', from: null, to: new Date(FEB) },
+          { normalizedRsn: 'bar', from: new Date(FEB), to: null },
+        ]);
+      });
+
+      it('emits a window per held name bounded by the next breakpoint', () => {
+        const windows = deriveNameWindows([
+          transition('foo', 'bar', FEB),
+          transition('bar', 'baz', APR),
+        ]);
+        expect(windows).toEqual([
+          { normalizedRsn: 'foo', from: null, to: new Date(FEB) },
+          {
+            normalizedRsn: 'bar',
+            from: new Date(FEB),
+            to: new Date(APR),
+          },
+          { normalizedRsn: 'baz', from: new Date(APR), to: null },
+        ]);
+      });
+
+      it('represents a revert as the same name in two separate windows', () => {
+        const windows = deriveNameWindows([
+          transition('foo', 'bar', FEB),
+          transition('bar', 'foo', APR),
+        ]);
+        expect(windows.map((w) => w.normalizedRsn)).toEqual([
+          'foo',
+          'bar',
+          'foo',
+        ]);
+      });
+
+      it('tiles the timeline contiguously', () => {
+        const windows = deriveNameWindows([
+          transition('foo', 'bar', FEB),
+          transition('bar', 'baz', APR),
+        ]);
+        for (let i = 0; i < windows.length - 1; i++) {
+          expect(windows[i].to).toEqual(windows[i + 1].from);
+        }
+        expect(windows[0].from).toBeNull();
+        expect(windows[windows.length - 1].to).toBeNull();
+      });
+
+      it('throws on an empty chain', () => {
+        expect(() => deriveNameWindows([])).toThrow();
+      });
+    });
+
+    describe('belongsToChainTarget', () => {
+      const windows = deriveNameWindows([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+
+      it('matches a name held during its own window', () => {
+        expect(
+          belongsToChainTarget(windows, 'foo', new Date('2026-01-01')),
+        ).toBe(true);
+        expect(
+          belongsToChainTarget(windows, 'bar', new Date('2026-03-01')),
+        ).toBe(true);
+        expect(
+          belongsToChainTarget(windows, 'baz', new Date('2026-05-01')),
+        ).toBe(true);
+      });
+
+      it('rejects a chain name used outside its window', () => {
+        expect(
+          belongsToChainTarget(windows, 'foo', new Date('2026-03-01')),
+        ).toBe(false);
+        expect(
+          belongsToChainTarget(windows, 'bar', new Date('2026-05-01')),
+        ).toBe(false);
+      });
+
+      it('rejects a name that never appears in the chain', () => {
+        expect(
+          belongsToChainTarget(windows, 'qux', new Date('2026-03-01')),
+        ).toBe(false);
+      });
+    });
+
+    describe('validateChain', () => {
+      it('accepts a well-formed chain', () => {
+        expect(validateChain([transition('foo', 'bar', FEB)])).toBeNull();
+        expect(
+          validateChain([
+            transition('foo', 'bar', FEB),
+            transition('bar', 'baz', APR),
+          ]),
+        ).toBeNull();
+      });
+
+      it('accepts links that match after normalization', () => {
+        expect(
+          validateChain([
+            transition('foo', 'mid bar', FEB),
+            transition('Mid-Bar', 'baz', APR),
+          ]),
+        ).toBeNull();
+      });
+
+      it('rejects an empty chain', () => {
+        expect(validateChain([])).toBe('empty');
+      });
+
+      it('rejects invalid names', () => {
+        expect(validateChain([transition('foo@', 'bar', FEB)])).toBe(
+          'invalid_rsn',
+        );
+        expect(
+          validateChain([transition('foo', 'this name is too long', FEB)]),
+        ).toBe('invalid_rsn');
+      });
+
+      it('rejects out-of-order or coincident transitions', () => {
+        expect(
+          validateChain([
+            transition('foo', 'bar', APR),
+            transition('bar', 'baz', FEB),
+          ]),
+        ).toBe('not_chronological');
+        expect(
+          validateChain([
+            transition('foo', 'bar', FEB),
+            transition('bar', 'baz', FEB),
+          ]),
+        ).toBe('not_chronological');
+      });
+
+      it('rejects a broken link between transitions', () => {
+        expect(
+          validateChain([
+            transition('foo', 'bar', FEB),
+            transition('qux', 'baz', APR),
+          ]),
+        ).toBe('inconsistent_link');
+      });
+    });
+  });
+
+  describe('decide', () => {
+    it('targets the existing record holding the current name', async () => {
+      const [{ id }] = await sql<{ id: number }[]>`
+      INSERT INTO players (username, normalized_username)
+      VALUES ('baz', ${normalizeRsn('baz')})
+      RETURNING id
+    `;
+      createdPlayerIds.push(id);
+
+      const plan = await decide([
+        transition('foo', 'bar', '2026-02-01'),
+        transition('bar', 'baz', '2026-04-01'),
+      ]);
+
+      expect(plan.target).toEqual({ action: 'use', playerId: id });
+    });
+
+    it('plans to create a target when no record holds the current name', async () => {
+      const plan = await decide([transition('foo', 'qux', '2026-02-01')]);
+      expect(plan.target).toEqual({ action: 'create', currentName: 'qux' });
+    });
+
+    it('gathers each scattered record by name window, skipping the target', async () => {
+      // The chain foo -> bar -> baz, current record holds baz.
+      const targetId = await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      const barRecordId = await makePlayer('bar');
+
+      // foo's challenge lives on the foo record (in the foo window).
+      const fooChallenge = await makeChallenge(
+        fooRecordId,
+        'foo',
+        '2026-01-15',
+      );
+      // bar's challenge lives on the bar record (in the bar window).
+      const barChallenge = await makeChallenge(
+        barRecordId,
+        'bar',
+        '2026-03-15',
+      );
+      // baz's challenge is already on the target — not a move.
+      await makeChallenge(targetId, 'baz', '2026-05-15');
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+
+      // windows[0]=foo, [1]=bar, [2]=baz.
+      expect(plan.sourcePlayers).toEqual([
+        { playerId: fooRecordId, windowIndex: 0, challengeIds: [fooChallenge] },
+        { playerId: barRecordId, windowIndex: 1, challengeIds: [barChallenge] },
+      ]);
+    });
+
+    it("does not gather a same-named challenge outside the player's window", async () => {
+      // Chain foo -> baz, renamed at FEB, so the foo window ends at FEB.
+      await makePlayer('baz');
+      const foo = await makePlayer('foo');
+
+      const ourChallenge = await makeChallenge(foo, 'foo', '2026-01-15');
+      // A later foo challenge falls after the rename: it is no longer the
+      // player's, so it is excluded even though it sits on the same record.
+      await makeChallenge(foo, 'foo', '2026-05-15');
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+
+      expect(plan.sourcePlayers).toEqual([
+        { playerId: foo, windowIndex: 0, challengeIds: [ourChallenge] },
+      ]);
+    });
+
+    it('ignores windows without source records', async () => {
+      // Chain foo -> bar -> baz -> qux. The player recorded as foo
+      // (window 0) and as baz (window 2) but never as bar (window 1).
+      await makePlayer('qux');
+      const fooRecordId = await makePlayer('foo');
+      const bazRecordId = await makePlayer('baz');
+      const fooChallenge = await makeChallenge(
+        fooRecordId,
+        'foo',
+        '2026-01-15',
+      );
+      const bazChallenge = await makeChallenge(
+        bazRecordId,
+        'baz',
+        '2026-05-15',
+      );
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+        transition('baz', 'qux', JUN),
+      ]);
+
+      // bar window (index 1) is skipped.
+      expect(plan.sourcePlayers).toEqual([
+        { playerId: fooRecordId, windowIndex: 0, challengeIds: [fooChallenge] },
+        { playerId: bazRecordId, windowIndex: 2, challengeIds: [bazChallenge] },
+      ]);
+    });
+
+    it('marks a source emptied when all of its rows move', async () => {
+      // The foo record's only challenge moves to the target, emptying it.
+      await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-15');
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+
+      expect(plan.emptiedSourceIds).toEqual([fooRecordId]);
+    });
+
+    it('does not mark a source emptied when it keeps a row', async () => {
+      // The foo record has one in-window challenge and one later challenge,
+      // so it is not emptied.
+      await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-15');
+      await makeChallenge(fooRecordId, 'foo', '2026-05-15');
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+
+      expect(plan.emptiedSourceIds).toEqual([]);
+    });
+  });
+
+  describe('formatPlan', () => {
+    it('reports an existing target with its challenge counts before and after', async () => {
+      const targetId = await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      // foo (0c) -> bar (1c) -> baz (1c)
+      await makeChallenge(targetId, 'baz', '2026-05-15');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-15');
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+      const display = await formatPlan(plan);
+
+      expect(display.target).toEqual({
+        name: 'baz',
+        isNew: false,
+        challengesBefore: 1,
+        challengesAfter: 2,
+        pbRecomputedFrom: new Date('2026-01-15'),
+      });
+    });
+
+    it('reports a target that would be created with a zero before count', async () => {
+      const fooRecordId = await makePlayer('foo');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-15');
+
+      const plan = await decide([transition('foo', 'qux', FEB)]);
+      const display = await formatPlan(plan);
+
+      expect(display.target).toEqual({
+        name: 'qux',
+        isNew: true,
+        challengesBefore: 0,
+        challengesAfter: 1,
+        pbRecomputedFrom: new Date('2026-01-15'),
+      });
+    });
+
+    it('describes each contribution with in-window stat and key counts', async () => {
+      // foo -> bar -> baz (target baz).
+      await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      const barRecordId = await makePlayer('bar');
+
+      await makeChallenge(fooRecordId, 'foo', '2026-01-10');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-20');
+      await makeChallenge(barRecordId, 'bar', '2026-03-15');
+
+      // Two foo stats in window, one after the rename.
+      await makeStats(fooRecordId, '2026-01-10', '2026-01-20', '2026-05-01');
+      // One foo key in window, one after.
+      await makeKeys(fooRecordId, '2026-01-15', '2026-05-01');
+      // One bar stat in window; no bar keys.
+      await makeStats(barRecordId, '2026-03-15');
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+      const display = await formatPlan(plan);
+
+      expect(display.contributions).toEqual([
+        {
+          sourceName: 'foo',
+          asName: 'foo',
+          span: { from: new Date('2026-01-10'), to: new Date('2026-01-20') },
+          challenges: 2,
+          stats: 2,
+          apiKeys: 1,
+        },
+        {
+          sourceName: 'bar',
+          asName: 'bar',
+          span: { from: new Date('2026-03-15'), to: new Date('2026-03-15') },
+          challenges: 1,
+          stats: 1,
+          apiKeys: 0,
+        },
+      ]);
+    });
+
+    it('summarizes each source with its outcome and pb cutoff date', async () => {
+      // foo -> bar -> baz. foo is deleted; bar is kept.
+      await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      const barRecordId = await makePlayer('bar');
+
+      await makeChallenge(fooRecordId, 'foo', '2026-01-10');
+      await makeChallenge(barRecordId, 'bar', '2026-03-15');
+      // One later bar challenge.
+      await makeChallenge(barRecordId, 'bar', '2026-05-15');
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+      const display = await formatPlan(plan);
+
+      expect(display.sources).toEqual([
+        { name: 'foo', outcome: 'deleted' },
+        {
+          name: 'bar',
+          outcome: 'kept',
+          pbRecomputedFrom: new Date('2026-03-15'),
+        },
+      ]);
+    });
+  });
+
+  describe('dryRunHistoricNameChange', () => {
+    it('rejects a malformed chain without touching the database', async () => {
+      const result = await dryRunHistoricNameChange([
+        transition('foo', 'bar', APR),
+        transition('bar', 'baz', FEB),
+      ]);
+      expect(result).toEqual({ ok: false, error: 'not_chronological' });
+    });
+
+    it('returns the display plan for a valid chain', async () => {
+      await makePlayer('baz');
+      const fooRecordId = await makePlayer('foo');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-15');
+
+      const result = await dryRunHistoricNameChange([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.plan.target.name).toBe('baz');
+        expect(result.plan.contributions).toHaveLength(1);
+        expect(result.plan.sources).toEqual([
+          { name: 'foo', outcome: 'deleted' },
+        ]);
+      }
     });
   });
 });

--- a/web/app/(account)/name-changes/name-change-row.tsx
+++ b/web/app/(account)/name-changes/name-change-row.tsx
@@ -33,6 +33,8 @@ function nameChangeInfo(nameChange: NameChange): [string, string | null] {
         'Rejected',
         `This name change was rejected because the account "${nameChange.newName}" has less experience than "${nameChange.oldName}" previously had.`,
       ];
+    case NameChangeStatus.FAILED:
+      return ['Failed', null];
   }
 }
 

--- a/web/app/actions/change-name.ts
+++ b/web/app/actions/change-name.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import {
+  CamelToSnakeCase,
   NameChange,
   NameChangeStatus,
   isValidRsn,
@@ -12,6 +13,13 @@ import { redirect } from 'next/navigation';
 import { sql } from './db';
 import processor from './name-change-processor';
 import { getSignedInUserId } from './users';
+
+type NameChangeRow = CamelToSnakeCase<NameChange> & {
+  player_id: number;
+  submitter_id: string | null;
+  hidden_from_feed: boolean;
+  hidden_from_profile: boolean;
+};
 
 export async function submitNameChangeForm(
   _state: string | null,
@@ -49,19 +57,14 @@ export async function submitNameChangeForm(
     return 'This player already has a pending name change';
   }
 
-  const nameChange: {
-    status: NameChangeStatus;
-    old_name: string;
-    new_name: string;
-    player_id: number;
-    submitted_at: Date;
-    submitter_id?: string;
-  } = {
+  const now = new Date();
+  const nameChange: Partial<NameChangeRow> = {
     status: NameChangeStatus.PENDING,
     old_name: player.username,
     new_name: newName,
     player_id: player.id,
-    submitted_at: new Date(),
+    submitted_at: now,
+    effective_from: now,
   };
   if (userId !== null) {
     nameChange.submitter_id = userId.toString();
@@ -74,14 +77,20 @@ export async function submitNameChangeForm(
   redirect('/name-changes');
 }
 
-type NameChangeRow = {
-  id: number;
-  old_name: string;
-  new_name: string;
-  status: NameChangeStatus;
-  submitted_at: Date;
-  processed_at: Date | null;
-};
+function rowToNameChange(nc: NameChangeRow): NameChange {
+  return {
+    id: nc.id,
+    oldName: nc.old_name,
+    newName: nc.new_name,
+    status: nc.status,
+    submittedAt: nc.submitted_at,
+    processedAt: nc.processed_at,
+    kind: nc.kind,
+    effectiveFrom: nc.effective_from,
+    effectiveTo: nc.effective_to,
+    sequenceId: nc.sequence_id,
+  };
+}
 
 export async function getRecentNameChanges(
   limit: number = 10,
@@ -93,21 +102,18 @@ export async function getRecentNameChanges(
       new_name,
       status,
       submitted_at,
-      processed_at
+      processed_at,
+      kind,
+      effective_from,
+      effective_to,
+      sequence_id
     FROM name_changes
-    WHERE hidden = FALSE
-    ORDER BY id DESC
+    WHERE hidden_from_feed = FALSE
+    ORDER BY effective_from DESC
     LIMIT ${limit}
   `;
 
-  return nameChanges.map((nc) => ({
-    id: nc.id,
-    oldName: nc.old_name,
-    newName: nc.new_name,
-    status: nc.status,
-    submittedAt: nc.submitted_at,
-    processedAt: nc.processed_at,
-  }));
+  return nameChanges.map(rowToNameChange);
 }
 
 export async function getNameChangesForPlayer(
@@ -121,22 +127,19 @@ export async function getNameChangesForPlayer(
       nc.new_name,
       nc.status,
       nc.submitted_at,
-      nc.processed_at
+      nc.processed_at,
+      nc.kind,
+      nc.effective_from,
+      nc.effective_to,
+      nc.sequence_id
     FROM name_changes nc
     JOIN players p ON nc.player_id = p.id
     WHERE p.normalized_username = ${normalizeRsn(username)}
       AND nc.status = ${NameChangeStatus.ACCEPTED}
-      AND nc.hidden = FALSE
-    ORDER BY nc.processed_at DESC
+      AND nc.hidden_from_profile = FALSE
+    ORDER BY nc.effective_from DESC
     LIMIT ${limit}
   `;
 
-  return nameChanges.map((nc) => ({
-    id: nc.id,
-    oldName: nc.old_name,
-    newName: nc.new_name,
-    status: nc.status,
-    submittedAt: nc.submitted_at,
-    processedAt: nc.processed_at,
-  }));
+  return nameChanges.map(rowToNameChange);
 }

--- a/web/app/actions/feed.ts
+++ b/web/app/actions/feed.ts
@@ -689,7 +689,7 @@ async function fetchNameChangeFeedItems(
     JOIN user_follows uf
       ON nc.player_id = uf.player_id AND uf.user_id = ${userId}
     WHERE nc.status = ${NameChangeStatus.ACCEPTED}
-      AND nc.hidden = FALSE
+      AND nc.hidden_from_feed = FALSE
       AND nc.processed_at IS NOT NULL
       ${cursorCondition}
     ORDER BY nc.processed_at DESC, nc.id DESC

--- a/web/app/actions/name-change-processor.ts
+++ b/web/app/actions/name-change-processor.ts
@@ -3,6 +3,7 @@ import {
   CamelToSnakeCase,
   HiscoresRateLimitError,
   NAME_CHANGE_PUBSUB_KEY,
+  NameChangeKind,
   NameChangeStatus,
   NameChangeUpdate,
   NameChangeUpdateType,
@@ -10,6 +11,7 @@ import {
   PlayerStats,
   Skill,
   hiscoreLookup,
+  isValidRsn,
   normalizeRsn,
 } from '@blert/common';
 
@@ -346,6 +348,463 @@ export async function recomputePbHistoryFrom(
   return deleted.count + inserted;
 }
 
+/** A single rename in a player's known name history. */
+export type ChainTransition = {
+  oldName: string;
+  newName: string;
+  effectiveFrom: Date;
+};
+
+/** Why a submitted name change chain is not well-formed. */
+export type ChainError =
+  | 'empty'
+  | 'invalid_rsn'
+  | 'not_chronological'
+  | 'inconsistent_link';
+
+/**
+ * Checks that a name change chain is well-formed: nonempty, every name valid,
+ * transitions strictly ordered by `effectiveFrom`, and with each transition's
+ * new name matching the next transition's old name.
+ *
+ * @returns The first problem found, or `null` if the chain is well-formed.
+ */
+export function validateChain(chain: ChainTransition[]): ChainError | null {
+  if (chain.length === 0) {
+    return 'empty';
+  }
+
+  for (const transition of chain) {
+    if (!isValidRsn(transition.oldName) || !isValidRsn(transition.newName)) {
+      return 'invalid_rsn';
+    }
+  }
+
+  for (let i = 1; i < chain.length; i++) {
+    if (chain[i].effectiveFrom <= chain[i - 1].effectiveFrom) {
+      return 'not_chronological';
+    }
+    if (normalizeRsn(chain[i - 1].newName) !== normalizeRsn(chain[i].oldName)) {
+      return 'inconsistent_link';
+    }
+  }
+
+  return null;
+}
+
+/** A contiguous time interval during which a player held a single RSN. */
+export type NameWindow = {
+  normalizedRsn: string;
+  from: Date | null;
+  to: Date | null;
+};
+
+function inWindow(t: Date, w: NameWindow): boolean {
+  const afterFrom = w.from === null || t > w.from;
+  const beforeTo = w.to === null || t <= w.to;
+  return afterFrom && beforeTo;
+}
+
+/**
+ * Derives a player's RSN history windows from a chronological chain.
+ *
+ * Produces `chain.length + 1` windows to cover the open-ended periods before
+ * the first name change and after the last name change.
+ */
+export function deriveNameWindows(chain: ChainTransition[]): NameWindow[] {
+  if (chain.length === 0) {
+    throw new Error('chain must be non-empty');
+  }
+
+  const windows: NameWindow[] = [
+    {
+      normalizedRsn: normalizeRsn(chain[0].oldName),
+      from: null,
+      to: chain[0].effectiveFrom,
+    },
+  ];
+  for (let i = 0; i < chain.length; i++) {
+    windows.push({
+      normalizedRsn: normalizeRsn(chain[i].newName),
+      from: chain[i].effectiveFrom,
+      to: i + 1 < chain.length ? chain[i + 1].effectiveFrom : null,
+    });
+  }
+  return windows;
+}
+
+/**
+ * Returns the normalized name the player held at time `t`
+ * from a list of windows.
+ */
+export function nameInWindowsAt(windows: NameWindow[], t: Date): string {
+  const window = windows.find((w) => inWindow(t, w));
+  // A well-formed chain spans all of time.
+  return window!.normalizedRsn;
+}
+
+/** Checks whether a name belongs to the chain's player at a given time. */
+export function belongsToChainTarget(
+  windows: NameWindow[],
+  normalizedRsn: string,
+  startTime: Date,
+): boolean {
+  return nameInWindowsAt(windows, startTime) === normalizedRsn;
+}
+
+function _chainFromHistoricSequence(
+  rows: NameChangeQueryResult[],
+): ChainTransition[] {
+  return rows
+    .toSorted((a, b) => a.effective_from.getTime() - b.effective_from.getTime())
+    .map((r) => ({
+      oldName: r.old_name,
+      newName: r.new_name,
+      effectiveFrom: r.effective_from,
+    }));
+}
+
+type TargetPlayer =
+  | { action: 'use'; playerId: number }
+  | { action: 'create'; currentName: string };
+
+/**
+ * The player ID of a source record for a historic name change sequence, with
+ * the challenges they participated in during a single name window.
+ * `windowIndex` references the migration plan's `windows`.
+ */
+type SourcePlayer = {
+  playerId: number;
+  windowIndex: number;
+  challengeIds: number[];
+};
+
+/**
+ * Description of what a historic name change sequence would change.
+ */
+export type MigrationPlan = {
+  target: TargetPlayer;
+  windows: NameWindow[];
+  sourcePlayers: SourcePlayer[];
+  /**
+   * Source records who are entirely absorbed by the target and can be deleted.
+   */
+  emptiedSourceIds: number[];
+};
+
+/**
+ * Read-only resolution of the target player in a historic name change sequence.
+ */
+async function resolveTarget(
+  chain: ChainTransition[],
+  db: Db = sql,
+): Promise<TargetPlayer> {
+  const currentName = chain[chain.length - 1].newName;
+
+  const [existing]: [{ id: number }?] = await db`
+    SELECT id FROM players WHERE normalized_username = ${normalizeRsn(currentName)}
+  `;
+  if (existing !== undefined) {
+    return { action: 'use', playerId: existing.id };
+  }
+
+  return { action: 'create', currentName };
+}
+
+/**
+ * Finds the `challenge_players` rows that belong to a historic sequence's
+ * target, grouped by source record and name window, ignoring those already
+ * attributed to the target.
+ */
+async function gatherSourcePlayers(
+  windows: NameWindow[],
+  target: TargetPlayer,
+  db: Db = sql,
+): Promise<SourcePlayer[]> {
+  const targetPlayerId = target.action === 'use' ? target.playerId : null;
+  const sources: SourcePlayer[] = [];
+
+  for (let windowIndex = 0; windowIndex < windows.length; windowIndex++) {
+    const window = windows[windowIndex];
+
+    const matched = await db<{ player_id: number; challenge_id: number }[]>`
+      SELECT cp.player_id, cp.challenge_id
+      FROM challenge_players cp
+      JOIN challenges c ON c.id = cp.challenge_id
+      WHERE translate(lower(cp.username), ' -', '__') = ${window.normalizedRsn}
+        ${window.from !== null ? db`AND c.start_time > ${window.from}` : db``}
+        ${window.to !== null ? db`AND c.start_time <= ${window.to}` : db``}
+        ${targetPlayerId !== null ? db`AND cp.player_id <> ${targetPlayerId}` : db``}
+      ORDER BY cp.player_id, cp.challenge_id
+    `;
+
+    const byPlayer = new Map<number, number[]>();
+    for (const { player_id, challenge_id } of matched) {
+      const ids = byPlayer.get(player_id) ?? [];
+      ids.push(challenge_id);
+      byPlayer.set(player_id, ids);
+    }
+
+    for (const [playerId, challengeIds] of byPlayer) {
+      sources.push({ playerId, windowIndex, challengeIds });
+    }
+  }
+
+  return sources;
+}
+
+/**
+ * Returns the IDs of source records in a migration that would lose all of
+ * their `challenge_players` rows to the target.
+ */
+async function findEmptiedSources(
+  sourcePlayers: SourcePlayer[],
+  db: Db = sql,
+): Promise<number[]> {
+  const movedCountByPlayer = new Map<number, number>();
+  for (const source of sourcePlayers) {
+    const prior = movedCountByPlayer.get(source.playerId) ?? 0;
+    movedCountByPlayer.set(source.playerId, prior + source.challengeIds.length);
+  }
+
+  const emptied: number[] = [];
+  for (const [playerId, movedCount] of movedCountByPlayer) {
+    const [{ count }] = await db<[{ count: string }]>`
+      SELECT COUNT(*) FROM challenge_players WHERE player_id = ${playerId}
+    `;
+    if (parseInt(count) === movedCount) {
+      emptied.push(playerId);
+    }
+  }
+
+  return emptied;
+}
+
+/** Computes the migration plan for a historic name change chain. Read-only. */
+export async function decide(
+  chain: ChainTransition[],
+  db: Db = sql,
+): Promise<MigrationPlan> {
+  const windows = deriveNameWindows(chain);
+  const target = await resolveTarget(chain, db);
+  const sourcePlayers = await gatherSourcePlayers(windows, target, db);
+  const emptiedSourceIds = await findEmptiedSources(sourcePlayers, db);
+
+  return { target, windows, sourcePlayers, emptiedSourceIds };
+}
+
+/**
+ * A human-readable projection of a {@link MigrationPlan}, resolving the plan's
+ * internal IDs and window indices into names, counts, and dates for review
+ * before committing a historic name change.
+ */
+export type DisplayPlan = {
+  target: {
+    name: string;
+    isNew: boolean;
+    challengesBefore: number;
+    challengesAfter: number;
+    /**
+     * Date of the earliest challenge ID moving onto the target, from which its
+     * personal bests are recomputed, or `null` if none move.
+     */
+    pbRecomputedFrom: Date | null;
+  };
+  /** One entry per source record and name window contributing data. */
+  contributions: DisplayContribution[];
+  /** One entry per source record, describing its overall fate. */
+  sources: DisplaySource[];
+};
+
+/** The data a single source record contributes under a single name window. */
+type DisplayContribution = {
+  sourceName: string;
+  /** Name under which the data was recorded. */
+  asName: string;
+  span: { from: Date; to: Date };
+  challenges: number;
+  stats: number;
+  apiKeys: number;
+};
+
+/**
+ * What happens to a single source record overall. A deleted record is fully
+ * absorbed by the target; a kept record retains data, and its personal bests
+ * are recomputed from the given date.
+ */
+type DisplaySource =
+  | { name: string; outcome: 'deleted' }
+  | { name: string; outcome: 'kept'; pbRecomputedFrom: Date };
+
+async function countChallenges(playerId: number, db: Db): Promise<number> {
+  const [{ count }] = await db<[{ count: string }]>`
+    SELECT COUNT(*) FROM challenge_players WHERE player_id = ${playerId}
+  `;
+  return parseInt(count);
+}
+
+/** Builds per-contribution display rows for a migration plan. */
+async function describeContributions(
+  plan: MigrationPlan,
+  usernames: Map<number, string>,
+  challengeDates: Map<number, Date>,
+  db: Db,
+): Promise<DisplayContribution[]> {
+  const contributions: DisplayContribution[] = [];
+  for (const source of plan.sourcePlayers) {
+    const window = plan.windows[source.windowIndex];
+
+    const times = source.challengeIds.map((id) =>
+      challengeDates.get(id)!.getTime(),
+    );
+    const span = {
+      from: new Date(Math.min(...times)),
+      to: new Date(Math.max(...times)),
+    };
+
+    const [{ count: stats }] = await db<[{ count: string }]>`
+      SELECT COUNT(*) FROM player_stats
+      WHERE player_id = ${source.playerId}
+        ${window.from !== null ? db`AND date > ${window.from}` : db``}
+        ${window.to !== null ? db`AND date <= ${window.to}` : db``}
+    `;
+
+    const [{ count: apiKeys }] = await db<[{ count: string }]>`
+      SELECT COUNT(*) FROM api_keys
+      WHERE player_id = ${source.playerId}
+        ${window.from !== null ? db`AND last_used > ${window.from}` : db``}
+        ${window.to !== null ? db`AND last_used <= ${window.to}` : db``}
+    `;
+
+    contributions.push({
+      sourceName: usernames.get(source.playerId)!,
+      asName: window.normalizedRsn,
+      span,
+      challenges: source.challengeIds.length,
+      stats: parseInt(stats),
+      apiKeys: parseInt(apiKeys),
+    });
+  }
+
+  return contributions;
+}
+
+/** Builds per-source display rows for a migration plan. */
+function describeSources(
+  plan: MigrationPlan,
+  usernames: Map<number, string>,
+  challengeDates: Map<number, Date>,
+): DisplaySource[] {
+  const idsByPlayer = new Map<number, number[]>();
+  for (const source of plan.sourcePlayers) {
+    const ids = idsByPlayer.get(source.playerId) ?? [];
+    ids.push(...source.challengeIds);
+    idsByPlayer.set(source.playerId, ids);
+  }
+
+  const sources: DisplaySource[] = [];
+  for (const [playerId, challengeIds] of idsByPlayer) {
+    const name = usernames.get(playerId)!;
+    if (plan.emptiedSourceIds.includes(playerId)) {
+      sources.push({ name, outcome: 'deleted' });
+    } else {
+      const cutoffId = Math.min(...challengeIds);
+      sources.push({
+        name,
+        outcome: 'kept',
+        pbRecomputedFrom: challengeDates.get(cutoffId)!,
+      });
+    }
+  }
+
+  return sources;
+}
+
+/** Resolves a migration plan into a human-readable preview. Read-only. */
+export async function formatPlan(
+  plan: MigrationPlan,
+  db: Db = sql,
+): Promise<DisplayPlan> {
+  const movedIds = plan.sourcePlayers.flatMap((s) => s.challengeIds);
+
+  // Resolve the names and dates the projection needs in one batch each.
+  const sourceIds = [...new Set(plan.sourcePlayers.map((s) => s.playerId))];
+  const nameRows = sourceIds.length
+    ? await db<{ id: number; username: string }[]>`
+        SELECT id, username FROM players WHERE id = ANY(${sourceIds})
+      `
+    : [];
+  const usernames = new Map(nameRows.map((r) => [r.id, r.username]));
+
+  const dateRows = movedIds.length
+    ? await db<{ id: number; start_time: Date }[]>`
+        SELECT id, start_time FROM challenges WHERE id = ANY(${movedIds})
+      `
+    : [];
+  const challengeDates = new Map(dateRows.map((r) => [r.id, r.start_time]));
+
+  let name: string;
+  let challengesBefore: number;
+  if (plan.target.action === 'use') {
+    const [player]: [{ username: string }?] = await db`
+      SELECT username FROM players WHERE id = ${plan.target.playerId}
+    `;
+    name = player!.username;
+    challengesBefore = await countChallenges(plan.target.playerId, db);
+  } else {
+    name = plan.target.currentName;
+    challengesBefore = 0;
+  }
+
+  // The target's PBs recompute from the first moved challenge.
+  const targetCutoffId = movedIds.length > 0 ? Math.min(...movedIds) : null;
+  const targetPbRecomputedFrom =
+    targetCutoffId !== null ? challengeDates.get(targetCutoffId)! : null;
+
+  const contributions = await describeContributions(
+    plan,
+    usernames,
+    challengeDates,
+    db,
+  );
+  const sources = describeSources(plan, usernames, challengeDates);
+
+  return {
+    target: {
+      name,
+      isNew: plan.target.action === 'create',
+      challengesBefore,
+      challengesAfter: challengesBefore + movedIds.length,
+      pbRecomputedFrom: targetPbRecomputedFrom,
+    },
+    contributions,
+    sources,
+  };
+}
+
+export type DryRunResult =
+  | { ok: true; plan: DisplayPlan }
+  | { ok: false; error: ChainError };
+
+/**
+ * Previews a historic name change chain without mutating any data.
+ *
+ * @param chain The historic sequence of name changes.
+ * @returns Plan detailing how the sequence would be migrated, or a validation
+ *   error if the sequence is invalid.
+ */
+export async function dryRunHistoricNameChange(
+  chain: ChainTransition[],
+): Promise<DryRunResult> {
+  const error = validateChain(chain);
+  if (error !== null) {
+    return { ok: false, error };
+  }
+
+  const plan = await decide(chain);
+  return { ok: true, plan: await formatPlan(plan) };
+}
+
 function compareExperience(
   before: PlayerExperience,
   after: PlayerExperience,
@@ -368,6 +827,10 @@ type NameChangeQueryResult = {
   new_name: string;
   player_id: number;
   skip_checks: boolean;
+  kind: NameChangeKind;
+  effective_from: Date;
+  effective_to: Date | null;
+  sequence_id: string | null;
   overall_experience: string;
   attack_experience: number;
   defence_experience: number;
@@ -389,6 +852,10 @@ export async function processNameChange(
       name_changes.new_name,
       name_changes.player_id,
       name_changes.skip_checks,
+      name_changes.kind,
+      name_changes.effective_from,
+      name_changes.effective_to,
+      name_changes.sequence_id,
       players.overall_experience,
       players.attack_experience,
       players.defence_experience,
@@ -406,7 +873,21 @@ export async function processNameChange(
     return null;
   }
 
+  if (nameChange.kind === NameChangeKind.HISTORIC) {
+    throw new Error(
+      'historic name changes should not be processed via processNameChange',
+    );
+  }
+
+  return processStandardNameChange(nameChange, db);
+}
+
+async function processStandardNameChange(
+  nameChange: NameChangeQueryResult,
+  db: Db,
+): Promise<NameChangeUpdate | null> {
   const {
+    id: changeId,
     old_name: oldName,
     new_name: newName,
     player_id: playerId,
@@ -419,13 +900,15 @@ export async function processNameChange(
   if (normalizeRsn(oldName) === normalizeRsn(newName)) {
     logger.info('name_change_display_only', { changeId, oldName, newName });
 
+    const now = new Date();
     await Promise.all([
       db`UPDATE players SET username = ${newName} WHERE id = ${playerId}`,
       db`
         UPDATE name_changes
         SET
           status = ${NameChangeStatus.ACCEPTED},
-          processed_at = ${new Date()}
+          processed_at = ${now},
+          effective_from = ${now}
         WHERE id = ${changeId}
       `,
     ]);
@@ -654,11 +1137,13 @@ export async function processNameChange(
     UPDATE players SET ${sql(playerUpdates)} WHERE id = ${playerId}
   `;
 
+  const acceptedAt = new Date();
   const updateNameChange = db`
     UPDATE name_changes
     SET
       status = ${NameChangeStatus.ACCEPTED},
-      processed_at = ${new Date()},
+      processed_at = ${acceptedAt},
+      effective_from = ${acceptedAt},
       migrated_documents = ${migratedDocuments}
     WHERE id = ${changeId}
   `;

--- a/web/app/api/admin/auth.ts
+++ b/web/app/api/admin/auth.ts
@@ -2,40 +2,71 @@ import { timingSafeEqual } from 'crypto';
 
 import logger from '@/utils/log';
 
-/**
- * Validates the Discord bot secret from the Authorization header.
- *
- * @param authHeader The Authorization header value (e.g., "Bearer <secret>")
- * @returns True if the secret is valid, false otherwise
- */
-export function validateDiscordBotAuth(authHeader: string | null): boolean {
+/** Extracts the token from a `Bearer <token>` authorization header. */
+function bearerToken(authHeader: string | null): string | null {
   if (authHeader === null) {
+    return null;
+  }
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return null;
+  }
+  return parts[1];
+}
+
+function secretsMatch(provided: string, expected: string): boolean {
+  try {
+    const expectedBuffer = Buffer.from(expected, 'utf-8');
+    const providedBuffer = Buffer.from(provided, 'utf-8');
+
+    if (expectedBuffer.length !== providedBuffer.length) {
+      return false;
+    }
+
+    return timingSafeEqual(providedBuffer, expectedBuffer);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates the admin API secret from the authorization header.
+ */
+export function validateAdminAuth(authHeader: string | null): boolean {
+  const token = bearerToken(authHeader);
+  if (token === null) {
     return false;
   }
 
-  const secret = process.env.BLERT_DISCORD_BOT_SECRET;
+  const secret = process.env.BLERT_ADMIN_SECRET;
   if (!secret) {
+    logger.error('admin_secret_not_configured');
+    return false;
+  }
+
+  return secretsMatch(token, secret);
+}
+
+/**
+ * Validates the Discord bot secret from the authorization header. The admin
+ * secret is also accepted, as it is valid for all admin endpoints.
+ */
+export function validateDiscordBotAuth(authHeader: string | null): boolean {
+  const token = bearerToken(authHeader);
+  if (token === null) {
+    return false;
+  }
+
+  const botSecret = process.env.BLERT_DISCORD_BOT_SECRET;
+  if (!botSecret) {
     logger.error('discord_bot_secret_not_configured');
     return false;
   }
 
-  const parts = authHeader.split(' ');
-  if (parts.length !== 2 || parts[0] !== 'Bearer') {
-    return false;
+  if (secretsMatch(token, botSecret)) {
+    return true;
   }
 
-  const providedSecret = parts[1];
-  try {
-    const secretBuffer = Buffer.from(secret, 'utf-8');
-    const providedBuffer = Buffer.from(providedSecret, 'utf-8');
-
-    // Buffers must be the same length for timingSafeEqual.
-    if (secretBuffer.length !== providedBuffer.length) {
-      return false;
-    }
-
-    return timingSafeEqual(secretBuffer, providedBuffer);
-  } catch {
-    return false;
-  }
+  const adminSecret = process.env.BLERT_ADMIN_SECRET;
+  return adminSecret !== undefined && secretsMatch(token, adminSecret);
 }

--- a/web/app/api/admin/historic-name-changes/route.ts
+++ b/web/app/api/admin/historic-name-changes/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest } from 'next/server';
+
+import {
+  ChainTransition,
+  dryRunHistoricNameChange,
+} from '@/actions/name-change-processor';
+import { withApiRoute } from '@/api/handler';
+
+import { validateAdminAuth } from '../auth';
+
+type TransitionInput = {
+  oldName: string;
+  newName: string;
+  effectiveFrom: string;
+};
+
+type HistoricNameChangeRequest = {
+  chain: TransitionInput[];
+  dryRun?: boolean;
+};
+
+function isTransitionInput(value: unknown): value is TransitionInput {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const t = value as Record<string, unknown>;
+  return (
+    typeof t.oldName === 'string' &&
+    typeof t.newName === 'string' &&
+    typeof t.effectiveFrom === 'string'
+  );
+}
+
+/**
+ * Endpoint which preview or apply a player's historic name change sequence.
+ * A request with `dryRun` omitted or `true` returns the migration plan without
+ * mutating anything.
+ */
+export const POST = withApiRoute(
+  { route: '/api/admin/historic-name-changes' },
+  async (request: NextRequest) => {
+    const authHeader = request.headers.get('authorization');
+    if (!validateAdminAuth(authHeader)) {
+      return Response.json({ error: 'unauthorized' }, { status: 401 });
+    }
+
+    let body: HistoricNameChangeRequest;
+    try {
+      body = (await request.json()) as HistoricNameChangeRequest;
+    } catch {
+      return Response.json({ error: 'invalid_body' }, { status: 400 });
+    }
+
+    if (!Array.isArray(body.chain) || !body.chain.every(isTransitionInput)) {
+      return Response.json({ error: 'invalid_chain' }, { status: 400 });
+    }
+
+    const chain: ChainTransition[] = [];
+    for (const transition of body.chain) {
+      const effectiveFrom = new Date(transition.effectiveFrom);
+      if (isNaN(effectiveFrom.getTime())) {
+        return Response.json({ error: 'invalid_date' }, { status: 400 });
+      }
+      chain.push({
+        oldName: transition.oldName,
+        newName: transition.newName,
+        effectiveFrom,
+      });
+    }
+
+    if (body.dryRun === false) {
+      return Response.json({ error: 'not_implemented' }, { status: 501 });
+    }
+
+    const result = await dryRunHistoricNameChange(chain);
+    if (!result.ok) {
+      return Response.json({ error: result.error }, { status: 400 });
+    }
+
+    return Response.json({ plan: result.plan });
+  },
+);


### PR DESCRIPTION
Updates the name change system with a historic migration planner. Given a complete, contiguous name history for a player, it looks up records in the database that would need to be migrate to consolidate all the data for that player under their current RSN. The plan outputs a list of player records whose data is being migrated with matching windows into other database rows, and what remains associated with the source after the migration is complete, if anything.

The plan does not take action. Its initial consumer is a new admin historic name change dry run endpoint, which presents the resulting plan back to the caller with some additional information. A future consumer will be able to actually apply the historic change.