### PR TITLE
web: Implement historic name changes

### DIFF
--- a/common/migrations/20260711050355-make-name-changes-player-id-nullable.ts
+++ b/common/migrations/20260711050355-make-name-changes-player-id-nullable.ts
@@ -1,0 +1,31 @@
+import { TransactionSql } from 'postgres';
+
+export async function migrate(sql: TransactionSql) {
+  // Historic name changes don't have player ids when inserted.
+  await sql`
+    ALTER TABLE name_changes ALTER COLUMN player_id DROP NOT NULL
+  `;
+
+  await sql`
+    ALTER TABLE name_changes ADD CONSTRAINT name_changes_effective_dates_ordered
+    CHECK (effective_to IS NULL OR effective_from < effective_to)
+  `;
+
+  await sql`
+    ALTER TABLE name_changes DROP CONSTRAINT name_changes_kind_columns_valid
+  `;
+  await sql`
+    ALTER TABLE name_changes ADD CONSTRAINT name_changes_kind_columns_valid
+    CHECK (
+      (kind = 0 AND player_id IS NOT NULL AND sequence_id IS NULL)
+      OR (kind = 1 AND sequence_id IS NOT NULL)
+    )
+  `;
+
+  // Exempt zombies from username uniqueness.
+  await sql`DROP INDEX uix_players_username`;
+  await sql`
+    CREATE UNIQUE INDEX uix_players_username ON players (normalized_username)
+    WHERE NOT starts_with(normalized_username, '*')
+  `;
+}

--- a/web/__tests__/actions/name-change-processor.test.ts
+++ b/web/__tests__/actions/name-change-processor.test.ts
@@ -1,6 +1,7 @@
 import {
   ChallengeType,
   NameChange,
+  NameChangeKind,
   NameChangeStatus,
   NameChangeUpdateType,
   PlayerExperience,
@@ -12,8 +13,10 @@ import { sql } from '@/actions/db';
 import {
   ChainTransition,
   NameChangeProcessor,
+  apply,
   belongsToChainTarget,
   decide,
+  deleteEmptiedSources,
   deriveNameWindows,
   dryRunHistoricNameChange,
   formatPlan,
@@ -1401,6 +1404,35 @@ describe('updatePlayerStats', () => {
     expect(oldRows[2].deaths_total).toBe(6);
   });
 
+  it('moves all rows up to toDate when fromDate is null', async () => {
+    await seedStats(newPlayerId, [
+      { date: '2026-01-01', tobCompletions: 3, deathsTotal: 1 },
+      { date: '2026-02-01', tobCompletions: 7, deathsTotal: 2 },
+      { date: '2026-05-01', tobCompletions: 15, deathsTotal: 5 }, // post-window
+    ]);
+
+    const moved = await updatePlayerStats(
+      oldPlayerId,
+      newPlayerId,
+      null,
+      new Date('2026-04-01'),
+      sql,
+    );
+    expect(moved).toBe(2);
+
+    // With no fromDate there is no prior baseline, so the in-window rows move
+    // unchanged onto the (empty) target.
+    const oldRows = await loadStats(oldPlayerId);
+    expect(oldRows.map((r) => r.tob_completions)).toEqual([3, 7]);
+    expect(oldRows.map((r) => r.deaths_total)).toEqual([1, 2]);
+
+    // The post-window row stays on the source, decremented by the window delta
+    // (7 tob, 2 deaths).
+    const newRows = await loadStats(newPlayerId);
+    expect(newRows.map((r) => r.tob_completions)).toEqual([8]);
+    expect(newRows.map((r) => r.deaths_total)).toEqual([3]);
+  });
+
   it('migrates only in-window stats when toDate is set', async () => {
     await seedStats(newPlayerId, [
       { date: '2026-01-01', tobCompletions: 4 }, // pre-window
@@ -1603,6 +1635,32 @@ describe('updateApiKeys', () => {
       }),
       expect.objectContaining({ key: 'unused', player_id: sourcePlayerId }),
     ]);
+  });
+
+  it('reassigns all keys up to toDate when fromDate is null', async () => {
+    await seedKeys(sourcePlayerId, [
+      { key: 'early', lastUsed: '2026-01-01' },
+      { key: 'in-window', lastUsed: '2026-02-15' },
+      { key: 'post', lastUsed: '2026-05-15' },
+      { key: 'unused', lastUsed: null },
+    ]);
+
+    const moved = await updateApiKeys(
+      targetPlayerId,
+      sourcePlayerId,
+      null,
+      new Date('2026-04-01'),
+      sql,
+    );
+    expect(moved).toBe(2);
+
+    const rows = await loadKeys();
+    const byKey = (k: string) => rows.find((r) => r.key === k);
+    expect(byKey('early')?.player_id).toBe(targetPlayerId);
+    expect(byKey('in-window')?.player_id).toBe(targetPlayerId);
+    expect(byKey('post')?.player_id).toBe(sourcePlayerId);
+    // A null last_used never satisfies the upper bound.
+    expect(byKey('unused')?.player_id).toBe(sourcePlayerId);
   });
 
   it('reassigns only in-window keys when toDate is set', async () => {
@@ -2429,6 +2487,7 @@ describe('historic name changes', () => {
 
   // Renames are spaced > 30 days apart, mirroring the OSRS username hold so
   // each name's challenges fall unambiguously in one window.
+  const JAN = '2026-01-01';
   const FEB = '2026-02-01';
   const APR = '2026-04-01';
   const JUN = '2026-06-01';
@@ -2443,6 +2502,71 @@ describe('historic name changes', () => {
       newName,
       effectiveFrom: new Date(effectiveFrom),
     };
+  }
+
+  async function challengesOf(playerId: number): Promise<number[]> {
+    const rows = await sql<{ challenge_id: number }[]>`
+      SELECT challenge_id FROM challenge_players
+      WHERE player_id = ${playerId}
+      ORDER BY challenge_id
+    `;
+    return rows.map((r) => r.challenge_id);
+  }
+
+  // The challenges underlying a player's personal best history.
+  async function pbChallengesOf(playerId: number): Promise<number[]> {
+    const rows = await sql<{ challenge_id: number }[]>`
+      SELECT cs.challenge_id
+      FROM personal_best_history pbh
+      JOIN challenge_splits cs ON cs.id = pbh.challenge_split_id
+      WHERE pbh.player_id = ${playerId}
+      ORDER BY cs.challenge_id
+    `;
+    return rows.map((r) => r.challenge_id);
+  }
+
+  async function recordingsOf(playerId: number): Promise<number> {
+    const [{ total_recordings }] = await sql<[{ total_recordings: number }]>`
+      SELECT total_recordings FROM players WHERE id = ${playerId}
+    `;
+    return total_recordings;
+  }
+
+  async function statCountOf(playerId: number): Promise<number> {
+    const [{ count }] = await sql<[{ count: string }]>`
+      SELECT COUNT(*) FROM player_stats WHERE player_id = ${playerId}
+    `;
+    return parseInt(count);
+  }
+
+  async function keyCountOf(playerId: number): Promise<number> {
+    const [{ count }] = await sql<[{ count: string }]>`
+      SELECT COUNT(*) FROM api_keys WHERE player_id = ${playerId}
+    `;
+    return parseInt(count);
+  }
+
+  async function playerExists(playerId: number): Promise<boolean> {
+    const [row] = await sql<[{ id: number }?]>`
+      SELECT id FROM players WHERE id = ${playerId}
+    `;
+    return row !== undefined;
+  }
+
+  async function addSplit(challengeId: number, ticks: number): Promise<number> {
+    const [{ id }] = await sql<[{ id: number }]>`
+      INSERT INTO challenge_splits (challenge_id, type, scale, ticks, accurate)
+      VALUES (${challengeId}, 1, 1, ${ticks}, true)
+      RETURNING id
+    `;
+    return id;
+  }
+
+  async function setPb(playerId: number, splitId: number): Promise<void> {
+    await sql`
+      INSERT INTO personal_best_history (player_id, challenge_split_id, created_at)
+      VALUES (${playerId}, ${splitId}, NOW())
+    `;
   }
 
   describe('name change chains', () => {
@@ -2761,6 +2885,34 @@ describe('historic name changes', () => {
 
       expect(plan.emptiedSourceIds).toEqual([]);
     });
+
+    it('flags target challenges not belonging to the player for eviction', async () => {
+      // Chain bar -> baz -> foo -> baz. During the periods where the player
+      // did not hold baz, some other player recorded challenges on it.
+      const bazId = await makePlayer('baz');
+      const before = await makeChallenge(bazId, 'baz', '2025-12-24');
+      const earlyBaz = await makeChallenge(bazId, 'baz', '2026-01-15');
+      const between = await makeChallenge(bazId, 'baz', '2026-03-15');
+      const currentBaz = await makeChallenge(bazId, 'baz', '2026-05-15');
+
+      const plan = await decide([
+        transition('bar', 'baz', JAN),
+        transition('baz', 'foo', FEB),
+        transition('foo', 'baz', APR),
+      ]);
+
+      expect(plan.evictedTargetChallengeIds).toEqual([before, between]);
+      expect(plan.evictedTargetChallengeIds).not.toContain(earlyBaz);
+      expect(plan.evictedTargetChallengeIds).not.toContain(currentBaz);
+    });
+
+    it('evicts nothing from a target that is newly created', async () => {
+      const fooRecordId = await makePlayer('foo');
+      await makeChallenge(fooRecordId, 'foo', '2026-01-15');
+      const plan = await decide([transition('foo', 'qux', FEB)]);
+      expect(plan.target).toEqual({ action: 'create', currentName: 'qux' });
+      expect(plan.evictedTargetChallengeIds).toEqual([]);
+    });
   });
 
   describe('formatPlan', () => {
@@ -2871,6 +3023,26 @@ describe('historic name changes', () => {
         },
       ]);
     });
+
+    it('reflects a target eviction and surfaces an API key blocker', async () => {
+      // Target baz has both a previous challenge and existing API key.
+      const bazId = await makePlayer('baz');
+      await makeChallenge(bazId, 'baz', '2026-05-15');
+      const foreign = await makeChallenge(bazId, 'baz', '2026-01-15');
+      const fooId = await makePlayer('foo');
+      await makeChallenge(fooId, 'foo', '2026-01-20');
+      await makeKeys(bazId, '2026-01-10');
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+      const display = await formatPlan(plan);
+
+      expect(display.target.challengesBefore).toBe(2);
+      expect(display.target.challengesAfter).toBe(2);
+      expect(display.evictedChallenges).toBe(1);
+      expect(display.unownedApiKeys).toBe(1);
+      expect(display.target.pbRecomputedFrom).toEqual(new Date('2026-01-15'));
+      expect(plan.evictedTargetChallengeIds).toEqual([foreign]);
+    });
   });
 
   describe('dryRunHistoricNameChange', () => {
@@ -2900,6 +3072,440 @@ describe('historic name changes', () => {
           { name: 'foo', outcome: 'deleted' },
         ]);
       }
+    });
+  });
+
+  describe('apply', () => {
+    it('consolidates scattered records onto the current record', async () => {
+      // foo -> bar -> baz, current record baz. Each record holds one of the
+      // player's challenges, with its stats, key, and a split.
+      const bazId = await makePlayer('baz');
+      const fooId = await makePlayer('foo');
+      const barId = await makePlayer('bar');
+      const fooChallenge = await makeChallenge(fooId, 'foo', '2026-01-15');
+      const barChallenge = await makeChallenge(barId, 'bar', '2026-03-15');
+      const bazChallenge = await makeChallenge(bazId, 'baz', '2026-05-15');
+      await addSplit(fooChallenge, 100);
+      await addSplit(barChallenge, 90);
+      await addSplit(bazChallenge, 110);
+      await makeStats(fooId, '2026-01-10');
+      await makeStats(barId, '2026-03-10');
+      await makeStats(bazId, '2026-05-10');
+      await makeKeys(fooId, '2026-01-10');
+      await makeKeys(barId, '2026-03-10');
+      await makeKeys(bazId, '2026-05-10');
+      await sql`UPDATE players SET total_recordings = 1 WHERE id = ANY(${[
+        bazId,
+        fooId,
+        barId,
+      ]})`;
+
+      const plan = await decide([
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+      await apply(plan);
+
+      // Everything is now on baz. foo and bar are left as empty husks.
+      expect(await challengesOf(bazId)).toEqual(
+        [bazChallenge, fooChallenge, barChallenge].sort((a, b) => a - b),
+      );
+      expect(await challengesOf(fooId)).toEqual([]);
+      expect(await challengesOf(barId)).toEqual([]);
+      expect(await recordingsOf(bazId)).toBe(3);
+      // The moved stats and keys land on baz alongside its own.
+      expect(await statCountOf(bazId)).toBe(3);
+      expect(await keyCountOf(bazId)).toBe(3);
+      // baz's PB ladder is rebuilt over all challenges in time order: 100 is the
+      // first best, 90 improves it, 110 does not.
+      expect(await pbChallengesOf(bazId)).toEqual(
+        [fooChallenge, barChallenge].sort((a, b) => a - b),
+      );
+    });
+
+    it('creates the current player when none exists and moves data onto it', async () => {
+      // foo -> bar, current name bar has no record yet.
+      const fooId = await makePlayer('foo');
+      const fooChallenge = await makeChallenge(fooId, 'foo', '2026-01-15');
+      await addSplit(fooChallenge, 100);
+      await makeStats(fooId, '2026-01-10');
+      await makeKeys(fooId, '2026-01-10');
+      await sql`UPDATE players SET total_recordings = 1 WHERE id = ${fooId}`;
+
+      const plan = await decide([transition('foo', 'bar', FEB)]);
+      await apply(plan);
+
+      const [bar] = await sql<[{ id: number }?]>`
+        SELECT id FROM players WHERE normalized_username = ${normalizeRsn('bar')}
+      `;
+      expect(bar).toBeDefined();
+      createdPlayerIds.push(bar!.id);
+
+      expect(await challengesOf(bar!.id)).toEqual([fooChallenge]);
+      expect(await recordingsOf(bar!.id)).toBe(1);
+      expect(await statCountOf(bar!.id)).toBe(1);
+      expect(await keyCountOf(bar!.id)).toBe(1);
+      expect(await pbChallengesOf(bar!.id)).toEqual([fooChallenge]);
+      expect(await challengesOf(fooId)).toEqual([]);
+    });
+
+    it('recomputes PBs on both sides when a shared record is split', async () => {
+      // Chain someone -> foo (Jan 1) -> baz (Feb 1), target baz. Every challenge
+      // is recorded as "foo", but only those in the window (Jan 1..Feb 1) are
+      // the target player's; the others belong to the unrelated players.
+      const bazId = await makePlayer('baz');
+      const fooId = await makePlayer('foo');
+      const a = await makeChallenge(fooId, 'foo', '2025-12-01'); // stays, 105
+      const b = await makeChallenge(fooId, 'foo', '2026-01-05'); // moves, 80
+      const c = await makeChallenge(fooId, 'foo', '2026-01-20'); // moves, 90
+      const d = await makeChallenge(fooId, 'foo', '2026-05-10'); // stays, 100
+      const e = await makeChallenge(fooId, 'foo', '2026-06-10'); // stays, 70
+      const aSplit = await addSplit(a, 105);
+      const bSplit = await addSplit(b, 80);
+      await addSplit(c, 90);
+      await addSplit(d, 100);
+      const eSplit = await addSplit(e, 70);
+      // foo's PB history as it stands before the migration: chronologically
+      // a (105), b (80), and e (70) each set a new best.
+      await setPb(fooId, aSplit);
+      await setPb(fooId, bSplit);
+      await setPb(fooId, eSplit);
+      await sql`UPDATE players SET total_recordings = 5 WHERE id = ${fooId}`;
+      await sql`UPDATE players SET total_recordings = 0 WHERE id = ${bazId}`;
+
+      const plan = await decide([
+        transition('someone', 'foo', '2026-01-01'),
+        transition('foo', 'baz', FEB),
+      ]);
+      await apply(plan);
+
+      // The in-window pair (b, c) moves to baz. b (80) is baz's PB; c (90) is
+      // later and worse, so a moved challenge is not blindly a PB.
+      expect(await challengesOf(bazId)).toEqual([b, c].sort((x, y) => x - y));
+      expect(await pbChallengesOf(bazId)).toEqual([b]);
+
+      // foo keeps the out-of-window challenges (a, d, e). With b gone, its ladder
+      // is a (105) then d (100) then e (70), all PBs — d is promoted, having
+      // been shadowed by the departed b (80).
+      expect(await challengesOf(fooId)).toEqual(
+        [a, d, e].sort((x, y) => x - y),
+      );
+      expect(await pbChallengesOf(fooId)).toEqual(
+        [a, d, e].sort((x, y) => x - y),
+      );
+
+      expect(await recordingsOf(bazId)).toBe(2);
+      expect(await recordingsOf(fooId)).toBe(3);
+    });
+
+    it('splits prior history off the target onto a zombie', async () => {
+      // foo -> baz, target baz. The baz record holds a past challenge recorded
+      // before the player held the name and one from the player. The foreign
+      // challenge has a faster split, shadowing the players's actual PB.
+      const bazId = await makePlayer('baz');
+      const foreign = await makeChallenge(bazId, 'baz', '2026-01-15');
+      const genuine = await makeChallenge(bazId, 'baz', '2026-05-15');
+      const foreignSplit = await addSplit(foreign, 80);
+      await addSplit(genuine, 100);
+      await setPb(bazId, foreignSplit);
+      // The later snapshot's counters include the prior holder's earlier ones.
+      await sql`
+        INSERT INTO player_stats (player_id, date, tob_completions, deaths_total)
+        VALUES
+          (${bazId}, ${new Date('2026-01-10')}, 5, 3),
+          (${bazId}, ${new Date('2026-05-10')}, 12, 8)
+      `;
+      await sql`UPDATE players SET total_recordings = 2 WHERE id = ${bazId}`;
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+      await apply(plan);
+
+      const [zombie] = await sql<[{ id: number }?]>`
+        SELECT id FROM players WHERE normalized_username = ${normalizeRsn('*baz')}
+      `;
+      expect(zombie).toBeDefined();
+      createdPlayerIds.push(zombie!.id);
+
+      // The foreign challenge, its PB, and the prior holder's snapshot move to
+      // the zombie unchanged.
+      expect(await challengesOf(zombie!.id)).toEqual([foreign]);
+      expect(await pbChallengesOf(zombie!.id)).toEqual([foreign]);
+      expect(
+        await sql`
+          SELECT date, tob_completions, deaths_total FROM player_stats
+          WHERE player_id = ${zombie!.id}
+        `,
+      ).toEqual([
+        { date: new Date('2026-01-10'), tob_completions: 5, deaths_total: 3 },
+      ]);
+      expect(await recordingsOf(zombie!.id)).toBe(1);
+
+      // The target keeps its own data with a recomputed PB and stats.
+      expect(await challengesOf(bazId)).toEqual([genuine]);
+      expect(await pbChallengesOf(bazId)).toEqual([genuine]);
+      expect(
+        await sql`
+          SELECT date, tob_completions, deaths_total FROM player_stats
+          WHERE player_id = ${bazId}
+        `,
+      ).toEqual([
+        { date: new Date('2026-05-10'), tob_completions: 7, deaths_total: 5 },
+      ]);
+      expect(await recordingsOf(bazId)).toBe(1);
+    });
+
+    it('refuses to consolidate when a prior holder left API keys', async () => {
+      const bazId = await makePlayer('baz');
+      const foreign = await makeChallenge(bazId, 'baz', '2026-01-15');
+      await makeKeys(bazId, '2026-01-10');
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+      expect(plan.unownedApiKeyCount).toBe(1);
+      await expect(apply(plan)).rejects.toThrow(/API key/);
+
+      expect(await challengesOf(bazId)).toEqual([foreign]);
+      const [zombie] = await sql`
+        SELECT id FROM players WHERE normalized_username = ${normalizeRsn('*baz')}
+      `;
+      expect(zombie).toBeUndefined();
+    });
+
+    it('refuses to consolidate on a prior holder key with no challenges to evict', async () => {
+      const bazId = await makePlayer('baz');
+      const genuine = await makeChallenge(bazId, 'baz', '2026-05-15');
+      await makeKeys(bazId, '2026-01-10');
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+      expect(plan.evictedTargetChallengeIds).toEqual([]);
+      expect(plan.unownedApiKeyCount).toBe(1);
+      await expect(apply(plan)).rejects.toThrow(/API key/);
+
+      expect(await challengesOf(bazId)).toEqual([genuine]);
+    });
+
+    it('counts an unused key on the target as unowned', async () => {
+      const bazId = await makePlayer('baz');
+      const genuine = await makeChallenge(bazId, 'baz', '2026-05-15');
+      await sql`
+        INSERT INTO api_keys (user_id, player_id, key, last_used)
+        VALUES (${userId}, ${bazId}, 'never-used-key', NULL)
+      `;
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+      expect(plan.unownedApiKeyCount).toBe(1);
+      await expect(apply(plan)).rejects.toThrow(/API key/);
+
+      expect(await challengesOf(bazId)).toEqual([genuine]);
+    });
+
+    it('creates a new zombie even when one already exists for the name', async () => {
+      await makePlayer('*baz');
+      const bazId = await makePlayer('baz');
+      await makeChallenge(bazId, 'baz', '2026-01-15');
+
+      const plan = await decide([transition('foo', 'baz', FEB)]);
+      await apply(plan);
+
+      const zombies = await sql<{ id: number }[]>`
+        SELECT id FROM players
+        WHERE normalized_username = ${normalizeRsn('*baz')}
+        ORDER BY id
+      `;
+      expect(zombies).toHaveLength(2);
+      zombies.forEach((z) => createdPlayerIds.push(z.id));
+    });
+  });
+
+  describe('deleteEmptiedSources', () => {
+    it('deletes records with no challenge_players rows', async () => {
+      const emptyId = await makePlayer('emptyhusk');
+      const deleted = await deleteEmptiedSources([emptyId]);
+      expect(deleted).toBe(1);
+      expect(await playerExists(emptyId)).toBe(false);
+    });
+
+    it('skips records with challenge_players rows', async () => {
+      const contestedId = await makePlayer('contested');
+      const safeId = await makePlayer('safehusk');
+      await makeChallenge(contestedId, 'contested', '2026-05-15');
+
+      const deleted = await deleteEmptiedSources([contestedId, safeId]);
+      expect(deleted).toBe(1);
+      expect(await playerExists(contestedId)).toBe(true);
+      expect(await playerExists(safeId)).toBe(false);
+    });
+
+    it('does nothing when empty', async () => {
+      const deleted = await deleteEmptiedSources([]);
+      expect(deleted).toBe(0);
+    });
+  });
+
+  describe('processNextHistoricSequence', () => {
+    const processor = new NameChangeProcessor({ autoStart: false });
+
+    // Inserts a pending historic sequence.
+    async function insertHistoricSequence(
+      sequenceId: string,
+      chain: ChainTransition[],
+    ): Promise<void> {
+      const rows = chain.map((t, i) => ({
+        player_id: null,
+        old_name: t.oldName,
+        new_name: t.newName,
+        status: NameChangeStatus.PENDING,
+        submitted_at: new Date(),
+        effective_from: t.effectiveFrom,
+        effective_to: i + 1 < chain.length ? chain[i + 1].effectiveFrom : null,
+        kind: NameChangeKind.HISTORIC,
+        sequence_id: sequenceId,
+      }));
+      await sql`INSERT INTO name_changes ${sql(rows)}`;
+    }
+
+    afterEach(async () => {
+      await sql`DELETE FROM name_changes`;
+    });
+
+    it('fully applies a pending historic sequence', async () => {
+      // foo -> bar -> baz, current record baz. foo's only challenge moves and
+      // empties it; bar keeps a later, out-of-window challenge and survives.
+      const bazId = await makePlayer('baz');
+      const fooId = await makePlayer('foo');
+      const barId = await makePlayer('bar');
+      const fooChallenge = await makeChallenge(fooId, 'foo', '2026-01-15');
+      const barChallenge = await makeChallenge(barId, 'bar', '2026-03-15');
+      const barLater = await makeChallenge(barId, 'bar', '2026-05-15');
+      const bazChallenge = await makeChallenge(bazId, 'baz', '2026-06-15');
+      await addSplit(fooChallenge, 100);
+      await addSplit(barChallenge, 90);
+      await makeStats(fooId, '2026-01-10');
+      await makeKeys(fooId, '2026-01-10');
+      await sql`UPDATE players SET total_recordings = 1 WHERE id = ${fooId}`;
+      await sql`UPDATE players SET total_recordings = 2 WHERE id = ${barId}`;
+      await sql`UPDATE players SET total_recordings = 1 WHERE id = ${bazId}`;
+
+      const sequenceId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      await insertHistoricSequence(sequenceId, [
+        transition('foo', 'bar', FEB),
+        transition('bar', 'baz', APR),
+      ]);
+
+      const result = await processor.processNextHistoricSequence();
+      expect(result).toBe('processed');
+
+      // Everything the player recorded now lives on baz.
+      expect(await challengesOf(bazId)).toEqual(
+        [fooChallenge, barChallenge, bazChallenge].sort((a, b) => a - b),
+      );
+      expect(await pbChallengesOf(bazId)).toEqual(
+        [fooChallenge, barChallenge].sort((a, b) => a - b),
+      );
+      expect(await statCountOf(bazId)).toBe(1);
+      expect(await keyCountOf(bazId)).toBe(1);
+      expect(await recordingsOf(bazId)).toBe(3);
+
+      // foo is emptied and deleted; bar keeps its out-of-window challenge.
+      expect(await playerExists(fooId)).toBe(false);
+      expect(await playerExists(barId)).toBe(true);
+      expect(await recordingsOf(barId)).toBe(1);
+      expect(await challengesOf(barId)).toEqual([barLater]);
+
+      // The sequence is accepted and now belongs to the target, so it surfaces
+      // as baz's name history.
+      const rows = await sql<
+        {
+          status: number;
+          player_id: number;
+          processed_at: Date | null;
+          migrated_documents: number;
+        }[]
+      >`
+        SELECT status, player_id, processed_at, migrated_documents
+        FROM name_changes
+        WHERE sequence_id = ${sequenceId}
+        ORDER BY effective_from
+      `;
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(row.status).toBe(NameChangeStatus.ACCEPTED);
+        expect(row.player_id).toBe(bazId);
+        expect(row.processed_at).not.toBeNull();
+        // 2 challenge_players + 1 stat + 1 key + 2 recomputed PBs.
+        expect(row.migrated_documents).toBe(6);
+      }
+    });
+
+    it('ignores standard name changes and reports nothing to do', async () => {
+      const playerId = await makePlayer('standalone');
+      await sql`
+        INSERT INTO name_changes (
+          player_id, old_name, new_name, status, submitted_at, effective_from
+        ) VALUES (
+          ${playerId}, 'standalone', 'renamed',
+          ${NameChangeStatus.PENDING}, NOW(), NOW()
+        )
+      `;
+
+      const result = await processor.processNextHistoricSequence();
+      expect(result).toBe('not_found');
+
+      const [row] = await sql<[{ status: number; kind: number }]>`
+        SELECT status, kind FROM name_changes WHERE player_id = ${playerId}
+      `;
+      expect(row.status).toBe(NameChangeStatus.PENDING);
+      expect(row.kind).toBe(NameChangeKind.STANDARD);
+    });
+
+    it('does not reprocess a previously accepted sequence', async () => {
+      const bazId = await makePlayer('baz');
+      const fooId = await makePlayer('foo');
+      const fooChallenge = await makeChallenge(fooId, 'foo', '2026-01-15');
+      await insertHistoricSequence('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', [
+        transition('foo', 'baz', FEB),
+      ]);
+
+      expect(await processor.processNextHistoricSequence()).toBe('processed');
+      const consolidated = await challengesOf(bazId);
+      expect(consolidated).toEqual([fooChallenge]);
+
+      // A second pass finds no pending sequence and changes nothing.
+      expect(await processor.processNextHistoricSequence()).toBe('not_found');
+      expect(await challengesOf(bazId)).toEqual(consolidated);
+    });
+
+    it('marks a terminally failing sequence FAILED and moves on to the next', async () => {
+      // Failing sequence where the target has a preexsting API key.
+      const bazId = await makePlayer('baz');
+      await makeChallenge(bazId, 'baz', '2026-01-15');
+      await makeKeys(bazId, '2026-01-10');
+      await insertHistoricSequence('cccccccc-cccc-cccc-cccc-cccccccccccc', [
+        transition('foo', 'baz', FEB),
+      ]);
+
+      // Newer, clean sequence.
+      const srcId = await makePlayer('srcname');
+      const srcChallenge = await makeChallenge(srcId, 'srcname', '2026-05-15');
+      await insertHistoricSequence('dddddddd-dddd-dddd-dddd-dddddddddddd', [
+        transition('srcname', 'dstname', JUN),
+      ]);
+
+      expect(await processor.processNextHistoricSequence()).toBe('failed');
+      const failed = await sql<{ status: NameChangeStatus }[]>`
+        SELECT status FROM name_changes
+        WHERE sequence_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+      `;
+      expect(failed.every((r) => r.status === NameChangeStatus.FAILED)).toBe(
+        true,
+      );
+
+      expect(await processor.processNextHistoricSequence()).toBe('processed');
+      const [dst] = await sql<[{ id: number }?]>`
+        SELECT id FROM players WHERE normalized_username = ${normalizeRsn('dstname')}
+      `;
+      expect(dst).toBeDefined();
+      createdPlayerIds.push(dst!.id);
+      expect(await challengesOf(dst!.id)).toEqual([srcChallenge]);
     });
   });
 });

--- a/web/app/actions/historic-name-changes.ts
+++ b/web/app/actions/historic-name-changes.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from 'crypto';
+
+import { NameChangeKind, NameChangeStatus } from '@blert/common';
+
+import { sql } from './db';
+import processor, {
+  type ChainError,
+  type ChainTransition,
+  validateChain,
+} from './name-change-processor';
+
+export {
+  type ChainTransition,
+  type DryRunResult,
+  dryRunHistoricNameChange,
+} from './name-change-processor';
+
+export type SubmitHistoricResult =
+  | { ok: true; sequenceId: string }
+  | { ok: false; error: ChainError };
+
+/**
+ * Records a historic name change chain as a pending sequence to be processed.
+ * @returns The sequence's ID, or a validation error if the chain is malformed.
+ */
+export async function submitHistoricNameChange(
+  chain: ChainTransition[],
+): Promise<SubmitHistoricResult> {
+  const error = validateChain(chain);
+  if (error !== null) {
+    return { ok: false, error };
+  }
+
+  const sequenceId = randomUUID();
+  const submittedAt = new Date();
+  const rows = chain.map((transition, i) => ({
+    player_id: null,
+    old_name: transition.oldName,
+    new_name: transition.newName,
+    status: NameChangeStatus.PENDING,
+    submitted_at: submittedAt,
+    effective_from: transition.effectiveFrom,
+    effective_to: i + 1 < chain.length ? chain[i + 1].effectiveFrom : null,
+    kind: NameChangeKind.HISTORIC,
+    sequence_id: sequenceId,
+  }));
+
+  await sql`INSERT INTO name_changes ${sql(rows)}`;
+  processor.start();
+
+  return { ok: true, sequenceId };
+}

--- a/web/app/actions/name-change-processor.ts
+++ b/web/app/actions/name-change-processor.ts
@@ -52,36 +52,50 @@ type PlayerStatsRow = CamelToSnakeCase<PlayerStats> & {
   id: number;
 };
 
+async function lastStatsAtOrBefore(
+  playerId: number,
+  date: Date | null,
+  db: Db,
+): Promise<PlayerStatsRow | undefined> {
+  // A null date means the window starts at the beginning of time, so there is
+  // no prior row to use as a baseline.
+  if (date === null) {
+    return undefined;
+  }
+  const [row] = await db<[PlayerStatsRow?]>`
+    SELECT *
+    FROM player_stats
+    WHERE player_id = ${playerId}
+    AND date <= ${date}
+    ORDER BY date DESC
+    LIMIT 1
+  `;
+  return row;
+}
+
 export async function updatePlayerStats(
   targetPlayerId: number,
   sourcePlayerId: number,
-  fromDate: Date,
+  fromDate: Date | null,
   toDate: Date | null = null,
   db: Db = sql,
 ): Promise<number> {
-  const [targetPlayerLastStats] = await db<[PlayerStatsRow?]>`
-    SELECT *
-    FROM player_stats
-    WHERE player_id = ${targetPlayerId}
-    AND date <= ${fromDate}
-    ORDER BY date DESC
-    LIMIT 1
-  `;
-
-  const [sourcePlayerLastStats] = await db<[PlayerStatsRow?]>`
-    SELECT *
-    FROM player_stats
-    WHERE player_id = ${sourcePlayerId}
-    AND date <= ${fromDate}
-    ORDER BY date DESC
-    LIMIT 1
-  `;
+  const targetPlayerLastStats = await lastStatsAtOrBefore(
+    targetPlayerId,
+    fromDate,
+    db,
+  );
+  const sourcePlayerLastStats = await lastStatsAtOrBefore(
+    sourcePlayerId,
+    fromDate,
+    db,
+  );
 
   const statsToMigrate = await db<PlayerStatsRow[]>`
     SELECT *
     FROM player_stats
     WHERE player_id = ${sourcePlayerId}
-    AND date > ${fromDate}
+    ${fromDate !== null ? sql`AND date > ${fromDate}` : sql``}
     ${toDate !== null ? sql`AND date <= ${toDate}` : sql``}
     ORDER BY date ASC
   `;
@@ -159,7 +173,7 @@ export async function updatePlayerStats(
  *
  * @param targetPlayerId ID of the target player.
  * @param sourcePlayerId ID of the source player.
- * @param fromDate Start date of the migration window.
+ * @param fromDate Start date of the migration window, or null for unbounded.
  * @param toDate Optional end date of the migration window.
  * @param db The database connection.
  * @returns The number of API keys reassigned.
@@ -167,7 +181,7 @@ export async function updatePlayerStats(
 export async function updateApiKeys(
   targetPlayerId: number,
   sourcePlayerId: number,
-  fromDate: Date,
+  fromDate: Date | null,
   toDate: Date | null = null,
   db: Db = sql,
 ): Promise<number> {
@@ -175,7 +189,7 @@ export async function updateApiKeys(
     UPDATE api_keys
     SET player_id = ${targetPlayerId}
     WHERE player_id = ${sourcePlayerId}
-      AND last_used > ${fromDate}
+      ${fromDate !== null ? sql`AND last_used > ${fromDate}` : sql``}
       ${toDate !== null ? sql`AND last_used <= ${toDate}` : sql``}
   `;
   return updated.count;
@@ -188,6 +202,22 @@ type SplitRow = {
   ticks: number;
   finish_time: Date;
 };
+
+/** Returns the distinct accurate splits recorded in a set of challenges. */
+async function distinctAccurateSplitTypes(
+  challengeIds: number[],
+  db: Db,
+): Promise<[number, number][]> {
+  if (challengeIds.length === 0) {
+    return [];
+  }
+  const rows = await db<{ type: number; scale: number }[]>`
+    SELECT DISTINCT type, scale
+    FROM challenge_splits
+    WHERE challenge_id = ANY(${challengeIds}) AND accurate
+  `;
+  return rows.map((r) => [r.type, r.scale]);
+}
 
 export async function updatePersonalBestHistory(
   targetPlayerId: number,
@@ -452,8 +482,11 @@ export function belongsToChainTarget(
   return nameInWindowsAt(windows, startTime) === normalizedRsn;
 }
 
-function _chainFromHistoricSequence(
-  rows: NameChangeQueryResult[],
+function chainFromHistoricSequence(
+  rows: Pick<
+    NameChangeQueryResult,
+    'old_name' | 'new_name' | 'effective_from'
+  >[],
 ): ChainTransition[] {
   return rows
     .toSorted((a, b) => a.effective_from.getTime() - b.effective_from.getTime())
@@ -490,6 +523,13 @@ export type MigrationPlan = {
    * Source records who are entirely absorbed by the target and can be deleted.
    */
   emptiedSourceIds: number[];
+  /**
+   * Challenges already on the target that predate the player's tenure under the
+   * current name and so belong to a prior holder. Split off to a zombie record.
+   */
+  evictedTargetChallengeIds: number[];
+  /** Number of API keys on the target belonging to a prior holder. */
+  unownedApiKeyCount: number;
 };
 
 /**
@@ -580,6 +620,57 @@ async function findEmptiedSources(
   return emptied;
 }
 
+/**
+ * Finds challenges already on the target record that do not belong to the
+ * chain's player.
+ */
+async function findTargetUnownedChallenges(
+  windows: NameWindow[],
+  target: TargetPlayer,
+  db: Db = sql,
+): Promise<number[]> {
+  if (target.action !== 'use') {
+    return [];
+  }
+
+  const rows = await db<
+    { challenge_id: number; username: string; start_time: Date }[]
+  >`
+    SELECT cp.challenge_id, cp.username, c.start_time
+    FROM challenge_players cp
+    JOIN challenges c ON c.id = cp.challenge_id
+    WHERE cp.player_id = ${target.playerId}
+    ORDER BY cp.challenge_id
+  `;
+
+  return rows
+    .filter(
+      (r) =>
+        !belongsToChainTarget(windows, normalizeRsn(r.username), r.start_time),
+    )
+    .map((r) => r.challenge_id);
+}
+
+/** Counts API keys on the target outside of the current player window. */
+async function countTargetUnownedKeys(
+  windows: NameWindow[],
+  target: TargetPlayer,
+  db: Db = sql,
+): Promise<number> {
+  if (target.action !== 'use') {
+    return 0;
+  }
+
+  const currentWindow = windows[windows.length - 1];
+  const rows = await db<{ last_used: Date | null }[]>`
+    SELECT last_used FROM api_keys WHERE player_id = ${target.playerId}
+  `;
+
+  return rows.filter(
+    (r) => r.last_used === null || !inWindow(r.last_used, currentWindow),
+  ).length;
+}
+
 /** Computes the migration plan for a historic name change chain. Read-only. */
 export async function decide(
   chain: ChainTransition[],
@@ -588,9 +679,256 @@ export async function decide(
   const windows = deriveNameWindows(chain);
   const target = await resolveTarget(chain, db);
   const sourcePlayers = await gatherSourcePlayers(windows, target, db);
-  const emptiedSourceIds = await findEmptiedSources(sourcePlayers, db);
 
-  return { target, windows, sourcePlayers, emptiedSourceIds };
+  const [emptiedSourceIds, evictedTargetChallengeIds, unownedApiKeyCount] =
+    await Promise.all([
+      findEmptiedSources(sourcePlayers, db),
+      findTargetUnownedChallenges(windows, target, db),
+      countTargetUnownedKeys(windows, target, db),
+    ]);
+
+  return {
+    target,
+    windows,
+    sourcePlayers,
+    emptiedSourceIds,
+    evictedTargetChallengeIds,
+    unownedApiKeyCount,
+  };
+}
+
+async function resolveOrCreateTargetId(
+  target: TargetPlayer,
+  db: Db,
+): Promise<number> {
+  if (target.action === 'use') {
+    return target.playerId;
+  }
+  const [created]: [{ id: number }] = await db`
+    INSERT INTO players (username, normalized_username)
+    VALUES (${target.currentName}, ${normalizeRsn(target.currentName)})
+    RETURNING id
+  `;
+  logger.info('historic_target_created', {
+    playerId: created.id,
+    name: target.currentName,
+  });
+  return created.id;
+}
+
+/**
+ * Returns the username for a "zombie" record storing data belonging to player
+ * `name` with unknown provenance.
+ */
+function zombieName(name: string): string {
+  const ZOMBIE_PREFIX = '*'; // Invalid OSRS character.
+  return `${ZOMBIE_PREFIX}${name}`;
+}
+
+class UnownedApiKeysError extends Error {
+  public readonly count: number;
+
+  constructor(count: number) {
+    super(`Target holds ${count} API key(s) belonging to a prior holder`);
+    this.count = count;
+  }
+}
+
+/**
+ * Splits the target's own challenges that belong to a prior holder of the
+ * current name onto a zombie record, removing their stats and personal bests
+ * from the consolidated player.
+ * @returns The number of documents moved onto the zombie.
+ * @throws UnownedApiKeyError if the target has a previous holder's API keys.
+ */
+async function evictTargetHistory(
+  plan: MigrationPlan,
+  targetId: number,
+  db: Db,
+): Promise<number> {
+  if (plan.unownedApiKeyCount > 0) {
+    throw new UnownedApiKeysError(plan.unownedApiKeyCount);
+  }
+
+  const evicted = plan.evictedTargetChallengeIds;
+  if (evicted.length === 0) {
+    return 0;
+  }
+
+  const currentName = plan.windows[plan.windows.length - 1].normalizedRsn;
+
+  const [{ username }] = await db<[{ username: string }]>`
+    SELECT username FROM players WHERE id = ${targetId}
+  `;
+  const zn = zombieName(username);
+
+  // Move data onto the zombie record for this username.
+  const [zombie] = await db<[{ id: number }]>`
+    INSERT INTO players (username, normalized_username, total_recordings)
+    VALUES (${zn}, ${normalizeRsn(zn)}, ${evicted.length})
+    RETURNING id
+  `;
+
+  let moved = 0;
+
+  const cp = await db`
+    UPDATE challenge_players SET player_id = ${zombie.id}
+    WHERE player_id = ${targetId} AND challenge_id = ANY(${evicted})
+  `;
+  moved += cp.count;
+
+  for (const window of plan.windows) {
+    if (window.normalizedRsn === currentName) {
+      continue;
+    }
+    moved += await updatePlayerStats(
+      zombie.id,
+      targetId,
+      window.from,
+      window.to,
+      db,
+    );
+  }
+
+  // Rebuild personal bests for the evicted splits on both records.
+  const splits = await distinctAccurateSplitTypes(evicted, db);
+  const cutoff = Math.min(...evicted);
+  moved += await recomputePbHistoryFrom(targetId, splits, cutoff, db);
+  moved += await recomputePbHistoryFrom(zombie.id, splits, cutoff, db);
+
+  await db`
+    UPDATE players SET total_recordings = total_recordings - ${evicted.length}
+    WHERE id = ${targetId}
+  `;
+
+  logger.info('historic_target_eviction', {
+    targetId,
+    zombieId: zombie.id,
+    evicted: evicted.length,
+  });
+
+  return moved;
+}
+
+/**
+ * Executes a migration plan against a database, consolidating the chain
+ * player's scattered data onto the target record.
+ * Does not delete emptied players from the plan.
+ *
+ * @returns The resolved target ID and the number of documents moved onto it.
+ */
+export async function apply(
+  plan: MigrationPlan,
+  db: Db = sql,
+): Promise<{ targetId: number; migratedDocuments: number }> {
+  const targetId = await resolveOrCreateTargetId(plan.target, db);
+
+  let migratedDocuments = 0;
+
+  // Split off any of the target's challenges that belong to a prior name
+  // holder before consolidating scattered data onto it.
+  migratedDocuments += await evictTargetHistory(plan, targetId, db);
+
+  const movedChallengeIds = plan.sourcePlayers.flatMap((s) => s.challengeIds);
+  if (movedChallengeIds.length === 0) {
+    return { targetId, migratedDocuments };
+  }
+
+  // Move all data onto the target in window order.
+  for (const source of plan.sourcePlayers) {
+    const window = plan.windows[source.windowIndex];
+    const moved = await db`
+      UPDATE challenge_players
+      SET player_id = ${targetId}
+      WHERE player_id = ${source.playerId}
+        AND challenge_id = ANY(${source.challengeIds})
+    `;
+    migratedDocuments += moved.count;
+    migratedDocuments += await updatePlayerStats(
+      targetId,
+      source.playerId,
+      window.from,
+      window.to,
+      db,
+    );
+    migratedDocuments += await updateApiKeys(
+      targetId,
+      source.playerId,
+      window.from,
+      window.to,
+      db,
+    );
+  }
+
+  // Recompute PBs for each surviving source record and the target over each
+  // of their affected windows.
+  const recompute = async (playerId: number, challengeIds: number[]) => {
+    const splits = await distinctAccurateSplitTypes(challengeIds, db);
+    migratedDocuments += await recomputePbHistoryFrom(
+      playerId,
+      splits,
+      Math.min(...challengeIds),
+      db,
+    );
+  };
+
+  await recompute(targetId, movedChallengeIds);
+
+  const idsBySource = new Map<number, number[]>();
+  for (const source of plan.sourcePlayers) {
+    const ids = idsBySource.get(source.playerId) ?? [];
+    ids.push(...source.challengeIds);
+    idsBySource.set(source.playerId, ids);
+  }
+  for (const [sourceId, challengeIds] of idsBySource) {
+    if (!plan.emptiedSourceIds.includes(sourceId)) {
+      await recompute(sourceId, challengeIds);
+    }
+  }
+
+  // Adjust each affected player's recording counts.
+  await db`
+    UPDATE players
+    SET total_recordings = total_recordings + ${movedChallengeIds.length}
+    WHERE id = ${targetId}
+  `;
+  for (const [sourceId, challengeIds] of idsBySource) {
+    await db`
+      UPDATE players
+      SET total_recordings = total_recordings - ${challengeIds.length}
+      WHERE id = ${sourceId}
+    `;
+  }
+
+  logger.info('historic_migration_applied', {
+    targetId,
+    migratedDocuments,
+    challengesMoved: movedChallengeIds.length,
+    sourceCount: idsBySource.size,
+  });
+
+  return { targetId, migratedDocuments };
+}
+
+/**
+ * Deletes player records that were emptied by a migration.
+ * @returns The number of records deleted.
+ */
+export async function deleteEmptiedSources(
+  emptiedSourceIds: number[],
+  db: Db = sql,
+): Promise<number> {
+  if (emptiedSourceIds.length === 0) {
+    return 0;
+  }
+  const deleted = await db`
+    DELETE FROM players
+    WHERE id = ANY(${emptiedSourceIds})
+      AND NOT EXISTS (
+        SELECT 1 FROM challenge_players WHERE player_id = players.id
+      )
+  `;
+  return deleted.count;
 }
 
 /**
@@ -605,8 +943,8 @@ export type DisplayPlan = {
     challengesBefore: number;
     challengesAfter: number;
     /**
-     * Date of the earliest challenge ID moving onto the target, from which its
-     * personal bests are recomputed, or `null` if none move.
+     * Date of the earliest challenge whose personal bests are recomputed on the
+     * target, whether moved on or evicted off, or `null` if none.
      */
     pbRecomputedFrom: Date | null;
   };
@@ -614,6 +952,12 @@ export type DisplayPlan = {
   contributions: DisplayContribution[];
   /** One entry per source record, describing its overall fate. */
   sources: DisplaySource[];
+  /**
+   * Challenges on the target outside of player windows, which would be evicted.
+   */
+  evictedChallenges: number;
+  /** Prior-holder API keys on the target. */
+  unownedApiKeys: number;
 };
 
 /** The data a single source record contributes under a single name window. */
@@ -736,9 +1080,10 @@ export async function formatPlan(
     : [];
   const usernames = new Map(nameRows.map((r) => [r.id, r.username]));
 
-  const dateRows = movedIds.length
+  const affectedIds = [...movedIds, ...plan.evictedTargetChallengeIds];
+  const dateRows = affectedIds.length
     ? await db<{ id: number; start_time: Date }[]>`
-        SELECT id, start_time FROM challenges WHERE id = ANY(${movedIds})
+        SELECT id, start_time FROM challenges WHERE id = ANY(${affectedIds})
       `
     : [];
   const challengeDates = new Map(dateRows.map((r) => [r.id, r.start_time]));
@@ -756,8 +1101,9 @@ export async function formatPlan(
     challengesBefore = 0;
   }
 
-  // The target's PBs recompute from the first moved challenge.
-  const targetCutoffId = movedIds.length > 0 ? Math.min(...movedIds) : null;
+  // The target's PBs recompute from the earliest moved or evicted challenge.
+  const targetCutoffId =
+    affectedIds.length > 0 ? Math.min(...affectedIds) : null;
   const targetPbRecomputedFrom =
     targetCutoffId !== null ? challengeDates.get(targetCutoffId)! : null;
 
@@ -774,11 +1120,16 @@ export async function formatPlan(
       name,
       isNew: plan.target.action === 'create',
       challengesBefore,
-      challengesAfter: challengesBefore + movedIds.length,
+      challengesAfter:
+        challengesBefore +
+        movedIds.length -
+        plan.evictedTargetChallengeIds.length,
       pbRecomputedFrom: targetPbRecomputedFrom,
     },
     contributions,
     sources,
+    evictedChallenges: plan.evictedTargetChallengeIds.length,
+    unownedApiKeys: plan.unownedApiKeyCount,
   };
 }
 
@@ -1093,12 +1444,12 @@ async function processStandardNameChange(
       // current values reflect the experience of the player who has taken over
       // the username.
       logger.info('name_change_zombie_player', { changeId, newName });
-      const zombieName = `*${newName}`;
+      const zombie = zombieName(newName);
       await db`
         UPDATE players
         SET
-          username = ${zombieName},
-          normalized_username = ${normalizeRsn(zombieName)},
+          username = ${zombie},
+          normalized_username = ${normalizeRsn(zombie)},
           total_recordings = total_recordings - ${challengesUpdated},
           overall_experience = 0,
           attack_experience = 0,
@@ -1177,6 +1528,74 @@ class PlayerInActiveChallengeError extends Error {
   }
 }
 
+export type HistoricSequenceResult =
+  | 'processed'
+  | 'unavailable'
+  | 'not_found'
+  | 'failed';
+
+/**
+ * Processes a pending historic name change sequence, consolidating the player's
+ * scattered data onto their current record.
+ */
+async function processHistoricSequence(
+  sequenceId: string,
+): Promise<HistoricSequenceResult> {
+  const applied = await sql.begin(async (tx) => {
+    const [{ locked }] = await tx<[{ locked: boolean }]>`
+      SELECT pg_try_advisory_xact_lock(17, hashtext(${sequenceId})) AS locked
+    `;
+    if (!locked) {
+      return 'unavailable' as const;
+    }
+
+    const rows = await tx<
+      Pick<NameChangeQueryResult, 'old_name' | 'new_name' | 'effective_from'>[]
+    >`
+      SELECT old_name, new_name, effective_from
+      FROM name_changes
+      WHERE sequence_id = ${sequenceId}
+        AND status = ${NameChangeStatus.PENDING}
+      ORDER BY effective_from
+      FOR UPDATE
+    `;
+    if (rows.length === 0) {
+      return 'not_found' as const;
+    }
+
+    const chain = chainFromHistoricSequence(rows);
+    const plan = await decide(chain, tx);
+    const { targetId, migratedDocuments } = await apply(plan, tx);
+
+    // Mark accepted. `effective_from` already holds the rename date.
+    await tx`
+      UPDATE name_changes
+      SET
+        status = ${NameChangeStatus.ACCEPTED},
+        player_id = ${targetId},
+        processed_at = ${new Date()},
+        migrated_documents = ${migratedDocuments}
+      WHERE sequence_id = ${sequenceId}
+    `;
+
+    return { emptiedSourceIds: plan.emptiedSourceIds, migratedDocuments };
+  });
+
+  if (applied === 'unavailable' || applied === 'not_found') {
+    return applied;
+  }
+
+  // Delete empty players as a separate pass after the migration to avoid
+  // deciding emptiness from an early transaction snapshot.
+  const deleted = await deleteEmptiedSources(applied.emptiedSourceIds);
+  logger.info('historic_sequence_accepted', {
+    sequenceId,
+    migratedDocuments: applied.migratedDocuments,
+    recordsDeleted: deleted,
+  });
+  return 'processed';
+}
+
 export type BatchProcessingResult = {
   /** Number of name changes successfully processed. */
   processed: number;
@@ -1247,6 +1666,7 @@ export class NameChangeProcessor {
             SELECT id
             FROM name_changes
             WHERE status = ${NameChangeStatus.PENDING}
+              AND kind = ${NameChangeKind.STANDARD}
             ORDER BY id
             FOR UPDATE SKIP LOCKED
             LIMIT 1
@@ -1320,6 +1740,47 @@ export class NameChangeProcessor {
     return result;
   }
 
+  /**
+   * Processes the oldest pending historic name change sequence, if any.
+   */
+  public async processNextHistoricSequence(): Promise<HistoricSequenceResult> {
+    const [row] = await sql<[{ sequence_id: string }?]>`
+      SELECT sequence_id
+      FROM name_changes
+      WHERE status = ${NameChangeStatus.PENDING}
+        AND kind = ${NameChangeKind.HISTORIC}
+      ORDER BY effective_from
+      LIMIT 1
+    `;
+    if (!row) {
+      return 'not_found';
+    }
+    try {
+      return await processHistoricSequence(row.sequence_id);
+    } catch (e) {
+      if (e instanceof UnownedApiKeysError) {
+        await sql`
+          UPDATE name_changes
+          SET status = ${NameChangeStatus.FAILED}, processed_at = ${new Date()}
+          WHERE sequence_id = ${row.sequence_id}
+            AND status = ${NameChangeStatus.PENDING}
+        `;
+        logger.warn('historic_sequence_failed', {
+          sequenceId: row.sequence_id,
+          reason: 'unowned_api_keys',
+          keyCount: e.count,
+        });
+        return 'failed';
+      }
+      logger.error('historic_sequence_error', {
+        sequenceId: row.sequence_id,
+        error: e instanceof Error ? e.message : String(e),
+        stack: e instanceof Error ? e.stack : undefined,
+      });
+      throw e;
+    }
+  }
+
   private async runBatchLoop(): Promise<void> {
     try {
       const result = await this.processBatch();
@@ -1332,6 +1793,12 @@ export class NameChangeProcessor {
       logger.error('name_change_batch_error', {
         error: e instanceof Error ? e.message : String(e),
       });
+    }
+
+    try {
+      await this.processNextHistoricSequence();
+    } catch {
+      // Errors are logged with their sequence id inside the method.
     }
 
     NameChangeProcessor.timeout = setTimeout(

--- a/web/app/api/admin/historic-name-changes/route.ts
+++ b/web/app/api/admin/historic-name-changes/route.ts
@@ -3,7 +3,8 @@ import { NextRequest } from 'next/server';
 import {
   ChainTransition,
   dryRunHistoricNameChange,
-} from '@/actions/name-change-processor';
+  submitHistoricNameChange,
+} from '@/actions/historic-name-changes';
 import { withApiRoute } from '@/api/handler';
 
 import { validateAdminAuth } from '../auth';
@@ -69,7 +70,11 @@ export const POST = withApiRoute(
     }
 
     if (body.dryRun === false) {
-      return Response.json({ error: 'not_implemented' }, { status: 501 });
+      const submission = await submitHistoricNameChange(chain);
+      if (!submission.ok) {
+        return Response.json({ error: submission.error }, { status: 400 });
+      }
+      return Response.json({ sequenceId: submission.sequenceId });
     }
 
     const result = await dryRunHistoricNameChange(chain);


### PR DESCRIPTION
Adds the apply side of the historic name change processor, taking a previous plan created by decide and running it against the database. Adds an admin API entrypoint which inserts historic name change sequences into the DB, and updates the name change processor to try to run one in each of its name batches.