### PR TITLE
2c2s: Project client hash to redis

### DIFF
--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -12,7 +12,7 @@ use super::core::command::{Command, Create, Envelope, Join};
 use super::core::deadline::{LifecycleConfig, next_deadline};
 use super::core::decide::decide;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
-use super::core::state::{ChallengeState, PhaseState, Snapshot};
+use super::core::state::{ChallengeState, LastCompleted, PhaseState, PublishedClient, Snapshot};
 use super::core::types::{ClientId, JournalSeq, MsgId, Timestamp, Uuid};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -165,8 +165,13 @@ pub trait ChallengeClaim: Send + Sync + 'static {
     /// Appends a decision's entries to the challenge's journal as a single atomic batch.
     async fn append(&self, batch: &[JournalEntry]) -> Result<(), StoreError>;
 
-    /// Publishes a snapshot of the challenge's state, signaling its update.
-    async fn project(&self, snapshot: &Snapshot) -> Result<(), StoreError>;
+    /// Publishes a snapshot of the challenge's state and its clients,
+    /// signaling the update.
+    async fn project(
+        &self,
+        snapshot: &Snapshot,
+        clients: &[PublishedClient],
+    ) -> Result<(), StoreError>;
 
     /// Broadcasts a lifecycle milestone to consumers.
     async fn announce(&self, update: &ChallengeServerUpdate) -> Result<(), StoreError>;
@@ -392,11 +397,19 @@ impl ActiveChallenge {
         }
     }
 
-    /// Publishes a snapshot of the current state, returning false if the
-    /// projection could not be written.
+    /// Publishes a snapshot of the current state and its clients, returning
+    /// false if the projection could not be written.
     async fn project(&self, cursor: MsgId) -> bool {
         let current = Snapshot::of(&self.state, cursor);
-        if let Err(error) = with_retries(self.state.uuid, || self.claim.project(&current)).await {
+        let clients: Vec<PublishedClient> = self
+            .state
+            .clients
+            .iter()
+            .map(|(&client_id, client)| PublishedClient::of(client_id, client))
+            .collect();
+        if let Err(error) =
+            with_retries(self.state.uuid, || self.claim.project(&current, &clients)).await
+        {
             tracing::error!(uuid = %self.state.uuid, %error, "projection_failed");
             return false;
         }
@@ -488,7 +501,7 @@ mod tests {
         renewals: AtomicU64,
         releases: AtomicU64,
         appended: Mutex<Vec<JournalEntry>>,
-        projected: Mutex<Vec<Snapshot>>,
+        projected: Mutex<Vec<(Snapshot, Vec<PublishedClient>)>>,
         announced: Mutex<Vec<ChallengeServerUpdate>>,
         deleted: Mutex<Vec<ChallengeState>>,
         // Holds the inbox feed's sender when the run is deadline-driven,
@@ -542,9 +555,17 @@ mod tests {
             Ok(())
         }
 
-        async fn project(&self, snapshot: &Snapshot) -> Result<(), StoreError> {
+        async fn project(
+            &self,
+            snapshot: &Snapshot,
+            clients: &[PublishedClient],
+        ) -> Result<(), StoreError> {
             self.log.next_result()?;
-            self.log.projected.lock().unwrap().push(snapshot.clone());
+            self.log
+                .projected
+                .lock()
+                .unwrap()
+                .push((snapshot.clone(), clients.to_vec()));
             Ok(())
         }
 
@@ -707,7 +728,27 @@ mod tests {
             status: ChallengeStatus::InProgress,
             cursor: MsgId::sequence(1),
         };
-        assert_eq!(*outcome.log.projected.lock().unwrap(), vec![expected]);
+        assert_eq!(
+            *outcome.log.projected.lock().unwrap(),
+            vec![(expected, vec![published_client()])],
+        );
+    }
+
+    /// The published form of the only client in `created_journal`.
+    fn published_client() -> PublishedClient {
+        PublishedClient {
+            user_id: UserId(1),
+            client_id: ClientId(10),
+            recording_type: RecordingType::Participant,
+            active: true,
+            stage: Stage::TobMaiden,
+            stage_attempt: None,
+            stage_status: StageStatus::Entered,
+            last_completed: LastCompleted {
+                stage: Stage::UnknownStage,
+                attempt: None,
+            },
+        }
     }
 
     #[tokio::test(start_paused = true)]
@@ -947,17 +988,20 @@ mod tests {
         assert!(outcome.log.appended.lock().unwrap().is_empty());
         assert_eq!(
             *outcome.log.projected.lock().unwrap(),
-            vec![Snapshot {
-                uuid,
-                challenge_type: ChallengeType::Tob,
-                mode: ChallengeMode::TobRegular,
-                stage: Stage::TobMaiden,
-                stage_attempt: None,
-                party: vec!["a".into()],
-                phase: ChallengePhase::Active,
-                status: ChallengeStatus::InProgress,
-                cursor: MsgId::sequence(1),
-            }],
+            vec![(
+                Snapshot {
+                    uuid,
+                    challenge_type: ChallengeType::Tob,
+                    mode: ChallengeMode::TobRegular,
+                    stage: Stage::TobMaiden,
+                    stage_attempt: None,
+                    party: vec!["a".into()],
+                    phase: ChallengePhase::Active,
+                    status: ChallengeStatus::InProgress,
+                    cursor: MsgId::sequence(1),
+                },
+                vec![published_client()],
+            )],
         );
     }
 

--- a/challenge-harder/src/lifecycle/coordinator.rs
+++ b/challenge-harder/src/lifecycle/coordinator.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 use super::challenge::{ChallengeSignal, ChallengeStore, Claim, Rejoin, Start, run_challenge};
 use super::core::command::{ClientStatusChange, Command, Create, Finish, Join, Update};
 use super::core::deadline::LifecycleConfig;
-use super::core::state::{ChallengePhase, Snapshot};
+use super::core::state::{ChallengePhase, PublishedClient, Snapshot};
 use super::core::types::{ClientId, MsgId, Uuid};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -679,7 +679,7 @@ mod tests {
             unreachable!();
         }
 
-        async fn project(&self, _: &Snapshot) -> Result<(), StoreError> {
+        async fn project(&self, _: &Snapshot, _: &[PublishedClient]) -> Result<(), StoreError> {
             unreachable!();
         }
 

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -5,8 +5,8 @@
 
 use super::command::StageProgress;
 use super::event::{Cause, JournalEntry, LifecycleEvent};
-use super::state::{ChallengeState, ClientState, PhaseState, StageState};
-use super::types::{ClientId, StageExt, StageStatus, Timestamp};
+use super::state::{ChallengeState, ClientState, LastCompleted, PhaseState, StageState};
+use super::types::{ClientId, StageExt, StageStatus, StageStatusExt, Timestamp};
 
 // it's an exhaustive enum folks
 #[allow(clippy::too_many_lines)]
@@ -51,6 +51,7 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
                     stage: state.stage,
                     stage_status: StageStatus::Entered,
                     stage_attempt: state.stage_attempt,
+                    last_completed: None,
                 },
             );
         }
@@ -168,14 +169,21 @@ fn stage_reported(
     attempt: Option<u32>,
     update: StageProgress,
 ) {
+    let finished = update.status.is_finished();
+
     if let Some(client) = state.clients.get_mut(&client_id) {
         client.stage = update.stage;
         client.stage_status = update.status;
         client.stage_attempt = attempt;
         client.active = true;
+        if finished {
+            client.last_completed = Some(LastCompleted {
+                stage: update.stage,
+                attempt,
+            });
+        }
     }
 
-    let finished = update.status == StageStatus::Completed || update.status == StageStatus::Wiped;
     if finished && attempt == state.stage_attempt && state.stage_state == StageState::InProgress {
         state.stage_status = update.status;
         state.stage_state = StageState::Ending { since: at };
@@ -288,6 +296,8 @@ mod tests {
         );
         let client = &state.clients[&CLIENT];
         assert_eq!(client.stage_status, StageStatus::Started);
+        // Only a finished report records a completion.
+        assert_eq!(client.last_completed, None);
         // A client report alone does not start a stage.
         assert_eq!(state.stage_status, StageStatus::Entered);
         assert_eq!(state.stage_state, StageState::InProgress);
@@ -308,6 +318,13 @@ mod tests {
             }
         );
         assert_eq!(state.stage_status, StageStatus::Completed);
+        assert_eq!(
+            state.clients[&CLIENT].last_completed,
+            Some(LastCompleted {
+                stage: Stage::TobMaiden,
+                attempt: None,
+            }),
+        );
 
         // The window opens at the first finisher and stays put.
         apply(
@@ -506,6 +523,7 @@ mod tests {
                 stage: Stage::TobBloat,
                 stage_status: StageStatus::Entered,
                 stage_attempt: None,
+                last_completed: None,
             },
         );
         assert_eq!(state.dormant_since, None);

--- a/challenge-harder/src/lifecycle/core/deadline.rs
+++ b/challenge-harder/src/lifecycle/core/deadline.rs
@@ -135,6 +135,7 @@ mod tests {
             stage: Stage::TobMaiden,
             stage_status: StageStatus::Started,
             stage_attempt: None,
+            last_completed: None,
         };
 
         ChallengeState {

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -10,7 +10,7 @@ use super::event::LifecycleEvent;
 use super::state::{ChallengeState, ClientState, PhaseState, StageState};
 use super::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, RecordingType, Stage,
-    StageExt, StageStatus,
+    StageExt, StageStatus, StageStatusExt,
 };
 
 /// Produces a series of journal events from a received command, detailing the
@@ -34,10 +34,6 @@ pub fn decide(
         Command::DeadlineFired(d) => deadline_fired(state, config, *d),
         Command::StageProcessed(_) => todo!(),
     }
-}
-
-fn is_finished(status: StageStatus) -> bool {
-    status == StageStatus::Completed || status == StageStatus::Wiped
 }
 
 fn create(state: &ChallengeState, c: &Create) -> Vec<LifecycleEvent> {
@@ -125,7 +121,7 @@ fn update(state: &ChallengeState, update: &Update) -> Vec<LifecycleEvent> {
             // Seal the stage when every client has finished it.
             let finished = |stage: Stage, status: StageStatus, attempt: Option<u32>| {
                 stage > state.stage // TODO(frolv): handle toa
-                    || (is_finished(status) && attempt.max(state.stage_attempt) == attempt)
+                    || (status.is_finished() && attempt.max(state.stage_attempt) == attempt)
             };
             let all_finished = state.clients.iter().all(|(id, c)| {
                 if *id == update.client_id {
@@ -145,6 +141,18 @@ fn update(state: &ChallengeState, update: &Update) -> Vec<LifecycleEvent> {
         }
         StageStatus::Started => {
             if progress.stage != state.stage || state.stage_status == StageStatus::Entered {
+                if progress.stage != state.stage
+                    && state.stage_status != StageStatus::Entered
+                    && !matches!(state.stage_state, StageState::Complete { .. })
+                {
+                    // If a start for new stage arrives before the previous
+                    // stage is sealed, seal it immediately.
+                    events.push(LifecycleEvent::StageSealed {
+                        stage: state.stage,
+                        attempt: state.stage_attempt,
+                        forced: true,
+                    });
+                }
                 events.push(LifecycleEvent::StageStarted {
                     stage: progress.stage,
                 });
@@ -395,6 +403,7 @@ mod tests {
             stage,
             stage_status: status,
             stage_attempt: attempt,
+            last_completed: None,
         }
     }
 
@@ -509,11 +518,62 @@ mod tests {
     }
 
     #[test]
-    fn new_stage_start_advances_challenge() {
+    fn new_stage_start_seals_the_outgoing_stage_and_advances() {
         let state = tob_state(vec![(
             CLIENT_A,
             client(Stage::TobMaiden, StageStatus::Completed, None),
         )]);
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &stage_update(CLIENT_A, Stage::TobBloat, StageStatus::Started),
+            ),
+            vec![
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::StageStarted {
+                    stage: Stage::TobBloat,
+                },
+                report(CLIENT_A, Stage::TobBloat, StageStatus::Started),
+            ],
+        );
+    }
+
+    #[test]
+    fn new_stage_start_leaves_a_sealed_stage_alone() {
+        let mut state = tob_state(vec![(
+            CLIENT_A,
+            client(Stage::TobMaiden, StageStatus::Completed, None),
+        )]);
+        state.stage_state = StageState::Complete {
+            since: Timestamp::from_millis(1_000),
+        };
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &stage_update(CLIENT_A, Stage::TobBloat, StageStatus::Started),
+            ),
+            vec![
+                LifecycleEvent::StageStarted {
+                    stage: Stage::TobBloat,
+                },
+                report(CLIENT_A, Stage::TobBloat, StageStatus::Started),
+            ],
+        );
+    }
+
+    #[test]
+    fn advance_from_an_unstarted_stage_does_not_seal() {
+        let mut state = tob_state(vec![(
+            CLIENT_A,
+            client(Stage::TobMaiden, StageStatus::Entered, None),
+        )]);
+        state.stage_status = StageStatus::Entered;
         assert_eq!(
             decide(
                 &state,

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -97,6 +97,50 @@ pub struct ClientState {
     pub stage: Stage,
     pub stage_status: StageStatus,
     pub stage_attempt: Option<u32>,
+    pub last_completed: Option<LastCompleted>,
+}
+
+/// A client's latest completed stage and attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LastCompleted {
+    pub stage: Stage,
+    pub attempt: Option<u32>,
+}
+
+/// A client's state as published for external readers.
+/// Mirrors `ChallengeClient` in `//challenge-server/redis-client.ts`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishedClient {
+    pub user_id: UserId,
+    pub client_id: ClientId,
+    #[serde(rename = "type")]
+    pub recording_type: RecordingType,
+    pub active: bool,
+    pub stage: Stage,
+    pub stage_attempt: Option<u32>,
+    pub stage_status: StageStatus,
+    pub last_completed: LastCompleted,
+}
+
+impl PublishedClient {
+    #[must_use]
+    pub fn of(client_id: ClientId, client: &ClientState) -> Self {
+        Self {
+            user_id: client.user_id,
+            client_id,
+            recording_type: client.recording_type,
+            active: client.active,
+            stage: client.stage,
+            stage_attempt: client.stage_attempt,
+            stage_status: client.stage_status,
+            last_completed: client.last_completed.unwrap_or(LastCompleted {
+                stage: Stage::UnknownStage,
+                attempt: None,
+            }),
+        }
+    }
 }
 
 /// State published by a challenge for outside readers.

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -215,6 +215,19 @@ pub trait StageExt {
     fn later_stages(self) -> Vec<Stage>;
 }
 
+pub trait StageStatusExt {
+    // Implemented for the Copy enum StageStatus, which is always passed by value.
+    #[allow(clippy::wrong_self_convention)]
+    fn is_finished(self) -> bool;
+}
+
+impl StageStatusExt for StageStatus {
+    /// Whether the status indicates the stage is over.
+    fn is_finished(self) -> bool {
+        self == StageStatus::Completed || self == StageStatus::Wiped
+    }
+}
+
 impl StageExt for Stage {
     fn challenge_type(self) -> Option<ChallengeType> {
         match self as i32 {

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -32,7 +32,7 @@ use super::core::command::{
 };
 use super::core::deadline::LifecycleConfig;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
-use super::core::state::{ChallengePhase, ChallengeState, Snapshot};
+use super::core::state::{ChallengePhase, ChallengeState, PublishedClient, Snapshot};
 use super::core::types::{
     ChallengeMode, ChallengeType, ClientId, MsgId, RecordingType, ReportedTimes, SessionToken,
     Stage, StageExt, UserId, Uuid,
@@ -567,7 +567,11 @@ impl ChallengeClaim for CollectorClaim {
         Ok(())
     }
 
-    async fn project(&self, snapshot: &Snapshot) -> Result<(), StoreError> {
+    async fn project(
+        &self,
+        snapshot: &Snapshot,
+        _clients: &[PublishedClient],
+    ) -> Result<(), StoreError> {
         self.projections
             .lock()
             .expect("collector lock poisoned")

--- a/challenge-harder/src/lifecycle/sim/scenarios/stage_end.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/stage_end.rs
@@ -52,6 +52,59 @@ async fn all_reports_inside_window_seals_normally() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn advance_inside_the_window_seals_the_outgoing_stage() {
+    // The next stage starts while the straggler window is still open, so
+    // the advance itself seals rather than the expired window. The
+    // straggler's own completion lands after the advance and is ignored.
+    let result = run(Scenario {
+        clients: vec![
+            Client::participant("a", 1)
+                .at(0, tob_start())
+                .at(100, report(Stage::TobMaiden, StageStatus::Started))
+                .at(1_000, report(Stage::TobMaiden, StageStatus::Completed))
+                .at(2_000, report(Stage::TobBloat, StageStatus::Started)),
+            Client::participant("b", 2)
+                .at(0, tob_start())
+                .at(100, report(Stage::TobMaiden, StageStatus::Started))
+                .at(3_000, report(Stage::TobMaiden, StageStatus::Completed)),
+        ],
+        run_until: 4_500,
+    })
+    .await;
+
+    let (_, journal) = result.only_challenge();
+    assert_eq!(
+        journal[7..],
+        vec![
+            entry(
+                7,
+                2_000,
+                cmd(6),
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: true,
+                },
+            ),
+            entry(
+                8,
+                2_000,
+                cmd(6),
+                LifecycleEvent::StageStarted {
+                    stage: Stage::TobBloat,
+                },
+            ),
+            entry(
+                9,
+                2_000,
+                cmd(6),
+                reported(1, Stage::TobBloat, StageStatus::Started),
+            ),
+        ],
+    );
+}
+
+#[tokio::test(start_paused = true)]
 async fn window_expiry_forces_seal() {
     let result = run(Scenario {
         clients: vec![

--- a/challenge-harder/src/store/mod.rs
+++ b/challenge-harder/src/store/mod.rs
@@ -16,7 +16,7 @@ use crate::lifecycle::challenge::{
 };
 use crate::lifecycle::core::command::{Command, Create, Envelope, Join};
 use crate::lifecycle::core::event::JournalEntry;
-use crate::lifecycle::core::state::{ChallengePhase, ChallengeState, Snapshot};
+use crate::lifecycle::core::state::{ChallengePhase, ChallengeState, PublishedClient, Snapshot};
 use crate::lifecycle::core::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ClientId, Epoch, MsgId, Stage, StageExt, Uuid,
 };
@@ -74,6 +74,12 @@ const CHALLENGE_KEY_PREFIX: &str = "challenge:";
 /// The challenge's projected state.
 fn challenge_key(uuid: Uuid) -> String {
     format!("{CHALLENGE_KEY_PREFIX}{uuid}")
+}
+
+/// The challenge's published clients.
+/// Matches `challengeClientsKey` in `//common/db/redis.ts`.
+fn clients_key(uuid: Uuid) -> String {
+    format!("{CHALLENGE_KEY_PREFIX}{uuid}:clients")
 }
 
 /// Which challenge a party is recording.
@@ -186,6 +192,7 @@ impl Store {
             journal_key: journal_key(uuid),
             lease_key: lease_key(uuid),
             challenge_key: challenge_key(uuid),
+            clients_key: clients_key(uuid),
             epoch,
             client: self.client.clone(),
             connection: self.connection.clone(),
@@ -207,7 +214,7 @@ fn parse_snapshot(uuid: Uuid, hash: &HashMap<String, String>) -> Result<Snapshot
             .map_err(|e| format!("invalid {name}: {e}"))
     }
 
-    let attempt = field(hash, "stageAttempt")?;
+    let attempt = hash.get("stageAttempt").map_or("", String::as_str);
     let party = field(hash, "party")?;
     let tag = field(hash, "phase")?;
     let phase = ChallengePhase::from_tag(tag).ok_or_else(|| format!("invalid phase: {tag}"))?;
@@ -471,6 +478,7 @@ struct RedisClaim {
     journal_key: String,
     lease_key: String,
     challenge_key: String,
+    clients_key: String,
     epoch: Epoch,
     client: redis::Client,
     connection: ConnectionManager,
@@ -529,40 +537,47 @@ impl ChallengeClaim for RedisClaim {
         }
     }
 
-    async fn project(&self, snapshot: &Snapshot) -> Result<(), StoreError> {
+    async fn project(
+        &self,
+        snapshot: &Snapshot,
+        clients: &[PublishedClient],
+    ) -> Result<(), StoreError> {
         let signal = serde_json::to_string(&ChallengeSignal::Updated {
             uuid: snapshot.uuid,
             cursor: snapshot.cursor,
         })
         .expect("signal serializes");
-        // The hash contract encodes a null stageAttempt as an empty string.
-        let attempt = snapshot
-            .stage_attempt
-            .map_or_else(String::new, |attempt| attempt.to_string());
-        let mut connection = self.connection.clone();
 
+        let mut state_pairs: Vec<(&str, String)> = vec![
+            ("type", (snapshot.challenge_type as i32).to_string()),
+            ("mode", (snapshot.mode as i32).to_string()),
+            ("status", (snapshot.status as u8).to_string()),
+            ("stage", (snapshot.stage as i32).to_string()),
+            ("party", snapshot.party.join(",")),
+            ("phase", snapshot.phase.tag().to_string()),
+            ("cursor", snapshot.cursor.to_string()),
+        ];
+        if let Some(attempt) = snapshot.stage_attempt {
+            state_pairs.push(("stageAttempt", attempt.to_string()));
+        }
+
+        let mut connection = self.connection.clone();
         let mut invocation = PROJECT_SCRIPT.prepare_invoke();
         invocation
             .key(&self.challenge_key)
             .key(&self.lease_key)
+            .key(&self.clients_key)
             .arg(self.epoch.0)
             .arg(signal)
-            .arg("type")
-            .arg(snapshot.challenge_type as i32)
-            .arg("mode")
-            .arg(snapshot.mode as i32)
-            .arg("status")
-            .arg(snapshot.status as u8)
-            .arg("stage")
-            .arg(snapshot.stage as i32)
-            .arg("stageAttempt")
-            .arg(attempt)
-            .arg("party")
-            .arg(snapshot.party.join(","))
-            .arg("phase")
-            .arg(snapshot.phase.tag())
-            .arg("cursor")
-            .arg(snapshot.cursor.to_string());
+            .arg(state_pairs.len() * 2);
+        for (field, value) in &state_pairs {
+            invocation.arg(*field).arg(value);
+        }
+        for client in clients {
+            invocation
+                .arg(client.client_id.0)
+                .arg(serde_json::to_string(client).expect("client serializes"));
+        }
 
         let accepted: i64 = invocation
             .invoke_async(&mut connection)
@@ -655,6 +670,7 @@ impl ChallengeClaim for RedisClaim {
             .key(&self.journal_key)
             .key(inbox_key(self.uuid))
             .key(streams_set_key(self.uuid))
+            .key(&self.clients_key)
             .key(directory_key(&party_key(
                 state.challenge_type,
                 &state.party,

--- a/challenge-harder/src/store/scripts.rs
+++ b/challenge-harder/src/store/scripts.rs
@@ -142,17 +142,24 @@ pub(super) static APPEND_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
     )
 });
 
-/// Writes the challenge's state hash and signals the update, provided
-/// the writer's epoch still holds the challenge's fence.
+/// Writes the challenge's state and clients hashes and signals the update,
+/// provided the writer's epoch still holds the challenge's fence.
+///
+/// `stageAttempt` is cleared before the pairs apply, as it is present in the
+/// state hash only while the challenge's stage tracks attempts. The clients
+/// hash is rewritten whole so departed clients disappear.
 ///
 /// ## Arguments
 ///
 /// - `KEYS[1]` = Challenge's state hash
 /// - `KEYS[2]` = Challenge's lease hash
+/// - `KEYS[3]` = Challenge's clients hash
 ///
 /// - `ARGV[1]` = Lease epoch
 /// - `ARGV[2]` = Serialized update signal
-/// - `ARGV[3..]` = Key-value pairs to set in the state hash
+/// - `ARGV[3]` = Number of state hash key-value arguments `n`
+/// - `ARGV[4..3+n]` = Key-value pairs to set in the state hash
+/// - `ARGV[4+n..]` = Key-value pairs to set in the clients hash
 ///
 /// ## Return value
 ///
@@ -164,7 +171,13 @@ pub(super) static PROJECT_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
         if redis.call('HGET', KEYS[2], 'fence') ~= ARGV[1] then
             return 0
         end
-        redis.call('HSET', KEYS[1], unpack(ARGV, 3))
+        local n = tonumber(ARGV[3])
+        redis.call('HDEL', KEYS[1], 'stageAttempt')
+        redis.call('HSET', KEYS[1], unpack(ARGV, 4, 3 + n))
+        redis.call('DEL', KEYS[3])
+        if #ARGV > 3 + n then
+            redis.call('HSET', KEYS[3], unpack(ARGV, 4 + n))
+        end
         redis.call('PUBLISH', '{SIGNAL_CHANNEL}', ARGV[2])
         return 1
         ",
@@ -273,8 +286,9 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
 /// successor may have overwritten them. Stage event streams are swept through
 /// the challenge's stream set. The journal and inbox are not deleted but left
 /// to expire, so that recently ended challenges can be inspected. The state
-/// hash is also left to expire, briefly, so that response waiters racing the
-/// deletion can still read the state their commands produced.
+/// and clients hashes are also left to expire, briefly, so that response
+/// waiters racing the deletion can still read the state their commands
+/// produced.
 ///
 /// ## Arguments
 ///
@@ -284,7 +298,8 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
 /// - `KEYS[4]` = Challenge's journal stream
 /// - `KEYS[5]` = Challenge's inbox stream
 /// - `KEYS[6]` = Challenge's stage streams set
-/// - `KEYS[7..]` = The challenge's routing keys (directory, client, and player)
+/// - `KEYS[7]` = Challenge's clients hash
+/// - `KEYS[8..]` = The challenge's routing keys (directory, client, and player)
 ///
 /// - `ARGV[1]` = Lease epoch
 /// - `ARGV[2]` = Challenge uuid
@@ -303,7 +318,8 @@ pub(super) static DELETE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
             return 0
         end
         redis.call('EXPIRE', KEYS[3], ARGV[5])
-        for i = 7, #KEYS do
+        redis.call('EXPIRE', KEYS[7], ARGV[5])
+        for i = 8, #KEYS do
             if redis.call('GET', KEYS[i]) == ARGV[2] then
                 redis.call('DEL', KEYS[i])
             end

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -12,10 +12,10 @@ use redis::AsyncCommands;
 use super::*;
 use crate::lifecycle::core::command::{Finish, Update};
 use crate::lifecycle::core::event::{Cause, LifecycleEvent};
-use crate::lifecycle::core::state::{ChallengePhase, PhaseState};
+use crate::lifecycle::core::state::{ChallengePhase, LastCompleted, PhaseState};
 use crate::lifecycle::core::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId, RecordingType,
-    Stage, Timestamp, UserId,
+    Stage, StageStatus, Timestamp, UserId,
 };
 
 /// Returns a unique client ID on every call. Tests share a Redis instance and
@@ -593,7 +593,7 @@ async fn projection_writes_hash_and_signals() {
     let mut messages = pubsub.on_message();
 
     claim
-        .project(&snapshot(uuid, 4))
+        .project(&snapshot(uuid, 4), &[])
         .await
         .expect("project should succeed");
     assert_eq!(store.read(uuid).await, Ok(Some(snapshot(uuid, 4))));
@@ -605,7 +605,6 @@ async fn projection_writes_hash_and_signals() {
         ("mode", "11"),
         ("status", "0"),
         ("stage", "10"),
-        ("stageAttempt", ""),
         ("party", "1Ogp,WWWWWWWWWWQQ"),
         ("phase", "ACTIVE"),
         ("cursor", "0-4"),
@@ -631,19 +630,62 @@ async fn projection_writes_hash_and_signals() {
     };
     assert_eq!(cursor, MsgId::sequence(4));
 
-    // A later projection overwrites the previous snapshot.
+    // A later projection overwrites the previous snapshot and publishes
+    // the challenge's clients.
     let updated = Snapshot {
         stage_attempt: Some(3),
         ..snapshot(uuid, 5)
     };
+    let client = PublishedClient {
+        user_id: UserId(435),
+        client_id: ClientId(286),
+        recording_type: RecordingType::Participant,
+        active: true,
+        stage: Stage::TobMaiden,
+        stage_attempt: Some(3),
+        stage_status: StageStatus::Completed,
+        last_completed: LastCompleted {
+            stage: Stage::TobMaiden,
+            attempt: Some(2),
+        },
+    };
     claim
-        .project(&updated)
+        .project(&updated, std::slice::from_ref(&client))
         .await
         .expect("project should succeed");
     let hash: BTreeMap<String, String> = connection.hgetall(challenge_key(uuid)).await.unwrap();
     assert_eq!(hash["stageAttempt"], "3");
     assert_eq!(hash["cursor"], "0-5");
     assert_eq!(store.read(uuid).await, Ok(Some(updated)));
+
+    // The clients hash holds the wire form the old contract's readers parse.
+    let clients: BTreeMap<String, String> = connection.hgetall(clients_key(uuid)).await.unwrap();
+    assert_eq!(
+        clients,
+        [(
+            "286".to_string(),
+            concat!(
+                r#"{"userId":435,"clientId":286,"type":1,"active":true,"#,
+                r#""stage":10,"stageAttempt":3,"stageStatus":2,"#,
+                r#""lastCompleted":{"stage":10,"attempt":2}}"#,
+            )
+            .to_string(),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    // Moving to a stage without attempt tracking removes the field, and a
+    // projection without clients removes the clients hash.
+    claim
+        .project(&snapshot(uuid, 6), &[])
+        .await
+        .expect("project should succeed");
+    let hash: BTreeMap<String, String> = connection.hgetall(challenge_key(uuid)).await.unwrap();
+    assert!(!hash.contains_key("stageAttempt"), "{hash:?}");
+    assert_eq!(store.read(uuid).await, Ok(Some(snapshot(uuid, 6))));
+    let clients: bool = connection.exists(clients_key(uuid)).await.unwrap();
+    assert!(!clients);
 
     clean_up(&store, uuid).await;
 }
@@ -667,7 +709,7 @@ async fn subscriber_delivers_update_signals() {
         cursor += 1;
         assert!(cursor < 10, "no signal after {cursor} projections");
         claim
-            .project(&snapshot(uuid, cursor))
+            .project(&snapshot(uuid, cursor), &[])
             .await
             .expect("project should succeed");
         let deadline = tokio::time::Instant::now() + Duration::from_millis(250);
@@ -699,7 +741,7 @@ async fn bumped_fence_rejects_projection() {
     let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
 
     assert_eq!(
-        claim.project(&snapshot(uuid, 1)).await,
+        claim.project(&snapshot(uuid, 1), &[]).await,
         Err(StoreError::Fenced),
     );
     let exists: bool = connection.exists(challenge_key(uuid)).await.unwrap();
@@ -969,7 +1011,7 @@ async fn start_creates_and_claims_a_challenge_for_a_free_party() {
 
     // The returned claim holds the fence, so its writes land immediately.
     claim
-        .project(&snapshot(uuid, 1))
+        .project(&snapshot(uuid, 1), &[])
         .await
         .expect("claim should hold the fence");
     assert_eq!(store.read(uuid).await, Ok(Some(snapshot(uuid, 1))));
@@ -995,7 +1037,7 @@ async fn start_joins_a_live_incumbent() {
     };
     let uuid = claim.uuid();
     claim
-        .project(&snapshot(uuid, 1))
+        .project(&snapshot(uuid, 1), &[])
         .await
         .expect("project should succeed");
 
@@ -1104,7 +1146,7 @@ async fn start_at_an_earlier_stage_creates_a_new_challenge() {
         ..snapshot(first, 1)
     };
     claim
-        .project(&progressed)
+        .project(&progressed, &[])
         .await
         .expect("project should succeed");
 
@@ -1170,7 +1212,7 @@ async fn start_joins_a_challenge_at_the_same_stage() {
         ..snapshot(first, 1)
     };
     claim
-        .project(&progressed)
+        .project(&progressed, &[])
         .await
         .expect("project should succeed");
 
@@ -1202,7 +1244,7 @@ async fn start_joins_a_challenge_from_a_later_stage() {
     };
     let first = claim.uuid();
     claim
-        .project(&snapshot(first, 1))
+        .project(&snapshot(first, 1), &[])
         .await
         .expect("project should succeed");
 
@@ -1239,7 +1281,7 @@ async fn start_supersedes_a_finished_incumbent() {
         ..snapshot(first, 2)
     };
     claim
-        .project(&terminated)
+        .project(&terminated, &[])
         .await
         .expect("project should succeed");
 
@@ -1295,7 +1337,7 @@ async fn start_supersedes_a_finishing_incumbent() {
         ..snapshot(first, 2)
     };
     claim
-        .project(&finishing)
+        .project(&finishing, &[])
         .await
         .expect("project should succeed");
 
@@ -1412,7 +1454,7 @@ async fn client_send_to_a_terminated_challenge_is_rejected() {
         ..snapshot(uuid, 2)
     };
     claim
-        .project(&terminated)
+        .project(&terminated, &[])
         .await
         .expect("project should succeed");
 
@@ -1463,7 +1505,7 @@ async fn rejoin_routes_and_enqueues_for_a_live_challenge() {
     };
     let uuid = claim.uuid();
     claim
-        .project(&snapshot(uuid, 1))
+        .project(&snapshot(uuid, 1), &[])
         .await
         .expect("project should succeed");
 
@@ -1542,7 +1584,7 @@ async fn rejoin_of_a_terminated_challenge_is_rejected() {
         ..snapshot(uuid, 2)
     };
     claim
-        .project(&terminated)
+        .project(&terminated, &[])
         .await
         .expect("project should succeed");
 
@@ -1684,7 +1726,7 @@ async fn delete_removes_a_terminated_challenges_state() {
         .await
         .expect("append should succeed");
     claim
-        .project(&snapshot(uuid, 1))
+        .project(&snapshot(uuid, 1), &[])
         .await
         .expect("project should succeed");
 
@@ -1830,7 +1872,7 @@ async fn bumped_fence_rejects_deletion() {
     };
     let uuid = claim.uuid();
     claim
-        .project(&snapshot(uuid, 1))
+        .project(&snapshot(uuid, 1), &[])
         .await
         .expect("project should succeed");
 

--- a/challenge-harder/tests/replay.rs
+++ b/challenge-harder/tests/replay.rs
@@ -1,0 +1,215 @@
+//! End-to-end smoke of the replay engine, driving the built binary through
+//! boot, a played window, and drain. Requires `BLERT_TEST_REDIS_URI`.
+
+use std::process::Command;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// Serializes the replay tests as they share a Redis instance.
+fn lock() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// A minimal, whole challenge.
+const WINDOW: &str = concat!(
+    r#"{"ts":1000,"op":"start","host":"sock-a","challengeUuid":"11111111-1111-1111-1111-111111111111","clientId":10,"userId":20,"request":{"userId":20,"clientId":10,"sessionToken":"tok-smoke","pluginVersion":"0.0.0","runeLiteVersion":"0.0.0","type":1,"mode":11,"party":["Skitter"],"stage":12,"recordingType":0},"http":{"ok":true,"statusCode":200,"response":{"uuid":"11111111-1111-1111-1111-111111111111","mode":11,"stage":12,"stageAttempt":null}}}"#,
+    "\n",
+    r#"{"ts":1500,"op":"update","host":"sock-a","challengeUuid":"11111111-1111-1111-1111-111111111111","clientId":10,"userId":20,"request":{"userId":20,"clientId":10,"sessionToken":"tok-smoke","update":{"stage":{"stage":12,"status":1}}},"http":{"ok":true,"statusCode":200,"response":{"uuid":"11111111-1111-1111-1111-111111111111","mode":11,"stage":12,"stageAttempt":null}}}"#,
+    "\n",
+    r#"{"ts":2500,"op":"finish","host":"sock-a","challengeUuid":"11111111-1111-1111-1111-111111111111","clientId":10,"userId":20,"request":{"userId":20,"clientId":10,"sessionToken":"tok-smoke","times":null,"soft":true},"http":{"ok":true,"statusCode":200,"response":null}}"#,
+    "\n",
+    r#"{"ts":3000,"op":"server-update","host":"sock-a","challengeUuid":"11111111-1111-1111-1111-111111111111","clientId":null,"userId":null,"request":{"id":"11111111-1111-1111-1111-111111111111","action":"FINISH"},"http":null}"#,
+    "\n",
+);
+
+#[test]
+fn replay_plays_a_window_end_to_end() {
+    let Ok(redis) = std::env::var("BLERT_TEST_REDIS_URI") else {
+        eprintln!("BLERT_TEST_REDIS_URI is not set; skipping replay smoke");
+        return;
+    };
+    let _lock = lock();
+
+    let scratch = std::env::temp_dir().join(format!("blert-replay-smoke-{}", std::process::id()));
+    std::fs::create_dir_all(&scratch).expect("scratch dir");
+    let window = scratch.join("window.jsonl");
+    std::fs::write(&window, WINDOW).expect("window fixture");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_challenge-harder"))
+        .args(["shadow", "replay"])
+        .arg(&window)
+        .args(["--redis", &redis, "--time-scale", "20", "--out"])
+        .arg(&scratch)
+        .output()
+        .expect("driver runs");
+
+    assert!(
+        output.status.success(),
+        "driver failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let run_dir = std::fs::read_dir(&scratch)
+        .expect("scratch dir listing")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.is_dir())
+        .expect("run directory created");
+
+    // Every command was accepted by the server, with the challenge mapped.
+    let commands =
+        std::fs::read_to_string(run_dir.join("commands.jsonl")).expect("commands written");
+    let lines: Vec<serde_json::Value> = commands
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("command line parses"))
+        .collect();
+    assert_eq!(lines.len(), 3, "{commands}");
+    for line in &lines {
+        assert_eq!(line["status"], 200, "{line}");
+    }
+    assert_eq!(lines[0]["op"], "start", "{commands}");
+    assert_eq!(lines[0]["mapping"], "new", "{commands}");
+    assert_eq!(lines[1]["mapping"], "match", "{commands}");
+
+    let remap: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(run_dir.join("remap.json")).expect("remap written"),
+    )
+    .expect("remap parses");
+    let replayed = remap["11111111-1111-1111-1111-111111111111"]
+        .as_str()
+        .expect("challenge was mapped");
+    assert_eq!(lines[0]["response"]["uuid"], replayed, "{remap}");
+
+    // The FINISH announcement arrived on the async channel after the finish
+    // command was accepted.
+    let pubsub = std::fs::read_to_string(run_dir.join("pubsub.jsonl")).expect("pubsub written");
+    let announcements: Vec<serde_json::Value> = pubsub
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("announcement line parses"))
+        .collect();
+    assert_eq!(announcements.len(), 1, "{pubsub}");
+    assert_eq!(announcements[0]["payload"]["action"], "FINISH", "{pubsub}");
+    assert_eq!(announcements[0]["payload"]["id"], replayed, "{pubsub}");
+    assert!(
+        announcements[0]["offsetMs"].as_f64() >= lines[2]["sentMs"].as_f64(),
+        "{pubsub}",
+    );
+
+    let journal =
+        std::fs::read_to_string(run_dir.join("journals").join(format!("{replayed}.jsonl")))
+            .expect("journal dumped");
+    for line in journal.lines() {
+        let _: serde_json::Value = serde_json::from_str(line).expect("journal entry parses");
+    }
+    assert!(journal.contains("ChallengeCreated"), "{journal}");
+    assert!(journal.contains("ChallengeTerminated"), "{journal}");
+
+    let summary = std::fs::read_to_string(run_dir.join("summary.json")).expect("summary written");
+    assert!(summary.contains(r#""commands": 3"#), "{summary}");
+    assert!(summary.contains(r#""incomplete": []"#), "{summary}");
+    assert!(summary.contains(r#""gracefulShutdown": true"#), "{summary}");
+
+    let log = std::fs::read_to_string(run_dir.join("server.log")).expect("server log written");
+    assert!(log.contains("challenge_server_listening"), "{log}");
+
+    // The differ reads the run back and finds nothing to report.
+    let diff = Command::new(env!("CARGO_BIN_EXE_challenge-harder"))
+        .args(["shadow", "diff"])
+        .arg(&window)
+        .arg(&run_dir)
+        .output()
+        .expect("differ runs");
+    let stdout = String::from_utf8_lossy(&diff.stdout);
+    assert!(
+        diff.status.success(),
+        "differ failed\nstdout: {stdout}\nstderr: {}",
+        String::from_utf8_lossy(&diff.stderr),
+    );
+    assert!(stdout.contains("DIVERGENCES\n  (none)"), "{stdout}");
+    assert!(stdout.contains("finished 1 (100%)"), "{stdout}");
+    let divergences =
+        std::fs::read_to_string(run_dir.join("divergences.jsonl")).expect("divergences written");
+    assert_eq!(divergences, "", "{divergences}");
+
+    std::fs::remove_dir_all(&scratch).ok();
+}
+
+/// A challenge whose only client disconnects. Its reconnected socket then
+/// sends a finish under a fresh session token without rejoining;
+/// the challenge ends through the reconnection window.
+const DISCONNECT_WINDOW: &str = concat!(
+    r#"{"ts":1000,"op":"start","host":"sock-a","challengeUuid":"22222222-2222-2222-2222-222222222222","clientId":11,"userId":21,"request":{"userId":21,"clientId":11,"sessionToken":"tok-gone","pluginVersion":"0.0.0","runeLiteVersion":"0.0.0","type":1,"mode":11,"party":["Skitter"],"stage":12,"recordingType":0},"http":{"ok":true,"statusCode":200,"response":{"uuid":"22222222-2222-2222-2222-222222222222"}}}"#,
+    "\n",
+    r#"{"ts":2000,"op":"status","host":"sock-a","challengeUuid":"22222222-2222-2222-2222-222222222222","clientId":11,"userId":21,"request":{"type":0,"userId":21,"clientId":11,"sessionToken":"tok-gone","status":2},"http":null}"#,
+    "\n",
+    r#"{"ts":2500,"op":"finish","host":"sock-a","challengeUuid":"22222222-2222-2222-2222-222222222222","clientId":11,"userId":21,"request":{"userId":21,"clientId":11,"sessionToken":"tok-back","times":null,"soft":true},"http":{"ok":true,"statusCode":200,"response":null}}"#,
+    "\n",
+    r#"{"ts":3000,"op":"server-update","host":"sock-a","challengeUuid":"22222222-2222-2222-2222-222222222222","clientId":null,"userId":null,"request":{"id":"22222222-2222-2222-2222-222222222222","action":"FINISH"},"http":null}"#,
+    "\n",
+);
+
+#[test]
+fn replay_waits_out_a_disconnect_ended_challenge() {
+    let Ok(redis) = std::env::var("BLERT_TEST_REDIS_URI") else {
+        eprintln!("BLERT_TEST_REDIS_URI is not set; skipping replay smoke");
+        return;
+    };
+    let _lock = lock();
+
+    let scratch =
+        std::env::temp_dir().join(format!("blert-replay-disconnect-{}", std::process::id(),));
+    std::fs::create_dir_all(&scratch).expect("scratch dir");
+    let window = scratch.join("window.jsonl");
+    std::fs::write(&window, DISCONNECT_WINDOW).expect("window fixture");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_challenge-harder"))
+        .args(["shadow", "replay"])
+        .arg(&window)
+        .args(["--redis", &redis, "--time-scale", "20", "--out"])
+        .arg(&scratch)
+        .output()
+        .expect("driver runs");
+
+    assert!(
+        output.status.success(),
+        "driver failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let run_dir = std::fs::read_dir(&scratch)
+        .expect("scratch dir listing")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.is_dir())
+        .expect("run directory created");
+
+    let summary = std::fs::read_to_string(run_dir.join("summary.json")).expect("summary written");
+    assert!(summary.contains(r#""incomplete": []"#), "{summary}");
+    assert!(summary.contains(r#""gracefulShutdown": true"#), "{summary}");
+
+    // The finish was accepted and ignored.
+    let commands =
+        std::fs::read_to_string(run_dir.join("commands.jsonl")).expect("commands written");
+    let lines: Vec<serde_json::Value> = commands
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("command line parses"))
+        .collect();
+    assert_eq!(lines.len(), 3, "{commands}");
+    for line in &lines {
+        assert_eq!(line["status"], 200, "{line}");
+    }
+    let log = std::fs::read_to_string(run_dir.join("server.log")).expect("server log written");
+    assert!(!log.contains("panicked"), "{log}");
+
+    let pubsub = std::fs::read_to_string(run_dir.join("pubsub.jsonl")).expect("pubsub written");
+    let announcements: Vec<serde_json::Value> = pubsub
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("announcement line parses"))
+        .collect();
+    assert_eq!(announcements.len(), 1, "{pubsub}");
+    assert_eq!(announcements[0]["payload"]["action"], "FINISH", "{pubsub}");
+
+    std::fs::remove_dir_all(&scratch).ok();
+}


### PR DESCRIPTION
Writes a hash of all clients to redis with every state projection, as consumed by the live server.