### PR TITLE
web: Add support for theming

### DIFF
--- a/web/app/components/attack-timeline/canvas/cell-content.ts
+++ b/web/app/components/attack-timeline/canvas/cell-content.ts
@@ -20,8 +20,8 @@ import {
 } from '../attack-metadata';
 import { CustomState } from '../types';
 
-import { BLERT_PURPLE, TEXT_PRIMARY } from './colors';
 import { ImageCache } from './image-cache';
+import { TimelinePalette } from './palette';
 import { BoundingBox, Point } from './types';
 
 const BARRAGES = new Set<PlayerAttack>([
@@ -139,7 +139,7 @@ function drawLabel(
   text: string,
   pos: Point,
   fontSize: number,
-  color: string = TEXT_PRIMARY,
+  color: string,
 ): void {
   ctx.font = `bold ${fontSize}px 'Plus Jakarta Sans', sans-serif`;
   ctx.fillStyle = color;
@@ -319,13 +319,14 @@ function drawLetterMode(
   pos: Point,
   cellSize: number,
   attackType: PlayerAttack,
+  textPrimary: string,
 ): void {
   const meta =
     ATTACK_METADATA[attackType] ?? ATTACK_METADATA[PlayerAttack.UNKNOWN];
   const fontSize = Math.floor(cellSize / 2);
 
   ctx.font = `bold ${fontSize}px 'Plus Jakarta Sans', sans-serif`;
-  ctx.fillStyle = meta.tagColor ?? TEXT_PRIMARY;
+  ctx.fillStyle = meta.tagColor ?? textPrimary;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillText(meta.letter, pos.x + cellSize / 2, pos.y + cellSize / 2);
@@ -358,6 +359,7 @@ export type PlayerCellOptions = {
   externalStates: CustomState[];
   letterMode: boolean;
   showInventoryTags: boolean;
+  palette: TimelinePalette;
 };
 
 /**
@@ -377,7 +379,8 @@ export function drawPlayerCell(
   imageCache: ImageCache,
   options: PlayerCellOptions,
 ): boolean {
-  const { actions, diedThisTick, externalStates, letterMode } = options;
+  const { actions, diedThisTick, externalStates, letterMode, palette } =
+    options;
 
   let pending = false;
 
@@ -394,7 +397,7 @@ export function drawPlayerCell(
 
   if (attack !== undefined && attackType !== undefined) {
     if (letterMode) {
-      drawLetterMode(ctx, pos, cellSize, attackType);
+      drawLetterMode(ctx, pos, cellSize, attackType, palette.textPrimary);
       hasBaseImage = true;
     } else {
       hasBaseImage = drawWeapon(
@@ -452,7 +455,14 @@ export function drawPlayerCell(
 
   customStates.push(...externalStates);
   if (customStates.length > 0) {
-    pending ||= !drawCustomStates(ctx, pos, cellSize, customStates, imageCache);
+    pending ||= !drawCustomStates(
+      ctx,
+      pos,
+      cellSize,
+      customStates,
+      imageCache,
+      palette,
+    );
   }
 
   return pending;
@@ -462,6 +472,7 @@ export type NpcCellOptions = {
   cell: BCFCell | undefined;
   npcLabel: string | undefined;
   externalStates: CustomState[];
+  palette: TimelinePalette;
 };
 
 /**
@@ -481,7 +492,7 @@ export function drawNpcCell(
   imageCache: ImageCache,
   options: NpcCellOptions,
 ): boolean {
-  const { cell, npcLabel, externalStates } = options;
+  const { cell, npcLabel, externalStates, palette } = options;
   let pending = false;
 
   const attack = cell?.actions?.find(
@@ -508,6 +519,7 @@ export function drawNpcCell(
       npcLabel,
       { x: pos.x + cellSize - 2, y: pos.y + cellSize },
       fontSize,
+      palette.textPrimary,
     );
   }
 
@@ -518,6 +530,7 @@ export function drawNpcCell(
       cellSize,
       externalStates,
       imageCache,
+      palette,
     );
   }
 
@@ -537,6 +550,7 @@ function drawCustomStates(
   cellSize: number,
   states: CustomState[],
   imageCache: ImageCache,
+  palette: TimelinePalette,
 ): boolean {
   let allDrawn = true;
 
@@ -552,7 +566,7 @@ function drawCustomStates(
     });
   } else if (first.label !== undefined) {
     ctx.font = `bold 8px 'Plus Jakarta Sans', sans-serif`;
-    ctx.fillStyle = TEXT_PRIMARY;
+    ctx.fillStyle = palette.textPrimary;
     ctx.textAlign = 'right';
     ctx.textBaseline = 'top';
     ctx.fillText(first.label, cellPos.x + cellSize, cellPos.y);
@@ -560,7 +574,7 @@ function drawCustomStates(
 
   if (states.length > 1) {
     ctx.font = `bold 8px 'Plus Jakarta Sans', sans-serif`;
-    ctx.fillStyle = BLERT_PURPLE;
+    ctx.fillStyle = palette.blertAccent;
     ctx.textAlign = 'right';
     ctx.textBaseline = 'top';
     ctx.fillText('+', cellPos.x + cellSize, cellPos.y + iconSize);

--- a/web/app/components/attack-timeline/canvas/cell.ts
+++ b/web/app/components/attack-timeline/canvas/cell.ts
@@ -1,27 +1,21 @@
 import { ActionOutline } from '../types';
 
 import {
-  CELL_BG_DEFAULT,
-  CELL_BG_DEFAULT_HOVER,
   CELL_BG_DEAD,
   CELL_BG_DEAD_HOVER,
-  CELL_BG_HIGHLIGHTED,
-  CELL_BG_HIGHLIGHTED_HOVER,
   CELL_BG_NPC_ATTACK,
   CELL_BG_NPC_ATTACK_HOVER,
   CELL_DEAD_HOVER_OPACITY,
   CELL_DEAD_OPACITY,
   OUTLINE_DANGER,
   OUTLINE_DANGER_HOVER,
-  OUTLINE_HOVER,
-  OUTLINE_NEUTRAL,
-  OUTLINE_NEUTRAL_HOVER,
   OUTLINE_NPC_ATTACK_HOVER,
   OUTLINE_SUCCESS,
   OUTLINE_SUCCESS_HOVER,
   OUTLINE_WARNING,
   OUTLINE_WARNING_HOVER,
 } from './colors';
+import { TimelinePalette } from './palette';
 import { Point } from './types';
 
 export type CellCategory = 'default' | 'highlighted' | 'npcAttack' | 'dead';
@@ -35,38 +29,49 @@ export type CellStyle = {
   opacity?: number;
 };
 
-const BG_NORMAL: Record<CellCategory, string> = {
-  default: CELL_BG_DEFAULT,
-  highlighted: CELL_BG_HIGHLIGHTED,
-  npcAttack: CELL_BG_NPC_ATTACK,
-  dead: CELL_BG_DEAD,
-};
+/** Background for a non-dead cell category, honoring hover state. */
+function categoryBackground(
+  palette: TimelinePalette,
+  category: CellCategory,
+  isHovered: boolean,
+): string {
+  switch (category) {
+    case 'default':
+      return isHovered ? palette.cellBgDefaultHover : palette.cellBgDefault;
+    case 'highlighted':
+      return isHovered
+        ? palette.cellBgHighlightedHover
+        : palette.cellBgHighlighted;
+    case 'npcAttack':
+      return isHovered ? CELL_BG_NPC_ATTACK_HOVER : CELL_BG_NPC_ATTACK;
+    case 'dead':
+      return isHovered ? CELL_BG_DEAD_HOVER : CELL_BG_DEAD;
+  }
+}
 
-const BG_HOVER: Record<CellCategory, string> = {
-  default: CELL_BG_DEFAULT_HOVER,
-  highlighted: CELL_BG_HIGHLIGHTED_HOVER,
-  npcAttack: CELL_BG_NPC_ATTACK_HOVER,
-  dead: CELL_BG_DEAD_HOVER,
-};
-
-const OUTLINE_NORMAL: Record<ActionOutline, string> = {
-  success: OUTLINE_SUCCESS,
-  warning: OUTLINE_WARNING,
-  danger: OUTLINE_DANGER,
-  neutral: OUTLINE_NEUTRAL,
-};
-
-const OUTLINE_HOVER_MAP: Record<ActionOutline, string> = {
-  success: OUTLINE_SUCCESS_HOVER,
-  warning: OUTLINE_WARNING_HOVER,
-  danger: OUTLINE_DANGER_HOVER,
-  neutral: OUTLINE_NEUTRAL_HOVER,
-};
+/** Outline color for an evaluation outline, honoring hover state. */
+function outlineColor(
+  palette: TimelinePalette,
+  outline: ActionOutline,
+  isHovered: boolean,
+): string {
+  switch (outline) {
+    case 'success':
+      return isHovered ? OUTLINE_SUCCESS_HOVER : OUTLINE_SUCCESS;
+    case 'warning':
+      return isHovered ? OUTLINE_WARNING_HOVER : OUTLINE_WARNING;
+    case 'danger':
+      return isHovered ? OUTLINE_DANGER_HOVER : OUTLINE_DANGER;
+    case 'neutral':
+      return isHovered ? palette.outlineNeutralHover : palette.outlineNeutral;
+  }
+}
 
 /**
  * Resolves the visual style for a cell based on its category, action evaluation
  * outline, and hover state.
  *
+ * @param palette The active decorative palette.
  * @param category The type of cell.
  * @param outline Optional evaluation outline.
  * @param isHovered Whether the cell is hovered.
@@ -75,6 +80,7 @@ const OUTLINE_HOVER_MAP: Record<ActionOutline, string> = {
  * @returns The styling for the cell, to be used in `drawCell`.
  */
 export function resolveCellStyle(
+  palette: TimelinePalette,
   category: CellCategory,
   outline: ActionOutline | undefined,
   isHovered: boolean,
@@ -85,24 +91,24 @@ export function resolveCellStyle(
   let background: string;
   if (isDead) {
     // Dead cells override chart background colors.
-    background = isHovered ? BG_HOVER.dead : BG_NORMAL.dead;
+    background = isHovered ? CELL_BG_DEAD_HOVER : CELL_BG_DEAD;
   } else if (chartBackground !== undefined) {
     background = chartBackground;
   } else {
-    background = isHovered ? BG_HOVER[category] : BG_NORMAL[category];
+    background = categoryBackground(palette, category, isHovered);
   }
 
   let resolvedOutline: string | undefined;
   if (isHovered) {
     if (outline !== undefined) {
-      resolvedOutline = OUTLINE_HOVER_MAP[outline];
+      resolvedOutline = outlineColor(palette, outline, true);
     } else if (category === 'npcAttack') {
       resolvedOutline = OUTLINE_NPC_ATTACK_HOVER;
     } else {
-      resolvedOutline = OUTLINE_HOVER;
+      resolvedOutline = palette.outlineHover;
     }
   } else if (outline !== undefined) {
-    resolvedOutline = OUTLINE_NORMAL[outline];
+    resolvedOutline = outlineColor(palette, outline, false);
   }
 
   return {

--- a/web/app/components/attack-timeline/canvas/colors.ts
+++ b/web/app/components/attack-timeline/canvas/colors.ts
@@ -1,11 +1,7 @@
 /**
- * Hardcoded color constants for the canvas timeline renderer.
- *
- * These mirror the CSS variables defined in `bcf-renderer.module.scss` and
- * `globals.scss`. Since canvas cannot efficiently read CSS variables, and the
- * app does not support runtime theme switching, hardcoding is safe.
- *
- * If the theme changes, these values must be updated to match.
+ * Diagnostic semantic color constants for the canvas timeline renderer.
+ * The base timeline colors are defined in `palette.ts`; these encode meaning
+ * and are consistent across themes.
  */
 
 import { ChartColor, ColorIntensity } from '../types';
@@ -63,12 +59,6 @@ export function getChartColor(
 
 // Cell backgrounds
 
-export const CELL_BG_DEFAULT = 'rgba(33, 35, 48, 0.5)';
-export const CELL_BG_DEFAULT_HOVER = 'rgba(33, 35, 48, 0.6)';
-
-export const CELL_BG_HIGHLIGHTED = 'rgba(48, 51, 73, 0.5)';
-export const CELL_BG_HIGHLIGHTED_HOVER = 'rgba(88, 101, 242, 0.3)';
-
 export const CELL_BG_NPC_ATTACK = 'rgba(239, 68, 68, 0.1)';
 export const CELL_BG_NPC_ATTACK_HOVER = 'rgba(239, 68, 68, 0.3)';
 
@@ -89,18 +79,8 @@ export const OUTLINE_WARNING_HOVER = 'rgba(222, 200, 88, 0.9)';
 export const OUTLINE_DANGER = 'rgba(239, 68, 68, 0.5)';
 export const OUTLINE_DANGER_HOVER = 'rgba(239, 68, 68, 0.9)';
 
-export const OUTLINE_NEUTRAL = 'rgba(195, 199, 201, 0.2)';
-export const OUTLINE_NEUTRAL_HOVER = 'rgba(88, 101, 242, 0.8)';
-
-export const OUTLINE_HOVER = 'rgba(88, 101, 242, 0.7)';
-
 export const OUTLINE_NPC_ATTACK_HOVER = 'rgba(239, 68, 68, 0.9)';
 
 // Text colors
 
-export const TEXT_TICK_HEADER = 'rgba(195, 199, 201, 0.9)';
-export const TEXT_PRIMARY = 'rgb(195, 199, 201)';
 export const TEXT_NPC_ATTACK = 'rgba(239, 68, 68, 0.9)';
-export const TEXT_HIGHLIGHTED = 'rgba(88, 101, 242, 0.9)';
-
-export const BLERT_PURPLE = 'rgb(88, 101, 242)';

--- a/web/app/components/attack-timeline/canvas/palette.ts
+++ b/web/app/components/attack-timeline/canvas/palette.ts
@@ -1,0 +1,68 @@
+/**
+ * Decorative, themed colors for the canvas timeline.
+ * Only a subset of colors are themeable, as colors which encode semantic
+ * meaning should stay consistent.
+ */
+export type TimelinePalette = {
+  /** Background for an empty cell. */
+  cellBgDefault: string;
+  cellBgDefaultHover: string;
+  /** Background for a cell with actions. */
+  cellBgHighlighted: string;
+  cellBgHighlightedHover: string;
+  /** Neutral (non-evaluated) cell outline. */
+  outlineNeutral: string;
+  outlineNeutralHover: string;
+  /** Outline drawn on any hovered cell without a more specific outline. */
+  outlineHover: string;
+  /** Tick number in the column header. */
+  textTickHeader: string;
+  /** Default label / letter text. */
+  textPrimary: string;
+  /**
+   * The theme's accent, equivalent to `blert-purple` in the default theme.
+   */
+  blertAccent: string;
+};
+
+/**
+ * Reads a CSS custom property value by name, e.g. `--blert-timeline-accent`.
+ */
+export type ColorReader = (name: string) => string;
+
+/**
+ * Builds the timeline's decorative palette from the app's CSS tokens.
+ *
+ * Each color is a single `--blert-timeline-*` custom property holding its final
+ * value, so reading tokens keeps the timeline in sync with the active theme.
+ *
+ * @param read Optional custom property reader. Defaults to the computed style
+ *   of the document root.
+ */
+export function buildTimelinePalette(read?: ColorReader): TimelinePalette {
+  if (read === undefined) {
+    if (typeof window === 'undefined') {
+      read = () => '';
+    } else {
+      const styles = getComputedStyle(document.documentElement);
+      read = (name) => styles.getPropertyValue(name);
+    }
+  }
+
+  const color = (name: string): string => {
+    return read(name).trim();
+  };
+
+  return {
+    cellBgDefault: color('--blert-timeline-cell-bg-default'),
+    cellBgDefaultHover: color('--blert-timeline-cell-bg-default-hover'),
+    cellBgHighlighted: color('--blert-timeline-cell-bg-highlighted'),
+    cellBgHighlightedHover: color('--blert-timeline-cell-bg-highlighted-hover'),
+    outlineNeutral: color('--blert-timeline-outline-neutral'),
+    outlineNeutralHover: color('--blert-timeline-outline-neutral-hover'),
+    outlineHover: color('--blert-timeline-outline-hover'),
+    textTickHeader: color('--blert-timeline-text-tick-header'),
+    textPrimary: color('--blert-timeline-text-primary'),
+    blertAccent: color('--blert-timeline-accent'),
+  };
+}

--- a/web/app/components/attack-timeline/canvas/renderer.ts
+++ b/web/app/components/attack-timeline/canvas/renderer.ts
@@ -12,8 +12,9 @@ import {
 
 import { drawPlayerCell, drawNpcCell } from './cell-content';
 import { CellCategory, drawCell, resolveCellStyle } from './cell';
-import { BLERT_PURPLE, getChartColor, TEXT_TICK_HEADER } from './colors';
+import { getChartColor } from './colors';
 import { ImageCache } from './image-cache';
+import { TimelinePalette } from './palette';
 import { Point, TimelineHover } from './types';
 
 export type TimelineDrawData = {
@@ -22,6 +23,7 @@ export type TimelineDrawData = {
   actionEvaluator?: ActionEvaluator;
   stateProvider?: StateProvider;
   imageCache: ImageCache;
+  palette: TimelinePalette;
   hover: TimelineHover | null;
   letterMode: boolean;
   showInventoryTags: boolean;
@@ -50,7 +52,7 @@ export function drawTimeline(
   data: TimelineDrawData,
   layout: TileLayout,
 ): boolean {
-  const { resolver, display, imageCache, hover } = data;
+  const { resolver, display, imageCache, hover, palette } = data;
   const { cellSize, startTick, tickCount, rowOrder } = layout;
 
   const columnWidth = cellSize + CELL_GAP;
@@ -98,6 +100,7 @@ export function drawTimeline(
               : undefined;
 
           const style = resolveCellStyle(
+            palette,
             category,
             undefined,
             isHovered,
@@ -112,6 +115,7 @@ export function drawTimeline(
             cell,
             npcLabel,
             externalStates,
+            palette,
           });
         } else {
           // Player cell.
@@ -150,6 +154,7 @@ export function drawTimeline(
               : undefined;
 
           const style = resolveCellStyle(
+            palette,
             category,
             evaluation.outline,
             isHovered,
@@ -166,6 +171,7 @@ export function drawTimeline(
             externalStates,
             letterMode: data.letterMode,
             showInventoryTags: data.showInventoryTags,
+            palette,
           });
         }
       } else {
@@ -178,7 +184,13 @@ export function drawTimeline(
             ? getChartColor(bgColor.color, bgColor.intensity)
             : undefined;
 
-        const style = resolveCellStyle(category, undefined, isHovered, chartBg);
+        const style = resolveCellStyle(
+          palette,
+          category,
+          undefined,
+          isHovered,
+          chartBg,
+        );
         drawCell(ctx, cellPos, cellSize, style);
       }
     }
@@ -187,7 +199,9 @@ export function drawTimeline(
     const isTickHovered =
       hover !== null && hover.type === 'tick-header' && hover.tick === tick;
     ctx.font = `${Math.floor(cellSize / 2) - 1}px 'Plus Jakarta Sans', sans-serif`;
-    ctx.fillStyle = isTickHovered ? BLERT_PURPLE : TEXT_TICK_HEADER;
+    ctx.fillStyle = isTickHovered
+      ? palette.blertAccent
+      : palette.textTickHeader;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillText(String(tick), colX + cellSize / 2, TICK_HEIGHT / 2);

--- a/web/app/components/attack-timeline/canvas/timeline-controller.ts
+++ b/web/app/components/attack-timeline/canvas/timeline-controller.ts
@@ -10,6 +10,7 @@ import {
 
 import { hitTest, HitTestResult } from './hit-test';
 import { ImageCache } from './image-cache';
+import { buildTimelinePalette, TimelinePalette } from './palette';
 import { drawTimeline, TimelineDrawData, TileLayout } from './renderer';
 import { TimelineHover, TimelineLayout } from './types';
 
@@ -47,10 +48,12 @@ export class TimelineController {
   private canvases: HTMLCanvasElement[] = [];
   private data: ControllerData | null = null;
   private layout: ControllerLayout | null = null;
+  private palette: TimelinePalette = buildTimelinePalette();
 
   private imageCache: ImageCache;
   private dpr = 1;
   private dprMql: MediaQueryList | null = null;
+  private themeObserver: MutationObserver | null = null;
 
   private hover: [TimelineHover, number] | null = null;
   private lastMouseEvent: MouseEvent | null = null;
@@ -89,6 +92,7 @@ export class TimelineController {
       canvas.addEventListener('click', this.onClick);
     }
 
+    this.observeTheme();
     this.syncDpr();
     this.resizeCanvases();
     this.drawAllSync();
@@ -152,6 +156,11 @@ export class TimelineController {
       this.dprMql = null;
     }
 
+    if (this.themeObserver !== null) {
+      this.themeObserver.disconnect();
+      this.themeObserver = null;
+    }
+
     this.lastMouseEvent = null;
   }
 
@@ -207,6 +216,27 @@ export class TimelineController {
     }
   }
 
+  /**
+   * Rebuilds the palette and redraws when the document's `data-theme` changes,
+   * so the timeline updates immediately on a theme switch.
+   */
+  private observeTheme(): void {
+    if (
+      this.themeObserver !== null ||
+      typeof MutationObserver === 'undefined'
+    ) {
+      return;
+    }
+    this.themeObserver = new MutationObserver(() => {
+      this.palette = buildTimelinePalette();
+      this.drawAllSync();
+    });
+    this.themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+  }
+
   private drawAllSync(): void {
     if (this.layout === null) {
       return;
@@ -240,6 +270,7 @@ export class TimelineController {
       actionEvaluator: this.data.actionEvaluator,
       stateProvider: this.data.stateProvider,
       imageCache: this.imageCache,
+      palette: this.palette,
       letterMode: this.data.letterMode,
       showInventoryTags: this.data.showInventoryTags,
       customRowContent: this.data.customRowContent,

--- a/web/app/components/left-nav/nav-player-search.tsx
+++ b/web/app/components/left-nav/nav-player-search.tsx
@@ -50,6 +50,7 @@ export default function NavPlayerSearch() {
       fluid
       id="blert-player-search"
       label="Find a player"
+      labelBg="var(--blert-surface-dark)"
       maxLength={12}
       onChange={(value) => {
         setUsername(value);

--- a/web/app/components/left-nav/styles.module.scss
+++ b/web/app/components/left-nav/styles.module.scss
@@ -19,11 +19,7 @@
   display: flex;
   height: 100%;
   width: var(--left-nav-width, $LEFT_NAV_WIDTH);
-  background: linear-gradient(
-    to bottom,
-    var(--blert-panel-background-color),
-    var(--blert-surface-dark)
-  );
+  background: var(--blert-surface-dark);
   flex-direction: column;
   overflow-y: scroll;
   transition: width 0.3s ease;
@@ -355,54 +351,16 @@
 .leftNav__menuItem {
   display: flex;
   align-items: center;
-  height: 48px;
+  height: 40px;
   justify-content: flex-start;
-  padding: 0 12px;
+  padding: 0 10px;
   margin: 4px 0;
 
   @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
-    height: 38px;
+    height: 36px;
     margin: 2px 0;
     padding: 0 8px;
   }
-}
-
-.leftNav__subMenu {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  margin: 0 8px 8px;
-  padding: 6px;
-  position: relative;
-  background: rgba(var(--blert-surface-light-base), 0.4);
-  border-radius: 6px;
-  border: 1px solid var(--blert-divider-color);
-
-  a {
-    width: 100%;
-  }
-}
-
-.leftNav__subMenuItem {
-  width: 100%;
-  padding: 4px 8px;
-  font-size: 0.85em;
-  border-radius: 4px;
-  color: var(--blert-font-color-secondary);
-  font-weight: 500;
-  transition: all 0.2s ease;
-  text-align: center;
-  margin: 1px 0;
-
-  &:hover {
-    background: var(--blert-surface-dark);
-    color: var(--blert-font-color-primary);
-  }
-}
-
-.leftNav__subMenuItemActive {
-  background: var(--blert-surface-darker);
-  color: var(--blert-font-color-primary);
 }
 
 .leftNav__menuItemInner {
@@ -442,20 +400,6 @@
       i {
         color: var(--blert-purple);
       }
-    }
-  }
-}
-
-.leftNav__menuItemInnerActive {
-  background: var(--blert-surface-light);
-
-  span {
-    color: var(--blert-font-color-primary);
-  }
-
-  .leftNav__menuItemIcon {
-    i {
-      color: var(--blert-purple);
     }
   }
 }

--- a/web/app/components/modal/style.module.scss
+++ b/web/app/components/modal/style.module.scss
@@ -29,7 +29,7 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 20px 24px;
+      padding: 12px 14px 12px 22px;
       border-bottom: 1px solid rgba(var(--blert-purple-base), 0.15);
       background: linear-gradient(
         135deg,
@@ -39,22 +39,33 @@
 
       h2 {
         margin: 0;
-        font-size: 1.25rem;
+        font-size: 1rem;
         font-weight: 600;
         color: var(--blert-font-color-primary);
       }
 
       button {
-        background: none;
+        width: 28px;
+        height: 28px;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         border: none;
-        padding: 8px;
+        background: none;
         cursor: pointer;
         transition: all 0.2s ease;
         font-size: 16px;
         color: var(--blert-font-color-secondary);
 
+        i {
+          position: relative;
+          top: 1px;
+        }
+
         &:hover {
-          color: var(--blert-font-color-primary);
+          color: var(--blert-purple);
+          background: var(--blert-surface-light);
         }
       }
     }

--- a/web/app/components/session-history/style.module.scss
+++ b/web/app/components/session-history/style.module.scss
@@ -28,12 +28,8 @@
 }
 
 .sessionCard {
-  background: linear-gradient(
-    135deg,
-    var(--blert-panel-background-color) 0%,
-    rgba(var(--blert-surface-dark-base), 0.8) 100%
-  );
-  border: 1px solid rgba(var(--blert-purple-base), 0.15);
+  background: var(--blert-panel-background-color);
+  border: 1px solid rgba(var(--blert-divider-color-base), 0.5);
   border-radius: 12px;
   margin-bottom: 16px;
   overflow: hidden;
@@ -50,12 +46,7 @@
 .activeSession {
   position: relative;
   border: 1px solid rgba(var(--blert-green-base), 0.15);
-  background: linear-gradient(
-    135deg,
-    rgba(var(--blert-green-base), 0.02) 0%,
-    var(--blert-panel-background-color) 30%,
-    rgba(var(--blert-surface-dark-base), 0.8) 100%
-  );
+  background: var(--blert-panel-background-color);
   box-shadow:
     0 4px 16px rgba(0, 0, 0, 0.2),
     0 0 20px rgba(var(--blert-green-base), 0.1);
@@ -267,11 +258,10 @@
   align-items: center;
   gap: 8px;
   padding: 12px;
-  background: rgba(var(--blert-surface-dark-base), 0.6);
+  background: var(--blert-surface-dark);
   border-radius: 8px;
   font-size: 0.9rem;
   color: var(--blert-font-color-primary);
-  border: 1px solid rgba(var(--blert-divider-color), 0.3);
   transition: all 0.2s ease;
 
   i {
@@ -297,7 +287,7 @@
 }
 
 .sessionChallenges {
-  border-top: 1px solid rgba(var(--blert-divider-color), 0.3);
+  border-top: 1px solid rgba(var(--blert-divider-color-base), 0.3);
   background: rgba(var(--blert-surface-darker-base), 0.4);
 }
 
@@ -313,7 +303,7 @@
   flex-direction: column;
   padding: 12px;
   background: rgba(var(--blert-panel-background-color-base), 0.8);
-  border: 1px solid rgba(var(--blert-divider-color), 0.2);
+  border: 1px solid rgba(var(--blert-divider-color-base), 0.3);
   border-radius: 8px;
   text-decoration: none;
   color: inherit;

--- a/web/app/components/settings-provider.tsx
+++ b/web/app/components/settings-provider.tsx
@@ -11,11 +11,9 @@ import {
 } from 'react';
 
 import { setUserSetting, syncSettings, UserSettings } from '@/actions/settings';
-
-import { useToast } from './toast';
 import { authClient } from '@/auth-client';
-
-export const SETTINGS_KEY_PREFIX = 'blert-setting:';
+import { useToast } from '@/components/toast';
+import { SETTINGS_KEY_PREFIX } from '@/utils/settings';
 
 type SettingsContextValue = {
   settings: UserSettings;

--- a/web/app/globals.scss
+++ b/web/app/globals.scss
@@ -1,9 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;700;800&display=swap');
 
-// NOTE: Theme color values are duplicated as hardcoded constants in
-// components/attack-timeline/canvas/colors.ts for the canvas renderer.
-// If you change base color values here, update that file to match.
-:root {
+// Base (Blert) theme tokens, declared on every `[data-theme]` scope, so a
+// nested element can set its own theme and derive its `rgb(var(--*-base))`
+// tokens from that instead of inheriting the active theme's.
+//
+// Other themes should override any tokens that differ.
+:root,
+[data-theme] {
   --topbar-height: 60px;
 
   --blert-red-base: 239, 68, 68;
@@ -17,6 +20,7 @@
 
   --blert-font-color-primary-base: 195, 199, 201;
   --blert-font-color-secondary-base: 94, 98, 136;
+  --blert-divider-color-base: 75, 78, 109;
 
   --blert-surface-dark-base: 23, 24, 33;
   --blert-surface-darker-base: 17, 18, 33;
@@ -36,7 +40,7 @@
   --blert-font-color-primary: rgb(var(--blert-font-color-primary-base));
   --blert-font-color-secondary: rgb(var(--blert-font-color-secondary-base));
   --blert-font-color-secondary-active: #acafc6;
-  --blert-divider-color: #4b4e6d;
+  --blert-divider-color: rgb(var(--blert-divider-color-base));
 
   --blert-surface-dark: rgb(var(--blert-surface-dark-base));
   --blert-surface-darker: rgb(var(--blert-surface-darker-base));
@@ -50,6 +54,19 @@
   --blert-silver-text-shadow:
     0 0 6px rgba(192, 192, 192, 0.5), 0 0 12px rgba(192, 192, 192, 0.25);
   --blert-bronze-text-shadow: 0 0 6px rgba(205, 127, 50, 0.4);
+
+  // Attack timeline decorative colors, read by its renderer.
+  // See components/attack-timeline/canvas/palette.ts.
+  --blert-timeline-cell-bg-default: rgba(33, 35, 48, 0.5);
+  --blert-timeline-cell-bg-default-hover: rgba(33, 35, 48, 0.6);
+  --blert-timeline-cell-bg-highlighted: rgba(48, 51, 73, 0.5);
+  --blert-timeline-cell-bg-highlighted-hover: rgba(88, 101, 242, 0.3);
+  --blert-timeline-outline-neutral: rgba(195, 199, 201, 0.2);
+  --blert-timeline-outline-neutral-hover: rgba(88, 101, 242, 0.8);
+  --blert-timeline-outline-hover: rgba(88, 101, 242, 0.7);
+  --blert-timeline-text-tick-header: rgba(195, 199, 201, 0.9);
+  --blert-timeline-text-primary: rgb(195, 199, 201);
+  --blert-timeline-accent: rgb(88, 101, 242);
 }
 
 * {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -13,6 +13,7 @@ import Topbar from './components/topbar';
 import { MAIN_LOGO } from './logo';
 import Providers from './providers';
 import Styler from './styler';
+import { THEME_INIT_SCRIPT } from './theme/theme-script';
 
 import './globals.scss';
 import styles from './styles.module.scss';
@@ -87,8 +88,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/web/app/network/components/network-info.module.scss
+++ b/web/app/network/components/network-info.module.scss
@@ -242,7 +242,7 @@
   gap: 8px;
   padding: 8px;
   background: rgba(var(--blert-surface-dark-base), 0.6);
-  border: 1px solid rgba(var(--blert-divider-color), 0.3);
+  border: 1px solid rgba(var(--blert-divider-color-base), 0.3);
   border-radius: 6px;
   transition: all 0.2s ease;
 
@@ -321,7 +321,7 @@
   gap: 8px;
   padding: 8px 12px;
   background: rgba(var(--blert-surface-dark-base), 0.4);
-  border: 1px dashed rgba(var(--blert-divider-color), 0.5);
+  border: 1px dashed rgba(var(--blert-divider-color-base), 0.5);
   border-radius: 6px;
   color: var(--blert-font-color-secondary);
   font-size: 0.8rem;

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -4,6 +4,7 @@ import ChallengeProvider from './challenge-context';
 import SettingsProvider from './components/settings-provider';
 import ToastProvider from './components/toast';
 import { DisplayWrapper } from './display';
+import ThemeApplier from './theme/theme-applier';
 
 type ProvidersProps = {
   children: React.ReactNode;
@@ -14,7 +15,10 @@ export default function Providers({ children }: ProvidersProps) {
     <DisplayWrapper>
       <ChallengeProvider>
         <ToastProvider>
-          <SettingsProvider>{children}</SettingsProvider>
+          <SettingsProvider>
+            <ThemeApplier />
+            {children}
+          </SettingsProvider>
         </ToastProvider>
       </ChallengeProvider>
     </DisplayWrapper>

--- a/web/app/search/challenges/style.module.scss
+++ b/web/app/search/challenges/style.module.scss
@@ -415,7 +415,7 @@
       cursor: pointer;
       color: var(--blert-font-color-primary);
       font-size: 0.9rem;
-      border: 1px solid rgba(var(--blert-purple-base), 0.1);
+      border: 1px solid var(--blert-divider-color);
       transition: all 0.2s ease;
       white-space: nowrap;
       overflow: hidden;

--- a/web/app/sessions/components/challenge-analysis.module.scss
+++ b/web/app/sessions/components/challenge-analysis.module.scss
@@ -372,7 +372,7 @@
   padding: 10px 16px;
   display: flex;
   align-items: center;
-  border-bottom: 1px solid rgba(var(--blert-divider-color), 0.3);
+  border-bottom: 1px solid rgba(var(--blert-divider-color-base), 0.3);
 
   &:last-child {
     justify-content: center;

--- a/web/app/sessions/components/session-header.module.scss
+++ b/web/app/sessions/components/session-header.module.scss
@@ -283,7 +283,7 @@
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
   background: rgba(var(--blert-surface-dark-base), 0.6);
-  border: 1px solid rgba(var(--blert-divider-color), 0.3);
+  border: 1px solid rgba(var(--blert-divider-color-base), 0.3);
   border-radius: 8px;
   font-size: 0.85rem;
   color: var(--blert-font-color-primary);

--- a/web/app/theme/theme-applier.tsx
+++ b/web/app/theme/theme-applier.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useSettingsContext } from '@/components/settings-provider';
+
+import { DEFAULT_THEME, resolveThemeId, THEME_SETTING_KEY } from './themes';
+
+/** Keeps `<html data-theme>` in sync with the persisted theme setting. */
+export default function ThemeApplier() {
+  const { settings, isLoading } = useSettingsContext();
+
+  useEffect(() => {
+    // While the settings context is loading, the attribute set by the pre-paint
+    // script is left untouched, as the unpopulated settings would resolve back
+    // to the default theme.
+    if (isLoading) {
+      return;
+    }
+    const resolved = resolveThemeId(settings[THEME_SETTING_KEY]);
+    if (resolved === DEFAULT_THEME) {
+      delete document.documentElement.dataset.theme;
+    } else {
+      document.documentElement.dataset.theme = resolved;
+    }
+  }, [settings, isLoading]);
+
+  return null;
+}

--- a/web/app/theme/theme-script.ts
+++ b/web/app/theme/theme-script.ts
@@ -1,0 +1,21 @@
+import { SETTINGS_KEY_PREFIX } from '@/utils/settings';
+
+import { DEFAULT_THEME, THEME_SETTING_KEY } from './themes';
+
+const STORAGE_KEY = SETTINGS_KEY_PREFIX + THEME_SETTING_KEY;
+
+/**
+ * Inline script that runs before first paint, reading the persisted theme from
+ * localStorage and sets `data-theme` on `<html>`, so the initial render is
+ * appropriately themed.
+ */
+export const THEME_INIT_SCRIPT = `(function () {
+  try {
+    var raw = localStorage.getItem(${JSON.stringify(STORAGE_KEY)});
+    if (raw === null) return;
+    var theme = JSON.parse(raw);
+    if (typeof theme === 'string' && theme !== ${JSON.stringify(DEFAULT_THEME)}) {
+      document.documentElement.dataset.theme = theme;
+    }
+  } catch (e) {}
+})();`;

--- a/web/app/theme/themes.ts
+++ b/web/app/theme/themes.ts
@@ -1,0 +1,29 @@
+export type ThemeId = 'blert';
+
+export type ThemeDefinition = {
+  id: ThemeId;
+  label: string;
+  description: string;
+};
+
+/**
+ * Available themes, in display order.
+ *
+ * Adding a theme is a matter of appending an entry here plus a matching
+ * `[data-theme='<id>']` token block in `globals.scss`.
+ */
+export const THEMES: ThemeDefinition[] = [
+  { id: 'blert', label: 'Blert', description: 'The classic Blert look.' },
+];
+
+export const DEFAULT_THEME: ThemeId = 'blert';
+
+/** The user settings key under which the chosen theme is stored. */
+export const THEME_SETTING_KEY = 'appearance.theme';
+
+/** Coerces an arbitrary stored value to a known theme id. */
+export function resolveThemeId(value: unknown): ThemeId {
+  return THEMES.some((theme) => theme.id === value)
+    ? (value as ThemeId)
+    : DEFAULT_THEME;
+}

--- a/web/app/utils/settings.ts
+++ b/web/app/utils/settings.ts
@@ -1,0 +1,8 @@
+/**
+ * localStorage key prefix for persisted user settings.
+ *
+ * This must in a plain (not 'use client`) module because it is shared by
+ * both client code (`user-settings`, `settings-provider`) and server code (the
+ * pre-paint `theme-script`, rendered by the root layout).
+ */
+export const SETTINGS_KEY_PREFIX = 'blert-setting:';

--- a/web/app/utils/user-settings.ts
+++ b/web/app/utils/user-settings.ts
@@ -2,10 +2,8 @@
 
 import { useCallback, useRef } from 'react';
 
-import {
-  SETTINGS_KEY_PREFIX,
-  useSettingsContext,
-} from '@/components/settings-provider';
+import { useSettingsContext } from '@/components/settings-provider';
+import { SETTINGS_KEY_PREFIX } from '@/utils/settings';
 
 type UseSettingOptions<T> = {
   key: string;


### PR DESCRIPTION
Lays the groundwork for multiple site themes by defining a theming system via user settings with a global applier that updates a data attribute on the root element to switch between CSS tokens.

Extracts hardcoded color values from the timeline canvas renderer into a config object that gets synced from the document's computed styles on data-theme changes, and defines those constants within the root CSS file. Also extracts a couple other missing color constants.

No new themes or user-facing theme UI is added.