### PR TITLE
web: Remove Discord link requirement for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,25 +141,16 @@ This creates a user in your local database.
 
 If you want to record and submit your own data using a local Blert plugin:
 
-1. Allow API key creation
+1. Generate an API key
 
-   In a `psql` shell connected to your local DB:
+   Visit [http://localhost:3000/settings/api-keys](http://localhost:3000/settings/api-keys)
+   while logged in and create a new API key.
 
-   ```sql
-   UPDATE users
-   SET can_create_api_key = true
-   WHERE username = '<your username>';
-   ```
+2. Connect your Blert plugin
 
-2. Generate an API key
-
-   Visit [http://localhost:3000/settings](http://localhost:3000/settings) while
-   logged in and create a new API key.
-
-3. Connect your Blert plugin
-
-   Paste the API key into your local Blert plugin and start recording. Your
-   data will stream into your local instance.
+   Point your local Blert plugin to `ws://localhost:3003`, then paste your API
+   key into its settings and start recording. Your data will stream into your
+   local instance.
 
 ---
 

--- a/web/app/(dashboard)/onboarding-card.module.scss
+++ b/web/app/(dashboard)/onboarding-card.module.scss
@@ -64,6 +64,9 @@
     font-size: 0.95rem;
     font-weight: 600;
     color: var(--blert-font-color-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   p {
@@ -74,13 +77,15 @@
   }
 }
 
-.command {
-  padding: 2px 6px;
-  background: var(--blert-surface-light);
-  border-radius: 4px;
-  font-family: var(--font-roboto-mono), monospace;
-  font-size: 0.8rem;
+.optionalBadge {
+  padding: 2px 8px;
+  background: rgba(var(--blert-purple-base), 0.15);
   color: var(--blert-purple);
+  border-radius: 20px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .discordLink,

--- a/web/app/(dashboard)/onboarding-card.tsx
+++ b/web/app/(dashboard)/onboarding-card.tsx
@@ -14,7 +14,7 @@ export default function OnboardingCard({ username }: OnboardingCardProps) {
       <div className={styles.header}>
         <h1>Welcome to Blert, {username}</h1>
         <p className={styles.subtitle}>
-          Link your account to start tracking your raids
+          Get the plugin and generate an API key to start tracking your raids
         </p>
       </div>
 
@@ -22,38 +22,25 @@ export default function OnboardingCard({ username }: OnboardingCardProps) {
         <div className={styles.step}>
           <div className={styles.stepNumber}>1</div>
           <div className={styles.stepContent}>
-            <h3>Join the Discord</h3>
+            <h3>Get the Plugin</h3>
             <p>
-              Join our Discord server and run{' '}
-              <code className={styles.command}>/link-discord</code> to connect
-              your account.
+              Install the Blert plugin from the RuneLite Plugin Hub if you
+              haven&apos;t already.
             </p>
             <a
-              href={DISCORD_INVITE_URL}
+              href="https://runelite.net/plugin-hub/show/blert"
               target="_blank"
               rel="noopener noreferrer"
-              className={styles.discordLink}
+              className={styles.settingsLink}
             >
-              <i className="fab fa-discord" />
-              Join Discord
+              <i className="fas fa-external-link-alt" />
+              Get Plugin
             </a>
           </div>
         </div>
 
         <div className={styles.step}>
           <div className={styles.stepNumber}>2</div>
-          <div className={styles.stepContent}>
-            <h3>Get Plugin Access</h3>
-            <p>
-              Once verified, ask a{' '}
-              <strong style={{ color: '#e91e63' }}>@Support</strong> member in
-              Discord to grant API key access.
-            </p>
-          </div>
-        </div>
-
-        <div className={styles.step}>
-          <div className={styles.stepNumber}>3</div>
           <div className={styles.stepContent}>
             <h3>Create an API Key</h3>
             <p>
@@ -64,6 +51,29 @@ export default function OnboardingCard({ username }: OnboardingCardProps) {
               <i className="fas fa-key" />
               Go to Settings
             </Link>
+          </div>
+        </div>
+
+        <div className={styles.step}>
+          <div className={styles.stepNumber}>3</div>
+          <div className={styles.stepContent}>
+            <h3>
+              Link Discord{' '}
+              <span className={styles.optionalBadge}>Optional</span>
+            </h3>
+            <p>
+              Join our Discord server and link your account for support,
+              announcements, and our Discord bot.
+            </p>
+            <a
+              href={DISCORD_INVITE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.discordLink}
+            >
+              <i className="fab fa-discord" />
+              Join Discord
+            </a>
           </div>
         </div>
       </div>

--- a/web/app/actions/users.ts
+++ b/web/app/actions/users.ts
@@ -159,13 +159,6 @@ export async function createApiKey(rsn: string): Promise<ApiKeyWithUsername> {
       throw new Error('Invalid RSN');
     }
 
-    const canCreate = await sql`
-      SELECT can_create_api_key FROM users WHERE id = ${userId}
-    `;
-    if (canCreate.length === 0 || !canCreate[0].can_create_api_key) {
-      throw new Error('Not authorized to create API keys');
-    }
-
     const [apiKeyCount] = await sql<{ count: string }[]>`
       SELECT COUNT(*) FROM api_keys WHERE user_id = ${userId}
     `;

--- a/web/app/guides/blert/getting-started/content.mdx
+++ b/web/app/guides/blert/getting-started/content.mdx
@@ -15,20 +15,9 @@ If you don't already have a Blert account,
 your OSRS account. Verify your email address to ensure you don't lose access to
 your account.
 
-## Step 3: Request API Key Access
+## Step 3: Generate Your API Key
 
-Open your [Linked Accounts](/settings/linked-accounts) page and click the
-**Generate Linking Code** button under the **Discord** section. Copy the
-generated code, then run the `/verify <code>` command in
-[Blert's Discord](https://discord.gg/c5Hgv3NnYe).
-
-Once your Discord account is linked, ping a <strong style={{ color: '#e91e63' }}>@Support</strong>
-asking for API key access.
-
-## Step 4: Generate Your API Key
-
-1. Once you have API key access, go to the
-   [API Keys page](/settings/api-keys).
+1. Go to the [API Keys page](/settings/api-keys).
 2. Enter your OSRS username in the **Generate new API key**
    section and click **Generate API Key**.
 3. Copy the generated key using the <i className="fas fa-copy" /> copy icon.
@@ -43,7 +32,7 @@ asking for API key access.
   style={{ width: '100%', height: 'auto', maxWidth: '600px' }}
 />
 
-## Step 5: Enter the Key in RuneLite
+## Step 4: Enter the Key in RuneLite
 
 1. Open RuneLite and go to the **Blert** plugin settings.
 2. Paste your API key into the **Blert API Key** field.
@@ -72,11 +61,22 @@ connection status listed at the top of the plugin panel.
 
 </Notice>
 
-## Step 6: Record Your First PvM Challenge
+## Step 5: Record Your First PvM Challenge
 
 You're now ready to start recording! Enter any PvM challenge like the
 Theatre of Blood or Inferno and Blert will automatically detect your run
 and begin tracking data.
+
+## Optional: Link Your Discord Account
+
+Linking your Discord account isn't required to use Blert, but it unlocks a
+better overall experience, including Discord bot usage and improved account
+support.
+
+Open your [Linked Accounts](/settings/linked-accounts) page and click the
+**Generate Linking Code** button under the **Discord** section. Copy the
+generated code, then run the `/verify <code>` command in
+[Blert's Discord](https://discord.gg/c5Hgv3NnYe).
 
 ## Troubleshooting
 
@@ -84,20 +84,12 @@ and begin tracking data.
 
 - Double-check that you copied the full key.
 - Ensure the key is associated with the OSRS name you're logged into.
-- If needed, regenerate the key from the
-  [API Keys page](/settings/api-keys).
+- If needed, regenerate the key from the [API Keys page](/settings/api-keys).
 
 ### No Data Uploading
 
 - Open the plugin sidebar and confirm you see your username connected.
 - Ensure the raid was properly started (e.g. not in a lobby).
-- Data is processed at the end of challenge stages (e.g. rooms/waves), so if
-  you're still in the middle of one, you won't see anything.
 - If you were spectating a raid and left early, it won't be displayed.
-
-### No Permission to Generate Key
-
-- You haven't been granted API access yet.
-- [Link your Discord account](#step-3-request-api-key-access) and ping
-  <strong style={{ color: '#e91e63' }}>@Support</strong> in Discord to request
-  access.
+- Reach out to support on [Discord](https://discord.gg/c5Hgv3NnYe) if
+  you&apos;re still experiencing issues.

--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -53,6 +53,24 @@ export default async function Home() {
           className={styles.statusPanel}
         >
           <div className={styles.statusCard}>
+            <h3 className={styles.statusHeading}>API keys without Discord</h3>
+            <span className={styles.statusTimestamp}>
+              Last updated: Jul 5, 2026 19:00 UTC
+            </span>
+            <ul className={styles.statusList}>
+              <li>
+                You can now generate an API key from your{' '}
+                <Link href="/settings/api-keys">account settings</Link> straight
+                after registering, without linking a Discord account.
+              </li>
+              <li>
+                Linking Discord is still available and recommended for bot
+                integration and account support, but it&apos;s optional.
+              </li>
+            </ul>
+          </div>
+
+          <div className={styles.statusCard}>
             <h3 className={styles.statusHeading}>🎉 Blert is Live!</h3>
             <span className={styles.statusTimestamp}>
               Last updated: Jan 14, 2026 05:00 UTC


### PR DESCRIPTION
Allows users to freely generate API keys after creating an account instead of having to link their Discord and be approved by a support member first.