### PR TITLE
socket: Allow all-instance capture

### DIFF
--- a/socket-server/capture.ts
+++ b/socket-server/capture.ts
@@ -21,6 +21,8 @@ export enum CaptureOp {
 
 /** A single entry in the capture stream. */
 export type CaptureRecord = {
+  /** Instance hostname. */
+  host: string;
   /** Event timestamp. */
   ts: number;
   op: CaptureOp;

--- a/socket-server/remote-challenge-manager.ts
+++ b/socket-server/remote-challenge-manager.ts
@@ -638,9 +638,8 @@ export class RemoteChallengeManager extends ChallengeManager {
 
   private async refreshCaptureFlag(): Promise<void> {
     try {
-      this.captureEnabled =
-        (await this.redisClient.get(CAPTURE_ENABLED_KEY)) ===
-        process.env.HOSTNAME;
+      const value = await this.redisClient.get(CAPTURE_ENABLED_KEY);
+      this.captureEnabled = value === process.env.HOSTNAME || value === '*';
     } catch {
       // Best-effort; keep the previous value.
     }
@@ -665,6 +664,7 @@ export class RemoteChallengeManager extends ChallengeManager {
     }
 
     const record: CaptureRecord = {
+      host: process.env.HOSTNAME ?? 'unknown',
       ts,
       op,
       challengeUuid,


### PR DESCRIPTION
A capture value of `*` applies to every socket server instance.