### PR TITLE
2c2s: Define data processing infrastructure

### DIFF
--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -2,18 +2,24 @@
 
 use core::future::Future;
 use core::time::Duration;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
 
 use super::core::apply::apply;
-use super::core::command::{Command, Create, Envelope, Join};
+use super::core::command::{Command, Create, Envelope, Join, Processed};
 use super::core::deadline::{LifecycleConfig, next_deadline};
 use super::core::decide::decide;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
-use super::core::state::{ChallengeState, LastCompleted, PhaseState, PublishedClient, Snapshot};
+use super::core::state::{
+    ChallengeState, LastCompleted, PhaseState, Processing, ProcessingState, PublishedClient,
+    Snapshot,
+};
 use super::core::types::{ClientId, JournalSeq, MsgId, Timestamp, Uuid};
+use crate::processing::{ProcessingRequest, StageProcessor};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum StoreError {
@@ -192,14 +198,23 @@ pub trait ChallengeClaim: Send + Sync + 'static {
 /// Capacity of the channel between a challenge's inbox feed and its actor task.
 const INBOX_BUFFER_LEN: usize = 32;
 
+/// Capacity of the Chanel, carrying processing run reports back to the actor.
+const CHANEL_BUFFER_LEN: usize = 4;
+
 /// Runs a claimed challenge until it terminates, then deletes its state.
 /// Challenges are initialized from their existing journal state, if it exists,
 /// continuing from where they left off.
 /// When `shutdown` flips true, the challenge releases its lease and exits.
-pub async fn run_challenge(config: LifecycleConfig, claim: Claim, shutdown: watch::Receiver<bool>) {
+pub async fn run_challenge(
+    config: LifecycleConfig,
+    claim: Claim,
+    processor: Option<Arc<dyn StageProcessor>>,
+    shutdown: watch::Receiver<bool>,
+) {
     let uuid = claim.uuid();
     let mut state = ChallengeState {
         uuid,
+        processing: Processing::new(config.processing.clone()),
         ..ChallengeState::default()
     };
     let mut next_seq = 0;
@@ -219,7 +234,7 @@ pub async fn run_challenge(config: LifecycleConfig, claim: Claim, shutdown: watc
             // The data issue must be resolved manually by either deleting the
             // bad journal or updating the server to understand it.
             tracing::error!(%uuid, reason, "journal_corrupt");
-            ActiveChallenge::new(config, claim, state, next_seq)
+            ActiveChallenge::new(config, claim, state, next_seq, processor)
                 .quarantine(shutdown)
                 .await;
             return;
@@ -230,7 +245,7 @@ pub async fn run_challenge(config: LifecycleConfig, claim: Claim, shutdown: watc
         }
     }
 
-    let mut challenge = ActiveChallenge::new(config, claim, state, next_seq);
+    let mut challenge = ActiveChallenge::new(config, claim, state, next_seq, processor);
     challenge.run(resumed_at, shutdown).await;
 }
 
@@ -263,6 +278,19 @@ pub struct ActiveChallenge {
     config: LifecycleConfig,
     claim: Claim,
     next_seq: u64,
+    processor: Option<Arc<dyn StageProcessor>>,
+}
+
+/// A challenge data processing task which is aborted when dropped.
+struct ProcessingTask {
+    trigger: JournalSeq,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for ProcessingTask {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
 }
 
 impl ActiveChallenge {
@@ -272,22 +300,26 @@ impl ActiveChallenge {
         claim: Claim,
         state: ChallengeState,
         next_seq: u64,
+        processor: Option<Arc<dyn StageProcessor>>,
     ) -> Self {
         ActiveChallenge {
             state,
             config,
             claim,
             next_seq,
+            processor,
         }
     }
 
     /// Serially applies inbox commands and their implied deadline timers until
-    /// the challenge terminates, publishing a fresh state snapshot after each.
-    /// Deletes the challenge's state at the end if it terminates.
+    /// the challenge terminates and finishing processing data, publishing a new
+    /// state snapshot after each. Deletes the challenge's state at the end if
+    /// it terminates.
     /// `resumed_at` is the time of the last journal entry in the challenge's
     /// clock, to continue timestamps from it.
+    #[allow(clippy::too_many_lines)]
     pub async fn run(&mut self, resumed_at: Timestamp, mut shutdown: watch::Receiver<bool>) {
-        if let PhaseState::Terminated { .. } = self.state.phase {
+        if self.state.terminated() && self.state.processing.settled() {
             // A previous task stopped between its terminal entry and deletion.
             self.conclude().await;
             return;
@@ -306,6 +338,17 @@ impl ActiveChallenge {
 
         let (tx, mut inbox) = mpsc::channel(INBOX_BUFFER_LEN);
         self.claim.follow(self.state.cursor, tx);
+
+        let (chanel_tx, mut chanel) = mpsc::channel(CHANEL_BUFFER_LEN);
+
+        // Respawn any run the journal shows started but never finished.
+        // The task is held purely for drop semantics.
+        let mut _run_task = match self.state.processing.active() {
+            Some(run) if matches!(run.state, ProcessingState::Running { .. }) => {
+                self.spawn_processing_run(chanel_tx.clone())
+            }
+            _ => None,
+        };
 
         let started = tokio::time::Instant::now();
         let base = resumed_at.as_millis();
@@ -328,7 +371,16 @@ impl ActiveChallenge {
                     self.release_lease().await;
                     return;
                 }
-                envelope = inbox.recv() => envelope.map(|e| (Cause::Command(e.id), e.cmd)),
+                envelope = inbox.recv() => {
+                    match envelope {
+                        Some(e) => Some((Cause::Command(e.id), e.cmd)),
+                        None => break,
+                    }
+                }
+                report = chanel.recv() => {
+                    let report = report.expect("the Chanel never closes");
+                    Some((Cause::Processing(report.trigger), Command::Processed(report)))
+                }
                 () = tokio::time::sleep_until(wake_at), if deadline.is_some() => {
                     deadline.map(|d| (Cause::Deadline(d.kind), Command::DeadlineFired(d)))
                 }
@@ -376,7 +428,35 @@ impl ActiveChallenge {
                         event = ?entry.event,
                         "journal_entry",
                     );
+                    let starts_run =
+                        matches!(entry.event, LifecycleEvent::ProcessingStarted { .. });
+                    let ends_run = match entry.event {
+                        LifecycleEvent::ProcessingFinished { .. } => true,
+                        LifecycleEvent::ProcessingFailed { trigger, ref error } => {
+                            tracing::error!(
+                                uuid = %self.state.uuid,
+                                trigger = trigger.0,
+                                error = %error.message,
+                                "processing_failed",
+                            );
+                            true
+                        }
+                        LifecycleEvent::ProcessingTimedOut { trigger } => {
+                            tracing::warn!(
+                                uuid = %self.state.uuid,
+                                trigger = trigger.0,
+                                "processing_timed_out",
+                            );
+                            true
+                        }
+                        _ => false,
+                    };
                     apply(&mut self.state, entry);
+                    if starts_run {
+                        _run_task = self.spawn_processing_run(chanel_tx.clone());
+                    } else if ends_run {
+                        _run_task = None;
+                    }
                 }
             }
 
@@ -390,7 +470,7 @@ impl ActiveChallenge {
                 return;
             }
 
-            if let PhaseState::Terminated { .. } = self.state.phase {
+            if self.state.terminated() && self.state.processing.settled() {
                 self.conclude().await;
                 break;
             }
@@ -473,6 +553,29 @@ impl ActiveChallenge {
 
     async fn append(&self, batch: &[JournalEntry]) -> Result<(), StoreError> {
         with_retries(self.state.uuid, || self.claim.append(batch)).await
+    }
+
+    fn spawn_processing_run(&self, chanel: mpsc::Sender<Processed>) -> Option<ProcessingTask> {
+        let processor = Arc::clone(self.processor.as_ref()?);
+        let run = self.state.processing.active()?;
+        let attempt = run.attempts;
+        let request = ProcessingRequest {
+            uuid: self.state.uuid,
+            trigger: run.trigger,
+        };
+        Some(ProcessingTask {
+            trigger: request.trigger.seq(),
+            handle: tokio::spawn(async move {
+                let result = processor.process(request).await;
+                let _ = chanel
+                    .send(Processed {
+                        trigger: request.trigger.seq(),
+                        attempt,
+                        result,
+                    })
+                    .await;
+            }),
+        })
     }
 }
 
@@ -659,7 +762,7 @@ mod tests {
             }),
         );
         let (_tx, rx) = watch::channel(false);
-        run_challenge(LifecycleConfig::default(), claim, rx).await;
+        run_challenge(LifecycleConfig::default(), claim, None, rx).await;
 
         RunOutcome { log, uuid }
     }
@@ -814,10 +917,7 @@ mod tests {
                     seq: JournalSeq(3),
                     at: Timestamp::ZERO,
                     caused_by: Cause::Command(MsgId::sequence(2)),
-                    event: LifecycleEvent::ChallengeTerminated {
-                        status: ChallengeStatus::Reset,
-                        empty: false,
-                    },
+                    event: LifecycleEvent::ChallengeTerminated { empty: false },
                 },
             ],
         );
@@ -828,9 +928,7 @@ mod tests {
             mode: ChallengeMode::TobRegular,
             party: vec!["a".into()],
             party_changed: false,
-            phase: PhaseState::Terminated {
-                status: ChallengeStatus::Reset,
-            },
+            phase: PhaseState::Terminated,
             reported_times: None,
             stage: Stage::TobMaiden,
             stage_attempt: None,
@@ -839,6 +937,7 @@ mod tests {
             clients: BTreeMap::new(),
             recorded_by: [ClientId(10)].into(),
             dormant_since: Some(Timestamp::ZERO),
+            processing: Processing::default(),
             cursor: MsgId::sequence(2),
         };
         assert_eq!(*outcome.log.deleted.lock().unwrap(), vec![expected]);
@@ -941,10 +1040,7 @@ mod tests {
             3,
             500,
             2,
-            LifecycleEvent::ChallengeTerminated {
-                status: ChallengeStatus::Reset,
-                empty: false,
-            },
+            LifecycleEvent::ChallengeTerminated { empty: false },
         ));
 
         // The queued command is never processed.
@@ -964,9 +1060,7 @@ mod tests {
             mode: ChallengeMode::TobRegular,
             party: vec!["a".into()],
             party_changed: false,
-            phase: PhaseState::Terminated {
-                status: ChallengeStatus::Reset,
-            },
+            phase: PhaseState::Terminated,
             reported_times: None,
             stage: Stage::TobMaiden,
             stage_attempt: None,
@@ -975,6 +1069,7 @@ mod tests {
             clients: BTreeMap::new(),
             recorded_by: [ClientId(10)].into(),
             dormant_since: Some(Timestamp::from_millis(500)),
+            processing: Processing::default(),
             cursor: MsgId::sequence(2),
         };
         assert_eq!(*outcome.log.deleted.lock().unwrap(), vec![expected]);
@@ -1036,10 +1131,7 @@ mod tests {
                     3,
                     0,
                     2,
-                    LifecycleEvent::ChallengeTerminated {
-                        status: ChallengeStatus::Reset,
-                        empty: false,
-                    },
+                    LifecycleEvent::ChallengeTerminated { empty: false },
                 ),
             ],
         );
@@ -1078,10 +1170,7 @@ mod tests {
                 seq: JournalSeq(3),
                 at: Timestamp::from_millis(1_000 + window),
                 caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-                event: LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Reset,
-                    empty: false,
-                },
+                event: LifecycleEvent::ChallengeTerminated { empty: false },
             }],
         );
         assert_eq!(outcome.log.deleted.lock().unwrap().len(), 1);
@@ -1113,10 +1202,7 @@ mod tests {
                 seq: JournalSeq(4),
                 at: Timestamp::from_millis(window * 3),
                 caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-                event: LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Reset,
-                    empty: false,
-                },
+                event: LifecycleEvent::ChallengeTerminated { empty: false },
             }],
         );
         assert_eq!(outcome.log.deleted.lock().unwrap().len(), 1);
@@ -1155,7 +1241,7 @@ mod tests {
             }),
         );
         let (_tx, rx) = watch::channel(false);
-        run_challenge(LifecycleConfig::default(), claim, rx).await;
+        run_challenge(LifecycleConfig::default(), claim, None, rx).await;
 
         assert_eq!(log.renewals.load(Ordering::Relaxed), 1);
         assert!(log.appended.lock().unwrap().is_empty());
@@ -1177,7 +1263,7 @@ mod tests {
             }),
         );
         let (shutdown, rx) = watch::channel(false);
-        let actor = tokio::spawn(run_challenge(LifecycleConfig::default(), claim, rx));
+        let actor = tokio::spawn(run_challenge(LifecycleConfig::default(), claim, None, rx));
 
         tokio::time::sleep(Duration::from_secs(1)).await;
         shutdown.send(true).expect("actor should be listening");

--- a/challenge-harder/src/lifecycle/coordinator.rs
+++ b/challenge-harder/src/lifecycle/coordinator.rs
@@ -13,6 +13,7 @@ use super::core::command::{ClientStatusChange, Command, Create, Finish, Join, Up
 use super::core::deadline::LifecycleConfig;
 use super::core::state::{ChallengePhase, PublishedClient, Snapshot};
 use super::core::types::{ClientId, MsgId, Uuid};
+use crate::processing::StageProcessor;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum CommandError {
@@ -194,6 +195,7 @@ fn spawn_challenge(
     registry: &Arc<Mutex<Registry>>,
     cache: &Arc<SnapshotCache>,
     claim: Claim,
+    processor: Option<Arc<dyn StageProcessor>>,
     shutdown: watch::Receiver<bool>,
 ) {
     let uuid = claim.uuid();
@@ -206,7 +208,7 @@ fn spawn_challenge(
     let cache = Arc::clone(cache);
     tokio::spawn(async move {
         // Run as a child to catch panics.
-        let outcome = tokio::spawn(run_challenge(config, claim, shutdown)).await;
+        let outcome = tokio::spawn(run_challenge(config, claim, processor, shutdown)).await;
         registry
             .lock()
             .expect("coordinator lock poisoned")
@@ -229,6 +231,7 @@ pub struct Coordinator {
     config: LifecycleConfig,
     store: Arc<dyn ChallengeStore>,
     cache: Arc<SnapshotCache>,
+    processor: Option<Arc<dyn StageProcessor>>,
     shutdown: watch::Receiver<bool>,
 }
 
@@ -250,6 +253,7 @@ impl Coordinator {
             config: LifecycleConfig::default(),
             cache: SnapshotCache::spawn(Arc::clone(&store)),
             store,
+            processor: None,
             shutdown,
         }
     }
@@ -257,6 +261,13 @@ impl Coordinator {
     #[must_use]
     pub fn with_config(mut self, config: LifecycleConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Sets the processor for running challenges' data processing pipelines.
+    #[must_use]
+    pub fn with_processor(mut self, processor: Arc<dyn StageProcessor>) -> Self {
+        self.processor = Some(processor);
         self
     }
 
@@ -311,6 +322,7 @@ impl Coordinator {
                         &self.registry,
                         &self.cache,
                         claim,
+                        self.processor.clone(),
                         self.shutdown.clone(),
                     );
                     (id, uuid, false)
@@ -434,6 +446,7 @@ impl Coordinator {
         let starts = Arc::clone(&self.starts);
         let cache = Arc::clone(&self.cache);
         let config = self.config.clone();
+        let processor = self.processor.clone();
         let mut shutdown = self.shutdown.clone();
 
         tokio::spawn(async move {
@@ -458,6 +471,7 @@ impl Coordinator {
                                 &registry,
                                 &cache,
                                 claim,
+                                processor.clone(),
                                 shutdown.clone(),
                             );
                         }
@@ -712,6 +726,7 @@ mod tests {
             &coordinator.registry,
             &coordinator.cache,
             Claim::new(uuid, Box::new(PanickingClaim)),
+            None,
             coordinator.shutdown.clone(),
         );
         let registered = |coordinator: &Coordinator| {

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -5,8 +5,8 @@
 
 use super::command::StageProgress;
 use super::event::{Cause, JournalEntry, LifecycleEvent};
-use super::state::{ChallengeState, ClientState, LastCompleted, PhaseState, StageState};
-use super::types::{ClientId, StageExt, StageStatus, StageStatusExt, Timestamp};
+use super::state::{ChallengeState, ClientState, LastCompleted, PhaseState, StageState, Trigger};
+use super::types::{ClientId, ProcessingError, StageExt, StageStatus, StageStatusExt, Timestamp};
 
 // it's an exhaustive enum folks
 #[allow(clippy::too_many_lines)]
@@ -33,6 +33,9 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             state.stage_attempt = None;
             state.stage_status = StageStatus::Entered;
             state.stage_state = StageState::InProgress;
+            state
+                .processing
+                .push(Trigger::Create { seq: entry.seq }, entry.at);
         }
         LifecycleEvent::ClientJoined {
             client_id,
@@ -83,14 +86,19 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             state.stage_status = StageStatus::Started;
             state.stage_state = StageState::InProgress;
         }
-        LifecycleEvent::StageSealed { .. } => {
+        LifecycleEvent::StageSealed { stage, attempt, .. } => {
             state.stage_state = StageState::Complete { since: entry.at };
+            state.processing.push(
+                Trigger::Stage {
+                    seq: entry.seq,
+                    stage,
+                    attempt,
+                },
+                entry.at,
+            );
         }
-        LifecycleEvent::ChallengeFinishing { status } => {
-            state.phase = PhaseState::Finishing {
-                since: entry.at,
-                status,
-            };
+        LifecycleEvent::ChallengeFinishing => {
+            state.phase = PhaseState::Finishing { since: entry.at };
         }
         LifecycleEvent::ClientFinished {
             client_id, times, ..
@@ -98,7 +106,7 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             state.clients.remove(&client_id);
             state.reported_times = state.reported_times.or(times);
             // Each finish extends the grace period for remaining clients.
-            if let PhaseState::Finishing { since, .. } = &mut state.phase {
+            if let PhaseState::Finishing { since } = &mut state.phase {
                 *since = entry.at;
             }
         }
@@ -115,9 +123,11 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         LifecycleEvent::ClientRemoved { client_id } => {
             state.clients.remove(&client_id);
         }
-        LifecycleEvent::ChallengeTerminated { status, empty: _ } => {
-            state.phase = PhaseState::Terminated { status };
-            state.reported_times = None;
+        LifecycleEvent::ChallengeTerminated { empty: _ } => {
+            state.phase = PhaseState::Terminated;
+            state
+                .processing
+                .push(Trigger::Finish { seq: entry.seq }, entry.at);
         }
         LifecycleEvent::ModeChanged { mode } => {
             state.mode = mode;
@@ -125,10 +135,34 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         LifecycleEvent::PartyChanged { .. } => {
             state.party_changed = true;
         }
-        LifecycleEvent::StageProcessingStarted { .. }
-        | LifecycleEvent::StageProcessingFinished { .. }
-        | LifecycleEvent::StageProcessingFailed { .. }
-        | LifecycleEvent::StageProcessingTimedOut { .. } => todo!(),
+        LifecycleEvent::ProcessingStarted { trigger } => {
+            state.processing.start(trigger, entry.at);
+        }
+        LifecycleEvent::ProcessingFinished {
+            trigger: _,
+            outcome,
+        } => {
+            let challenge_type = state.challenge_type;
+            state
+                .processing
+                .finish(challenge_type, entry.at, Ok(outcome));
+        }
+        LifecycleEvent::ProcessingFailed { trigger: _, error } => {
+            let challenge_type = state.challenge_type;
+            state
+                .processing
+                .finish(challenge_type, entry.at, Err(error));
+        }
+        LifecycleEvent::ProcessingTimedOut { trigger: _ } => {
+            let challenge_type = state.challenge_type;
+            let timed_out = ProcessingError {
+                message: "timed out".into(),
+                retriable: true,
+            };
+            state
+                .processing
+                .finish(challenge_type, entry.at, Err(timed_out));
+        }
     }
 
     // Check whether the challenge's clients have gone inactive.
@@ -192,12 +226,15 @@ fn stage_reported(
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
+
     use super::*;
     use crate::lifecycle::core::command::StageProgress;
     use crate::lifecycle::core::deadline::DeadlineKind;
+    use crate::lifecycle::core::state::{Processing, ProcessingConfig, ProcessingState, Trigger};
     use crate::lifecycle::core::types::{
-        ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId, RecordingType,
-        ReportedTimes, Stage, Timestamp, UserId, Uuid,
+        ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId,
+        ProcessingOutcome, RecordingType, ReportedTimes, Stage, Timestamp, UserId, Uuid,
     };
 
     const CLIENT: ClientId = ClientId(10);
@@ -610,19 +647,12 @@ mod tests {
         let mut state = created_tob_state();
         apply(
             &mut state,
-            entry(
-                9_000,
-                2,
-                LifecycleEvent::ChallengeFinishing {
-                    status: ChallengeStatus::Wiped,
-                },
-            ),
+            entry(9_000, 2, LifecycleEvent::ChallengeFinishing),
         );
         assert_eq!(
             state.phase,
             PhaseState::Finishing {
-                since: Timestamp::from_millis(9_000),
-                status: ChallengeStatus::Wiped,
+                since: Timestamp::from_millis(9_000)
             }
         );
     }
@@ -632,13 +662,7 @@ mod tests {
         let mut state = created_tob_state();
         apply(
             &mut state,
-            entry(
-                9_000,
-                2,
-                LifecycleEvent::ChallengeFinishing {
-                    status: ChallengeStatus::Wiped,
-                },
-            ),
+            entry(9_000, 2, LifecycleEvent::ChallengeFinishing),
         );
         apply(
             &mut state,
@@ -656,8 +680,7 @@ mod tests {
         assert_eq!(
             state.phase,
             PhaseState::Finishing {
-                since: Timestamp::from_millis(12_500),
-                status: ChallengeStatus::Wiped,
+                since: Timestamp::from_millis(12_500)
             }
         );
     }
@@ -759,18 +782,10 @@ mod tests {
             entry(
                 9_000,
                 2,
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Reset,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ),
         );
-        assert_eq!(
-            state.phase,
-            PhaseState::Terminated {
-                status: ChallengeStatus::Reset
-            }
-        );
+        assert_eq!(state.phase, PhaseState::Terminated);
     }
 
     #[test]
@@ -849,5 +864,240 @@ mod tests {
             }
         );
         assert_eq!(state.stage_status, StageStatus::Wiped);
+    }
+
+    fn processing_tob_state() -> ChallengeState {
+        let mut state = created_tob_state();
+        state.processing = Processing::new(ProcessingConfig {
+            max_attempts: 2,
+            run_timeout: Duration::from_secs(10),
+            retry_backoff: Duration::from_secs(3),
+        });
+        state
+    }
+
+    fn processing_entry(at_ms: u64, event: LifecycleEvent) -> JournalEntry {
+        JournalEntry {
+            seq: JournalSeq(9),
+            at: Timestamp::from_millis(at_ms),
+            caused_by: Cause::Processing(JournalSeq(5)),
+            event,
+        }
+    }
+
+    fn maiden_seal(at_ms: u64) -> JournalEntry {
+        JournalEntry {
+            seq: JournalSeq(5),
+            at: Timestamp::from_millis(at_ms),
+            caused_by: Cause::Command(MsgId::sequence(3)),
+            event: LifecycleEvent::StageSealed {
+                stage: Stage::TobMaiden,
+                attempt: None,
+                forced: false,
+            },
+        }
+    }
+
+    #[test]
+    fn seal_queues_a_processing_run_at_its_journal_position() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+
+        let run = state.processing.active().expect("exists");
+        assert_eq!(
+            run.trigger,
+            Trigger::Stage {
+                seq: JournalSeq(5),
+                stage: Stage::TobMaiden,
+                attempt: None,
+            },
+        );
+        assert_eq!(
+            run.state,
+            ProcessingState::Idle {
+                since: Timestamp::from_millis(5_000)
+            },
+        );
+    }
+
+    #[test]
+    fn creation_and_termination_queue_boundary_runs() {
+        let mut state = ChallengeState {
+            processing: Processing::new(ProcessingConfig {
+                max_attempts: 2,
+                run_timeout: Duration::from_secs(10),
+                retry_backoff: Duration::from_secs(3),
+            }),
+            ..ChallengeState::default()
+        };
+
+        let create = JournalEntry {
+            seq: JournalSeq(0),
+            at: Timestamp::from_millis(100),
+            caused_by: Cause::Command(MsgId::sequence(0)),
+            event: LifecycleEvent::ChallengeCreated {
+                uuid: Uuid::nil(),
+                challenge_type: ChallengeType::Tob,
+                mode: ChallengeMode::TobRegular,
+                party: vec!["a".into()],
+                stage: Stage::TobMaiden,
+            },
+        };
+        apply(&mut state, create);
+        assert_eq!(
+            state.processing.active().expect("exists").trigger,
+            Trigger::Create { seq: JournalSeq(0) },
+        );
+
+        apply(
+            &mut state,
+            JournalEntry {
+                seq: JournalSeq(1),
+                at: Timestamp::from_millis(200),
+                caused_by: Cause::Command(MsgId::sequence(1)),
+                event: LifecycleEvent::ChallengeTerminated { empty: false },
+            },
+        );
+
+        // Finish runs is queued after the create run.
+        assert_eq!(
+            state.processing.active().expect("exists").trigger,
+            Trigger::Create { seq: JournalSeq(0) },
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                300,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(0),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                400,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(0),
+                    outcome: ProcessingOutcome::Boundary,
+                },
+            ),
+        );
+        assert_eq!(
+            state.processing.active().expect("exists").trigger,
+            Trigger::Finish { seq: JournalSeq(1) },
+        );
+        assert!(!state.processing.settled());
+    }
+
+    #[test]
+    fn processing_events_drive_the_run_without_moving_the_cursor() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+        let cursor = state.cursor;
+
+        apply(
+            &mut state,
+            processing_entry(
+                5_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+        let run = state.processing.active().unwrap();
+        assert_eq!(run.attempts, 1);
+        assert_eq!(
+            run.state,
+            ProcessingState::Running {
+                since: Timestamp::from_millis(5_000)
+            },
+        );
+
+        // A timeout is a retriable failure with attempts remaining.
+        apply(
+            &mut state,
+            processing_entry(
+                15_000,
+                LifecycleEvent::ProcessingTimedOut {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+        let run = state.processing.active().unwrap();
+        assert_eq!(run.attempts, 1);
+        assert!(run.retriable);
+        assert_eq!(
+            run.state,
+            ProcessingState::Idle {
+                since: Timestamp::from_millis(15_000)
+            },
+        );
+
+        // The final attempt's failure abandons the run.
+        apply(
+            &mut state,
+            processing_entry(
+                18_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                19_000,
+                LifecycleEvent::ProcessingFailed {
+                    trigger: JournalSeq(5),
+                    error: ProcessingError {
+                        message: "scripted".into(),
+                        retriable: true,
+                    },
+                },
+            ),
+        );
+        assert!(state.processing.settled());
+
+        assert_eq!(state.cursor, cursor);
+    }
+
+    #[test]
+    fn final_status_is_set_by_the_last_processing_outcome() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+        apply(
+            &mut state,
+            processing_entry(
+                5_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                6_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(5),
+                    outcome: ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    },
+                },
+            ),
+        );
+        assert!(state.processing.settled());
+
+        apply(
+            &mut state,
+            entry(
+                9_000,
+                4,
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+        );
+        assert_eq!(state.status(), ChallengeStatus::Reset);
     }
 }

--- a/challenge-harder/src/lifecycle/core/command.rs
+++ b/challenge-harder/src/lifecycle/core/command.rs
@@ -5,8 +5,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use super::deadline::Deadline;
 use super::types::{
-    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, RecordingType, ReportedTimes,
-    SessionToken, Stage, StageProcessingError, StageProcessingOutcome, StageStatus, UserId,
+    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError, ProcessingOutcome,
+    RecordingType, ReportedTimes, SessionToken, Stage, StageStatus, UserId,
 };
 
 /// A client's stage progress report.
@@ -102,16 +102,15 @@ pub struct ClientStatusChange {
     pub status: ClientStatus,
 }
 
-/// Completion message from the stage processing pipeline.
+/// Terminal report from a processing run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct StageProcessed {
-    pub stage: Stage,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub attempt: Option<u32>,
-    /// Journal position of the `StageSealed` that spawned the processing run.
-    pub seal_seq: JournalSeq,
-    pub result: Result<StageProcessingOutcome, StageProcessingError>,
+pub struct Processed {
+    /// Journal position of the entry that triggered the run.
+    pub trigger: JournalSeq,
+    /// The run attempt which produced the result.
+    pub attempt: u32,
+    pub result: Result<ProcessingOutcome, ProcessingError>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -121,7 +120,7 @@ pub enum Command {
     Update(Update),
     Finish(Finish),
     ClientStatus(ClientStatusChange),
-    StageProcessed(StageProcessed),
+    Processed(Processed),
     DeadlineFired(Deadline),
 }
 

--- a/challenge-harder/src/lifecycle/core/deadline.rs
+++ b/challenge-harder/src/lifecycle/core/deadline.rs
@@ -7,7 +7,7 @@ use core::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use super::state::{ChallengeState, PhaseState, StageState};
+use super::state::{ChallengeState, PhaseState, ProcessingConfig, ProcessingState, StageState};
 use super::types::Timestamp;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -20,6 +20,10 @@ pub enum DeadlineKind {
     CleanupDisconnect,
     /// Inactivity window while every client is idle.
     CleanupAllIdle,
+    /// Delay before the next attempt of a failed processing run.
+    ProcessingRetry,
+    /// Cap on the duration of a processing run attempt.
+    ProcessingTimeout,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -44,6 +48,8 @@ pub struct LifecycleConfig {
     pub inactivity_timeout: Duration,
     /// Interval at which a running challenge renews its lease.
     pub lease_renewal_interval: Duration,
+    /// Options for challenge data processing runs.
+    pub processing: ProcessingConfig,
 }
 
 impl Default for LifecycleConfig {
@@ -54,6 +60,7 @@ impl Default for LifecycleConfig {
             reconnection_window: Duration::from_mins(5),
             inactivity_timeout: Duration::from_mins(15),
             lease_renewal_interval: Duration::from_secs(10),
+            processing: ProcessingConfig::default(),
         }
     }
 }
@@ -69,6 +76,11 @@ impl LifecycleConfig {
             reconnection_window: self.reconnection_window / factor,
             inactivity_timeout: self.inactivity_timeout / factor,
             lease_renewal_interval: self.lease_renewal_interval / factor,
+            processing: ProcessingConfig {
+                max_attempts: self.processing.max_attempts,
+                run_timeout: self.processing.run_timeout / factor,
+                retry_backoff: self.processing.retry_backoff / factor,
+            },
         }
     }
 }
@@ -76,7 +88,20 @@ impl LifecycleConfig {
 /// Returns the next deadline implied by `state`, if any.
 #[must_use]
 pub fn next_deadline(state: &ChallengeState, config: &LifecycleConfig) -> Option<Deadline> {
-    if let PhaseState::Terminated { .. } = state.phase {
+    let lifecycle = lifecycle_deadline(state, config);
+    let processing = processing_deadline(state);
+    match (lifecycle, processing) {
+        (Some(lifecycle), Some(processing)) => Some(if processing.at < lifecycle.at {
+            processing
+        } else {
+            lifecycle
+        }),
+        (lifecycle, processing) => lifecycle.or(processing),
+    }
+}
+
+fn lifecycle_deadline(state: &ChallengeState, config: &LifecycleConfig) -> Option<Deadline> {
+    if let PhaseState::Terminated = state.phase {
         return None;
     }
 
@@ -88,7 +113,7 @@ pub fn next_deadline(state: &ChallengeState, config: &LifecycleConfig) -> Option
         });
     }
 
-    if let PhaseState::Finishing { since, .. } = state.phase {
+    if let PhaseState::Finishing { since } = state.phase {
         // Start the completion grace period from when the stage was finalized.
         let anchor = match state.stage_state {
             StageState::Complete { since: sealed_at } => since.max(sealed_at),
@@ -118,12 +143,35 @@ pub fn next_deadline(state: &ChallengeState, config: &LifecycleConfig) -> Option
     None
 }
 
+fn processing_deadline(state: &ChallengeState) -> Option<Deadline> {
+    let run = state.processing.active()?;
+    let config = state.processing.config();
+    match run.state {
+        ProcessingState::Running { since } => Some(Deadline {
+            kind: DeadlineKind::ProcessingTimeout,
+            at: since + config.run_timeout,
+        }),
+        ProcessingState::Idle { since } => {
+            let backoff = if run.attempts == 0 {
+                Duration::ZERO
+            } else {
+                config.retry_backoff
+            };
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingRetry,
+                at: since + backoff,
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lifecycle::core::state::ClientState;
+    use crate::lifecycle::core::state::{ClientState, Processing, Trigger};
     use crate::lifecycle::core::types::{
-        ChallengeStatus, ChallengeType, ClientId, RecordingType, Stage, StageStatus, UserId,
+        ChallengeStatus, ChallengeType, ClientId, JournalSeq, ProcessingError, RecordingType,
+        Stage, StageStatus, UserId,
     };
 
     fn mid_stage_state() -> ChallengeState {
@@ -153,7 +201,47 @@ mod tests {
             reconnection_window: Duration::from_mins(5),
             inactivity_timeout: Duration::from_mins(15),
             lease_renewal_interval: Duration::from_secs(10),
+            processing: ProcessingConfig::default(),
         }
+    }
+
+    /// A processing run with one trigger queued at `since`.
+    fn queued_processing(since: Timestamp) -> Processing {
+        let mut processing = Processing::new(ProcessingConfig {
+            max_attempts: 3,
+            run_timeout: Duration::from_secs(10),
+            retry_backoff: Duration::from_secs(3),
+        });
+        processing.push(
+            Trigger::Stage {
+                seq: JournalSeq(5),
+                stage: Stage::TobMaiden,
+                attempt: None,
+            },
+            since,
+        );
+        processing
+    }
+
+    /// A processing run which has been running since `since`.
+    fn running_processing(since: Timestamp) -> Processing {
+        let mut processing = queued_processing(since);
+        processing.start(JournalSeq(5), since);
+        processing
+    }
+
+    /// A processing run which failed its first attempt at `since`.
+    fn failed_processing(since: Timestamp) -> Processing {
+        let mut processing = running_processing(since);
+        processing.finish(
+            ChallengeType::Tob,
+            since,
+            Err(ProcessingError {
+                message: "scripted".into(),
+                retriable: true,
+            }),
+        );
+        processing
     }
 
     #[test]
@@ -164,6 +252,9 @@ mod tests {
         assert_eq!(config.reconnection_window, Duration::from_secs(30));
         assert_eq!(config.inactivity_timeout, Duration::from_secs(90));
         assert_eq!(config.lease_renewal_interval, Duration::from_secs(1));
+        assert_eq!(config.processing.run_timeout, Duration::from_secs(3));
+        assert_eq!(config.processing.retry_backoff, Duration::from_millis(500));
+        assert_eq!(config.processing.max_attempts, 0);
     }
 
     #[test]
@@ -191,7 +282,6 @@ mod tests {
             },
             phase: PhaseState::Finishing {
                 since: Timestamp::from_millis(5_100),
-                status: ChallengeStatus::Wiped,
             },
             ..mid_stage_state()
         };
@@ -213,7 +303,6 @@ mod tests {
             },
             phase: PhaseState::Finishing {
                 since: Timestamp::from_millis(5_100),
-                status: ChallengeStatus::Wiped,
             },
             ..mid_stage_state()
         };
@@ -228,7 +317,6 @@ mod tests {
         // A definitive finish arriving after the seal anchors the grace.
         state.phase = PhaseState::Finishing {
             since: Timestamp::from_millis(8_000),
-            status: ChallengeStatus::Wiped,
         };
         assert_eq!(
             next_deadline(&state, &test_config()),
@@ -244,7 +332,6 @@ mod tests {
         let state = ChallengeState {
             phase: PhaseState::Finishing {
                 since: Timestamp::from_millis(5_000),
-                status: ChallengeStatus::Abandoned,
             },
             ..mid_stage_state()
         };
@@ -307,7 +394,6 @@ mod tests {
         };
         state.phase = PhaseState::Finishing {
             since: Timestamp::from_millis(7_100),
-            status: ChallengeStatus::Wiped,
         };
         assert_eq!(
             next_deadline(&state, &test_config()),
@@ -330,16 +416,104 @@ mod tests {
     }
 
     #[test]
-    fn terminated_challenge_has_no_deadlines() {
+    fn terminated_challenge_without_processing_has_no_deadlines() {
         let state = ChallengeState {
-            phase: PhaseState::Terminated {
-                status: ChallengeStatus::Wiped,
-            },
+            phase: PhaseState::Terminated,
             stage_state: StageState::Complete {
                 since: Timestamp::from_millis(7_000),
             },
             ..mid_stage_state()
         };
         assert_eq!(next_deadline(&state, &LifecycleConfig::default()), None);
+    }
+
+    #[test]
+    fn queued_processing_run_is_due_immediately() {
+        let state = ChallengeState {
+            processing: queued_processing(Timestamp::from_millis(5_000)),
+            ..mid_stage_state()
+        };
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingRetry,
+                at: Timestamp::from_millis(5_000),
+            }),
+        );
+    }
+
+    #[test]
+    fn failed_processing_run_waits_for_retry() {
+        let state = ChallengeState {
+            processing: failed_processing(Timestamp::from_millis(5_000)),
+            ..mid_stage_state()
+        };
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingRetry,
+                at: Timestamp::from_millis(8_000),
+            }),
+        );
+    }
+
+    #[test]
+    fn active_processing_run_has_a_timeout() {
+        let state = ChallengeState {
+            processing: running_processing(Timestamp::from_millis(5_000)),
+            ..mid_stage_state()
+        };
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingTimeout,
+                at: Timestamp::from_millis(15_000),
+            }),
+        );
+    }
+
+    #[test]
+    fn terminated_challenge_with_active_processing_has_a_timeout() {
+        let state = ChallengeState {
+            phase: PhaseState::Terminated,
+            processing: running_processing(Timestamp::from_millis(5_000)),
+            ..mid_stage_state()
+        };
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingTimeout,
+                at: Timestamp::from_millis(15_000),
+            }),
+        );
+    }
+
+    #[test]
+    fn earliest_deadline_wins() {
+        // The stage end grace period at 7s beats the processing timeout at 15s.
+        let mut state = ChallengeState {
+            stage_state: StageState::Ending {
+                since: Timestamp::from_millis(5_000),
+            },
+            processing: running_processing(Timestamp::from_millis(5_000)),
+            ..mid_stage_state()
+        };
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::StageEnd,
+                at: Timestamp::from_millis(7_000),
+            }),
+        );
+
+        // A queued run beats the stage end.
+        state.processing = queued_processing(Timestamp::from_millis(5_500));
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingRetry,
+                at: Timestamp::from_millis(5_500),
+            }),
+        );
     }
 }

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -4,13 +4,14 @@
 //! converting incoming commands to a set of intended actions that are later
 //! applied.
 
-use super::command::{ClientStatus, ClientStatusChange, Command, Create, Finish, Join, Update};
+use super::command::{
+    ClientStatus, ClientStatusChange, Command, Create, Finish, Join, Processed, Update,
+};
 use super::deadline::{Deadline, DeadlineKind, LifecycleConfig, next_deadline};
 use super::event::LifecycleEvent;
-use super::state::{ChallengeState, ClientState, PhaseState, StageState};
+use super::state::{ChallengeState, ClientState, PhaseState, ProcessingState, StageState};
 use super::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, RecordingType, Stage,
-    StageExt, StageStatus, StageStatusExt,
+    ChallengeMode, ChallengeType, RecordingType, Stage, StageExt, StageStatus, StageStatusExt,
 };
 
 /// Produces a series of journal events from a received command, detailing the
@@ -20,9 +21,13 @@ pub fn decide(
     config: &LifecycleConfig,
     cmd: &Command,
 ) -> Vec<LifecycleEvent> {
-    if let PhaseState::Terminated { .. } = state.phase {
-        // Nothing to do after termination.
-        return Vec::new();
+    if state.terminated() {
+        // Only processing continues after termination.
+        return match cmd {
+            Command::Processed(report) => processed(state, report),
+            Command::DeadlineFired(d) => deadline_fired(state, config, *d),
+            _ => Vec::new(),
+        };
     }
 
     match cmd {
@@ -32,7 +37,7 @@ pub fn decide(
         Command::Finish(f) => finish(state, f),
         Command::ClientStatus(c) => client_status(state, c),
         Command::DeadlineFired(d) => deadline_fired(state, config, *d),
-        Command::StageProcessed(_) => todo!(),
+        Command::Processed(p) => processed(state, p),
     }
 }
 
@@ -259,9 +264,9 @@ fn deadline_fired(
             forced: true,
         }],
         DeadlineKind::ChallengeEnd => {
-            let PhaseState::Finishing { status, .. } = state.phase else {
+            if !matches!(state.phase, PhaseState::Finishing { .. }) {
                 unreachable!("ChallengeEnd is only derivable when finishing");
-            };
+            }
 
             // Clients which never sent their finish requests are cut off.
             let mut events: Vec<LifecycleEvent> = state
@@ -270,14 +275,12 @@ fn deadline_fired(
                 .map(|&client_id| LifecycleEvent::ClientRemoved { client_id })
                 .collect();
             events.push(LifecycleEvent::ChallengeTerminated {
-                status,
                 // TODO(frolv): Set based on recorded data once stage processing exists.
                 empty: false,
             });
             events
         }
         DeadlineKind::CleanupDisconnect => vec![LifecycleEvent::ChallengeTerminated {
-            status: terminal_status(state.challenge_type, state.stage, state.stage_status),
             // TODO(frolv): Set based on recorded data once stage processing exists.
             empty: false,
         }],
@@ -288,11 +291,26 @@ fn deadline_fired(
                 .map(|&client_id| LifecycleEvent::ClientRemoved { client_id })
                 .collect();
             events.push(LifecycleEvent::ChallengeTerminated {
-                status: terminal_status(state.challenge_type, state.stage, state.stage_status),
                 // TODO(frolv): Set based on recorded data once stage processing exists.
                 empty: false,
             });
             events
+        }
+        DeadlineKind::ProcessingRetry => {
+            let Some(run) = state.processing.active() else {
+                unreachable!("processing deadlines imply an active run");
+            };
+            vec![LifecycleEvent::ProcessingStarted {
+                trigger: run.trigger.seq(),
+            }]
+        }
+        DeadlineKind::ProcessingTimeout => {
+            let Some(run) = state.processing.active() else {
+                unreachable!("processing deadlines imply an active run");
+            };
+            vec![LifecycleEvent::ProcessingTimedOut {
+                trigger: run.trigger.seq(),
+            }]
         }
     }
 }
@@ -321,9 +339,7 @@ fn finish(state: &ChallengeState, finish: &Finish) -> Vec<LifecycleEvent> {
         // Wait for other clients to report their finishes.
         let mut events = Vec::new();
         if definitive && matches!(state.phase, PhaseState::Active) {
-            events.push(LifecycleEvent::ChallengeFinishing {
-                status: terminal_status(state.challenge_type, client.stage, client.stage_status),
-            });
+            events.push(LifecycleEvent::ChallengeFinishing);
         }
         events.push(finished);
         return events;
@@ -340,55 +356,47 @@ fn finish(state: &ChallengeState, finish: &Finish) -> Vec<LifecycleEvent> {
         });
     }
 
-    let status = if let PhaseState::Finishing { status, .. } = state.phase {
-        status
-    } else {
-        terminal_status(state.challenge_type, client.stage, client.stage_status)
-    };
     events.push(LifecycleEvent::ChallengeTerminated {
-        status,
         // TODO(frolv): Set based on recorded data once stage processing exists.
         empty: false,
     });
     events
 }
 
-// TODO(frolv): Temporary until stage processing exists. Callers pass either a
-// client's view of the challenge or the challenge's own last known progress.
-fn terminal_status(
-    challenge_type: ChallengeType,
-    stage: Stage,
-    stage_status: StageStatus,
-) -> ChallengeStatus {
-    let last_stage = challenge_type.last_stage();
-
-    // Some challenges can continue past their last stage. They should always
-    // count as completed as long as the last stage is completed.
-    if last_stage.is_some_and(|last| stage > last) {
-        return ChallengeStatus::Completed;
+fn processed(state: &ChallengeState, report: &Processed) -> Vec<LifecycleEvent> {
+    let Some(run) = state.processing.active() else {
+        return Vec::new();
+    };
+    // A report is only valid while its own attempt is still running.
+    if run.trigger.seq() != report.trigger
+        || run.attempts != report.attempt
+        || !matches!(run.state, ProcessingState::Running { .. })
+    {
+        return Vec::new();
     }
 
-    match stage_status {
-        StageStatus::Started => ChallengeStatus::Abandoned,
-        StageStatus::Entered => ChallengeStatus::Reset,
-        StageStatus::Wiped => ChallengeStatus::Wiped,
-        StageStatus::Completed => {
-            if last_stage.is_some_and(|last| stage == last) {
-                ChallengeStatus::Completed
-            } else {
-                ChallengeStatus::Reset
-            }
-        }
+    match &report.result {
+        Ok(outcome) => vec![LifecycleEvent::ProcessingFinished {
+            trigger: report.trigger,
+            outcome: *outcome,
+        }],
+        Err(error) => vec![LifecycleEvent::ProcessingFailed {
+            trigger: report.trigger,
+            error: error.clone(),
+        }],
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use core::time::Duration;
+
     use super::*;
-    use crate::lifecycle::core::command::StageProgress;
-    use crate::lifecycle::core::state::ClientState;
+    use crate::lifecycle::core::command::{Processed, StageProgress};
+    use crate::lifecycle::core::state::{ClientState, Processing, ProcessingConfig, Trigger};
     use crate::lifecycle::core::types::{
-        ClientId, RecordingType, ReportedTimes, Timestamp, UserId, Uuid,
+        ClientId, JournalSeq, ProcessingError, ProcessingOutcome, RecordingType, ReportedTimes,
+        Timestamp, UserId, Uuid,
     };
 
     const CLIENT_A: ClientId = ClientId(10);
@@ -915,10 +923,7 @@ mod tests {
                     soft: true,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Abandoned,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -942,10 +947,7 @@ mod tests {
                     soft: false,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Wiped,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -969,10 +971,7 @@ mod tests {
                     soft: false,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Reset,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -1000,10 +999,7 @@ mod tests {
                     soft: false,
                     times: Some(times),
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Completed,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -1038,73 +1034,9 @@ mod tests {
                     soft: false,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Completed,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
-    }
-
-    #[test]
-    fn terminal_status_reflects_stage_position_and_outcome() {
-        let cases = [
-            (
-                ChallengeType::Tob,
-                Stage::TobMaiden,
-                StageStatus::Started,
-                ChallengeStatus::Abandoned,
-            ),
-            (
-                ChallengeType::Tob,
-                Stage::TobMaiden,
-                StageStatus::Wiped,
-                ChallengeStatus::Wiped,
-            ),
-            (
-                ChallengeType::Tob,
-                Stage::TobBloat,
-                StageStatus::Completed,
-                ChallengeStatus::Reset,
-            ),
-            (
-                ChallengeType::Tob,
-                Stage::TobNylocas,
-                StageStatus::Entered,
-                ChallengeStatus::Reset,
-            ),
-            (
-                ChallengeType::Tob,
-                Stage::TobVerzik,
-                StageStatus::Completed,
-                ChallengeStatus::Completed,
-            ),
-            (
-                ChallengeType::Mokhaiotl,
-                Stage::MokhaiotlDelve8,
-                StageStatus::Started,
-                ChallengeStatus::Abandoned,
-            ),
-            (
-                ChallengeType::Mokhaiotl,
-                Stage::MokhaiotlDelve8plus,
-                StageStatus::Started,
-                ChallengeStatus::Completed,
-            ),
-            (
-                ChallengeType::Mokhaiotl,
-                Stage::MokhaiotlDelve8plus,
-                StageStatus::Wiped,
-                ChallengeStatus::Completed,
-            ),
-        ];
-        for (challenge_type, stage, stage_status, expected) in cases {
-            assert_eq!(
-                terminal_status(challenge_type, stage, stage_status),
-                expected,
-                "{challenge_type:?} at {stage:?} with {stage_status:?}",
-            );
-        }
     }
 
     fn status_change(client_id: ClientId, status: ClientStatus) -> Command {
@@ -1257,10 +1189,7 @@ mod tests {
                 &LifecycleConfig::default(),
                 &Command::DeadlineFired(fired),
             ),
-            vec![LifecycleEvent::ChallengeTerminated {
-                status: ChallengeStatus::Abandoned,
-                empty: false,
-            }],
+            vec![LifecycleEvent::ChallengeTerminated { empty: false }],
         );
     }
 
@@ -1296,10 +1225,7 @@ mod tests {
                 LifecycleEvent::ClientRemoved {
                     client_id: CLIENT_B
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Abandoned,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -1490,7 +1416,6 @@ mod tests {
         ]);
         state.phase = PhaseState::Finishing {
             since: Timestamp::from_millis(1_000),
-            status: ChallengeStatus::Completed,
         };
         let join = Command::Join(super::Join {
             user_id: UserId(1),
@@ -1605,9 +1530,7 @@ mod tests {
                 &finish_cmd(CLIENT_A, false, None),
             ),
             vec![
-                LifecycleEvent::ChallengeFinishing {
-                    status: ChallengeStatus::Wiped,
-                },
+                LifecycleEvent::ChallengeFinishing,
                 LifecycleEvent::ClientFinished {
                     client_id: CLIENT_A,
                     definitive: true,
@@ -1652,7 +1575,6 @@ mod tests {
         ]);
         state.phase = PhaseState::Finishing {
             since: Timestamp::from_millis(5_000),
-            status: ChallengeStatus::Wiped,
         };
         assert_eq!(
             decide(
@@ -1696,10 +1618,7 @@ mod tests {
                     attempt: None,
                     forced: true,
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Wiped,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -1712,7 +1631,6 @@ mod tests {
         )]);
         state.phase = PhaseState::Finishing {
             since: Timestamp::from_millis(5_000),
-            status: ChallengeStatus::Wiped,
         };
         state.stage_state = StageState::Complete {
             since: Timestamp::from_millis(5_500),
@@ -1731,10 +1649,7 @@ mod tests {
                 LifecycleEvent::ClientRemoved {
                     client_id: CLIENT_B,
                 },
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Wiped,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ],
         );
     }
@@ -1750,7 +1665,6 @@ mod tests {
         ]);
         state.phase = PhaseState::Finishing {
             since: Timestamp::from_millis(5_100),
-            status: ChallengeStatus::Wiped,
         };
         state.stage_state = StageState::Ending {
             since: Timestamp::from_millis(5_000),
@@ -1767,6 +1681,299 @@ mod tests {
                 &Command::DeadlineFired(premature),
             ),
             vec![],
+        );
+    }
+
+    fn sealed_tob_state() -> ChallengeState {
+        let mut state = tob_state(vec![(
+            CLIENT_A,
+            client(Stage::TobMaiden, StageStatus::Wiped, None),
+        )]);
+        state.processing = Processing::new(ProcessingConfig {
+            max_attempts: 2,
+            run_timeout: Duration::from_secs(10),
+            retry_backoff: Duration::from_secs(3),
+        });
+        state.processing.push(
+            Trigger::Stage {
+                seq: JournalSeq(5),
+                stage: Stage::TobMaiden,
+                attempt: None,
+            },
+            Timestamp::from_millis(1_000),
+        );
+        state
+    }
+
+    fn processing_tob_state() -> ChallengeState {
+        let mut state = sealed_tob_state();
+        state
+            .processing
+            .start(JournalSeq(5), Timestamp::from_millis(1_000));
+        state
+    }
+
+    fn processing_result(
+        trigger: u64,
+        attempt: u32,
+        result: Result<ProcessingOutcome, ProcessingError>,
+    ) -> Command {
+        Command::Processed(Processed {
+            trigger: JournalSeq(trigger),
+            attempt,
+            result,
+        })
+    }
+
+    #[test]
+    fn processed_report_resolves_the_active_run() {
+        let state = processing_tob_state();
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    5,
+                    1,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    })
+                ),
+            ),
+            vec![LifecycleEvent::ProcessingFinished {
+                trigger: JournalSeq(5),
+                outcome: ProcessingOutcome::Stage {
+                    status: StageStatus::Completed,
+                    ticks: 237,
+                },
+            }],
+        );
+
+        let error = ProcessingError {
+            message: "stream unavailable".into(),
+            retriable: true,
+        };
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(5, 1, Err(error.clone())),
+            ),
+            vec![LifecycleEvent::ProcessingFailed {
+                trigger: JournalSeq(5),
+                error,
+            }],
+        );
+    }
+
+    #[test]
+    fn processed_report_for_a_stale_run_is_dropped() {
+        let state = processing_tob_state();
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    4,
+                    1,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    })
+                ),
+            ),
+            vec![],
+        );
+
+        let state = tob_state(vec![(
+            CLIENT_A,
+            client(Stage::TobMaiden, StageStatus::Wiped, None),
+        )]);
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    5,
+                    1,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    })
+                ),
+            ),
+            vec![],
+        );
+    }
+
+    #[test]
+    fn processed_report_for_a_timed_out_attempt_is_dropped() {
+        let mut state = processing_tob_state();
+        state.processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(11_000),
+            Err(ProcessingError {
+                message: "timed out".into(),
+                retriable: true,
+            }),
+        );
+
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    5,
+                    1,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    })
+                ),
+            ),
+            vec![],
+        );
+    }
+
+    #[test]
+    fn processed_report_from_a_superseded_attempt_is_dropped() {
+        let mut state = processing_tob_state();
+        // The first attempt timed out and its retry is running.
+        state.processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(11_000),
+            Err(ProcessingError {
+                message: "timed out".into(),
+                retriable: true,
+            }),
+        );
+        state
+            .processing
+            .start(JournalSeq(5), Timestamp::from_millis(14_000));
+
+        // The dead first attempt's late report is dropped.
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    5,
+                    1,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    })
+                ),
+            ),
+            vec![],
+        );
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    5,
+                    2,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Wiped,
+                        ticks: 180,
+                    })
+                ),
+            ),
+            vec![LifecycleEvent::ProcessingFinished {
+                trigger: JournalSeq(5),
+                outcome: ProcessingOutcome::Stage {
+                    status: StageStatus::Wiped,
+                    ticks: 180,
+                },
+            }],
+        );
+    }
+
+    #[test]
+    fn processing_retry_starts_a_new_run() {
+        let state = sealed_tob_state();
+        let fired = next_deadline(&state, &LifecycleConfig::default())
+            .expect("a fresh run implies a deadline");
+        assert_eq!(fired.kind, DeadlineKind::ProcessingRetry);
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &Command::DeadlineFired(fired),
+            ),
+            vec![LifecycleEvent::ProcessingStarted {
+                trigger: JournalSeq(5),
+            }],
+        );
+    }
+
+    #[test]
+    fn processing_timeout_times_out_the_run() {
+        let state = processing_tob_state();
+        let fired = next_deadline(&state, &LifecycleConfig::default())
+            .expect("a running run implies a deadline");
+        assert_eq!(fired.kind, DeadlineKind::ProcessingTimeout);
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &Command::DeadlineFired(fired),
+            ),
+            vec![LifecycleEvent::ProcessingTimedOut {
+                trigger: JournalSeq(5),
+            }],
+        );
+    }
+
+    #[test]
+    fn terminated_challenge_only_accepts_processing_reports() {
+        let mut state = processing_tob_state();
+        state.phase = PhaseState::Terminated;
+        state.clients.clear();
+
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &stage_update(CLIENT_A, Stage::TobBloat, StageStatus::Started),
+            ),
+            vec![],
+        );
+
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &processing_result(
+                    5,
+                    1,
+                    Ok(ProcessingOutcome::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 237,
+                    })
+                ),
+            ),
+            vec![LifecycleEvent::ProcessingFinished {
+                trigger: JournalSeq(5),
+                outcome: ProcessingOutcome::Stage {
+                    status: StageStatus::Completed,
+                    ticks: 237,
+                },
+            }],
+        );
+        let fired = next_deadline(&state, &LifecycleConfig::default())
+            .expect("a processing run implies a deadline");
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &Command::DeadlineFired(fired),
+            ),
+            vec![LifecycleEvent::ProcessingTimedOut {
+                trigger: JournalSeq(5),
+            }],
         );
     }
 }

--- a/challenge-harder/src/lifecycle/core/event.rs
+++ b/challenge-harder/src/lifecycle/core/event.rs
@@ -5,9 +5,8 @@ use serde::{Deserialize, Serialize};
 use super::command::StageProgress;
 use super::deadline::DeadlineKind;
 use super::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId, RecordingType,
-    ReportedTimes, SessionToken, Stage, StageProcessingError, StageProcessingOutcome, Timestamp,
-    UserId, Uuid,
+    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError, ProcessingOutcome,
+    RecordingType, ReportedTimes, SessionToken, Stage, Timestamp, UserId, Uuid,
 };
 
 /// What triggered a lifecycle event.
@@ -18,6 +17,8 @@ pub enum Cause {
     Command(MsgId),
     /// A deadline coming due.
     Deadline(DeadlineKind),
+    /// A report from a processing run triggered by the journal entry at `seq`.
+    Processing(JournalSeq),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -78,29 +79,23 @@ pub enum LifecycleEvent {
         attempt: Option<u32>,
         forced: bool,
     },
-    StageProcessingStarted {
-        stage: Stage,
-        attempt: Option<u32>,
+    /// A processing run for the entry at journal position `trigger` began.
+    ProcessingStarted {
+        trigger: JournalSeq,
     },
-    StageProcessingFinished {
-        stage: Stage,
-        attempt: Option<u32>,
-        outcome: StageProcessingOutcome,
+    ProcessingFinished {
+        trigger: JournalSeq,
+        outcome: ProcessingOutcome,
     },
-    StageProcessingFailed {
-        stage: Stage,
-        attempt: Option<u32>,
-        error: StageProcessingError,
+    ProcessingFailed {
+        trigger: JournalSeq,
+        error: ProcessingError,
     },
-    StageProcessingTimedOut {
-        stage: Stage,
-        attempt: Option<u32>,
+    ProcessingTimedOut {
+        trigger: JournalSeq,
     },
     /// A client definitively finished the challenge, entering its finishing phase.
-    ChallengeFinishing {
-        // TODO(frolv): Temporary until stage processing is implemented.
-        status: ChallengeStatus,
-    },
+    ChallengeFinishing,
     ClientFinished {
         client_id: ClientId,
         definitive: bool,
@@ -119,7 +114,6 @@ pub enum LifecycleEvent {
     /// Terminal challenge event.
     /// `empty` marks a challenge with no recorded data which should be deleted.
     ChallengeTerminated {
-        status: ChallengeStatus,
         empty: bool,
     },
 }
@@ -127,7 +121,7 @@ pub enum LifecycleEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lifecycle::core::types::Timestamp;
+    use crate::lifecycle::core::types::{StageStatus, Timestamp};
 
     #[test]
     fn journal_entry_format_is_stable() {
@@ -164,5 +158,65 @@ mod tests {
             r#"{"seq":5,"at":3500,"caused_by":"StageEnd","event":{"StageSealed":{"stage":11,"attempt":null,"forced":true}}}"#
         );
         assert_eq!(serde_json::from_str::<JournalEntry>(&json).unwrap(), forced);
+
+        let processed = JournalEntry {
+            seq: JournalSeq(6),
+            at: Timestamp::from_millis(4_000),
+            caused_by: Cause::Processing(JournalSeq(5)),
+            event: LifecycleEvent::ProcessingFinished {
+                trigger: JournalSeq(5),
+                outcome: ProcessingOutcome::Stage {
+                    status: StageStatus::Completed,
+                    ticks: 237,
+                },
+            },
+        };
+        let json = serde_json::to_string(&processed).unwrap();
+        assert_eq!(
+            json,
+            r#"{"seq":6,"at":4000,"caused_by":5,"event":{"ProcessingFinished":{"trigger":5,"outcome":{"Stage":{"status":2,"ticks":237}}}}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<JournalEntry>(&json).unwrap(),
+            processed
+        );
+
+        let boundary = JournalEntry {
+            seq: JournalSeq(8),
+            at: Timestamp::from_millis(4_200),
+            caused_by: Cause::Processing(JournalSeq(0)),
+            event: LifecycleEvent::ProcessingFinished {
+                trigger: JournalSeq(0),
+                outcome: ProcessingOutcome::Boundary,
+            },
+        };
+        let json = serde_json::to_string(&boundary).unwrap();
+        assert_eq!(
+            json,
+            r#"{"seq":8,"at":4200,"caused_by":0,"event":{"ProcessingFinished":{"trigger":0,"outcome":"Boundary"}}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<JournalEntry>(&json).unwrap(),
+            boundary
+        );
+
+        let failed = JournalEntry {
+            seq: JournalSeq(7),
+            at: Timestamp::from_millis(4_100),
+            caused_by: Cause::Processing(JournalSeq(5)),
+            event: LifecycleEvent::ProcessingFailed {
+                trigger: JournalSeq(5),
+                error: ProcessingError {
+                    message: "stream unavailable".into(),
+                    retriable: true,
+                },
+            },
+        };
+        let json = serde_json::to_string(&failed).unwrap();
+        assert_eq!(
+            json,
+            r#"{"seq":7,"at":4100,"caused_by":5,"event":{"ProcessingFailed":{"trigger":5,"error":{"message":"stream unavailable","retriable":true}}}}"#
+        );
+        assert_eq!(serde_json::from_str::<JournalEntry>(&json).unwrap(), failed);
     }
 }

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -1,12 +1,15 @@
 //! Derived state of an active challenge.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
+use core::time::Duration;
+
 use super::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, MsgId, RecordingType, ReportedTimes,
-    SessionToken, Stage, StageStatus, Timestamp, UserId, Uuid,
+    ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, ClientId, JournalSeq, MsgId,
+    ProcessingError, ProcessingOutcome, RecordingType, ReportedTimes, SessionToken, Stage,
+    StageStatus, Timestamp, UserId, Uuid,
 };
 
 /// Progress of the challenge's current stage attempt.
@@ -31,31 +34,204 @@ pub enum PhaseState {
     Finishing {
         /// Time of the most recent client finish.
         since: Timestamp,
-        // TODO(frolv): Remove once stage processing is added.
-        status: ChallengeStatus,
     },
     /// The challenge has ended.
-    Terminated { status: ChallengeStatus },
+    Terminated,
 }
 
 impl PhaseState {
-    /// The phase's user-facing status.
-    #[must_use]
-    pub fn status(self) -> ChallengeStatus {
-        match self {
-            PhaseState::Active | PhaseState::Finishing { .. } => ChallengeStatus::InProgress,
-            PhaseState::Terminated { status } => status,
-        }
-    }
-
     /// Returns the published form of the phase.
     #[must_use]
     pub fn phase(self) -> ChallengePhase {
         match self {
             PhaseState::Active => ChallengePhase::Active,
             PhaseState::Finishing { .. } => ChallengePhase::Finishing,
-            PhaseState::Terminated { .. } => ChallengePhase::Terminated,
+            PhaseState::Terminated => ChallengePhase::Terminated,
         }
+    }
+}
+
+/// Options for a challenge's data processing pipeline.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessingConfig {
+    /// Attempts before giving up. Zero disables processing entirely.
+    pub max_attempts: u32,
+    /// Longest an attempt may run before it is aborted.
+    pub run_timeout: Duration,
+    /// Delay following a failed attempt before retrying.
+    pub retry_backoff: Duration,
+}
+
+impl Default for ProcessingConfig {
+    fn default() -> Self {
+        ProcessingConfig {
+            max_attempts: 0,
+            run_timeout: Duration::from_secs(30),
+            retry_backoff: Duration::from_secs(5),
+        }
+    }
+}
+
+/// A journal entry which starts a processing run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Trigger {
+    /// A new challenge was created.
+    Create { seq: JournalSeq },
+    /// A stage completed.
+    Stage {
+        seq: JournalSeq,
+        stage: Stage,
+        attempt: Option<u32>,
+    },
+    /// A challenge terminated.
+    Finish { seq: JournalSeq },
+}
+
+impl Trigger {
+    /// Journal position of the triggering entry.
+    #[must_use]
+    pub fn seq(self) -> JournalSeq {
+        match self {
+            Trigger::Create { seq } | Trigger::Stage { seq, .. } | Trigger::Finish { seq } => seq,
+        }
+    }
+}
+
+/// Status of an active processing run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProcessingState {
+    Idle { since: Timestamp },
+    Running { since: Timestamp },
+}
+
+/// An active processing run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProcessingRun {
+    pub trigger: Trigger,
+    pub attempts: u32,
+    /// False once a run fails with a non-retriable error.
+    pub retriable: bool,
+    pub state: ProcessingState,
+}
+
+impl ProcessingRun {
+    fn new(trigger: Trigger, at: Timestamp) -> Self {
+        ProcessingRun {
+            trigger,
+            attempts: 0,
+            retriable: true,
+            state: ProcessingState::Idle { since: at },
+        }
+    }
+
+    /// If `true`, the run cannot be retried any further.
+    #[must_use]
+    pub fn exhausted(&self, config: &ProcessingConfig) -> bool {
+        !self.retriable || self.attempts >= config.max_attempts
+    }
+}
+
+/// State of a challenge's data processing pipeline.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Processing {
+    config: ProcessingConfig,
+    active: Option<ProcessingRun>,
+    pending: VecDeque<Trigger>,
+    failed: Vec<Trigger>,
+    /// Status derived from the most recently processed outcome.
+    status: Option<ChallengeStatus>,
+}
+
+impl Processing {
+    pub fn new(config: ProcessingConfig) -> Self {
+        Self {
+            config,
+            active: None,
+            pending: VecDeque::new(),
+            failed: Vec::new(),
+            status: None,
+        }
+    }
+
+    /// Records a new trigger, starting its run if free.
+    pub fn push(&mut self, trigger: Trigger, at: Timestamp) {
+        if self.config.max_attempts == 0 {
+            return;
+        }
+        if self.active.is_none() {
+            self.active = Some(ProcessingRun::new(trigger, at));
+        } else {
+            self.pending.push_back(trigger);
+        }
+    }
+
+    /// Begins an attempt of the active run.
+    pub fn start(&mut self, seq: JournalSeq, at: Timestamp) {
+        if let Some(run) = &mut self.active
+            && run.trigger.seq() == seq
+        {
+            run.attempts += 1;
+            run.state = ProcessingState::Running { since: at };
+        }
+    }
+
+    /// Consumes the result of an attempt of the active run. A successful
+    /// outcome or an exhausted run completes it, starting the next pending run.
+    /// A failed run with attempts remaining marks it for retry.
+    pub fn finish(
+        &mut self,
+        challenge_type: ChallengeType,
+        at: Timestamp,
+        result: Result<ProcessingOutcome, ProcessingError>,
+    ) {
+        let Some(run) = &mut self.active else {
+            return;
+        };
+        match result {
+            Ok(ProcessingOutcome::Stage { status, .. }) => {
+                if let Trigger::Stage { stage, .. } = run.trigger {
+                    self.status = Some(status_if_finished_now(challenge_type, stage, status));
+                }
+            }
+            Ok(ProcessingOutcome::Boundary) => {}
+            Err(error) => {
+                run.retriable &= error.retriable;
+                if !run.exhausted(&self.config) {
+                    run.state = ProcessingState::Idle { since: at };
+                    return;
+                }
+                self.failed.push(run.trigger);
+            }
+        }
+
+        self.active = self
+            .pending
+            .pop_front()
+            .map(|trigger| ProcessingRun::new(trigger, at));
+    }
+
+    /// The run currently owning the pipeline.
+    #[must_use]
+    pub fn active(&self) -> Option<&ProcessingRun> {
+        self.active.as_ref()
+    }
+
+    /// Triggers whose runs were abandoned after exhausting their attempts.
+    #[must_use]
+    pub fn failed(&self) -> &[Trigger] {
+        &self.failed
+    }
+
+    /// Timing parameters of the pipeline's runs.
+    #[must_use]
+    pub fn config(&self) -> &ProcessingConfig {
+        &self.config
+    }
+
+    /// Whether the pipeline has no further work.
+    #[must_use]
+    pub fn settled(&self) -> bool {
+        self.active.is_none() && self.pending.is_empty()
     }
 }
 
@@ -172,7 +348,7 @@ impl Snapshot {
             stage_attempt: state.stage_attempt,
             party: state.party.clone(),
             phase: state.phase.phase(),
-            status: state.phase.status(),
+            status: state.status(),
             cursor,
         }
     }
@@ -201,6 +377,311 @@ pub struct ChallengeState {
     pub recorded_by: BTreeSet<ClientId>,
     /// When the challenge lost its last active client.
     pub dormant_since: Option<Timestamp>,
+    /// State of the challenge's processing pipeline.
+    pub processing: Processing,
     /// Last applied inbox message.
     pub cursor: MsgId,
+}
+
+impl ChallengeState {
+    /// The challenge's published status.
+    #[must_use]
+    pub fn status(&self) -> ChallengeStatus {
+        match self.phase {
+            PhaseState::Active | PhaseState::Finishing { .. } => ChallengeStatus::InProgress,
+            PhaseState::Terminated => self.processing.status.unwrap_or_else(|| {
+                status_if_finished_now(self.challenge_type, self.stage, self.stage_status)
+            }),
+        }
+    }
+
+    // Whether the challenge has terminated.
+    #[inline]
+    #[must_use]
+    pub fn terminated(&self) -> bool {
+        matches!(self.phase, PhaseState::Terminated)
+    }
+}
+
+/// Status a challenge ending at `stage` with `stage_status` would receive.
+fn status_if_finished_now(
+    challenge_type: ChallengeType,
+    stage: Stage,
+    stage_status: StageStatus,
+) -> ChallengeStatus {
+    let last_stage = challenge_type.last_stage();
+
+    if last_stage.is_some_and(|last| stage > last) {
+        return ChallengeStatus::Completed;
+    }
+
+    match stage_status {
+        StageStatus::Started => ChallengeStatus::Abandoned,
+        StageStatus::Entered => ChallengeStatus::Reset,
+        StageStatus::Wiped => ChallengeStatus::Wiped,
+        StageStatus::Completed => {
+            if last_stage.is_some_and(|last| stage == last) {
+                ChallengeStatus::Completed
+            } else {
+                ChallengeStatus::Reset
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(max_attempts: u32) -> ProcessingConfig {
+        ProcessingConfig {
+            max_attempts,
+            run_timeout: Duration::from_secs(10),
+            retry_backoff: Duration::from_secs(3),
+        }
+    }
+
+    fn trigger(seq: u64, stage: Stage) -> Trigger {
+        Trigger::Stage {
+            seq: JournalSeq(seq),
+            stage,
+            attempt: None,
+        }
+    }
+
+    fn outcome(status: StageStatus) -> ProcessingOutcome {
+        ProcessingOutcome::Stage { status, ticks: 100 }
+    }
+
+    fn error(retriable: bool) -> ProcessingError {
+        ProcessingError {
+            message: "scripted".into(),
+            retriable,
+        }
+    }
+
+    #[test]
+    fn processing_push_activates_when_free_and_queues_others() {
+        let mut processing = Processing::new(config(2));
+        assert!(processing.settled());
+
+        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        assert_eq!(
+            processing.active(),
+            Some(&ProcessingRun {
+                trigger: trigger(3, Stage::TobMaiden),
+                attempts: 0,
+                retriable: true,
+                state: ProcessingState::Idle {
+                    since: Timestamp::from_millis(100)
+                },
+            }),
+        );
+        assert!(!processing.settled());
+
+        processing.push(trigger(7, Stage::TobBloat), Timestamp::from_millis(200));
+        assert_eq!(processing.active().unwrap().trigger.seq(), JournalSeq(3));
+    }
+
+    #[test]
+    fn processing_start_only_responds_to_the_active_trigger() {
+        let mut processing = Processing::new(config(2));
+        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+
+        processing.start(JournalSeq(9), Timestamp::from_millis(150));
+        assert_eq!(processing.active().unwrap().attempts, 0);
+
+        processing.start(JournalSeq(3), Timestamp::from_millis(150));
+        let run = processing.active().unwrap();
+        assert_eq!(run.attempts, 1);
+        assert_eq!(
+            run.state,
+            ProcessingState::Running {
+                since: Timestamp::from_millis(150)
+            },
+        );
+    }
+
+    #[test]
+    fn processing_finish_records_status_and_starts_next() {
+        let mut processing = Processing::new(config(2));
+        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        processing.push(trigger(7, Stage::TobBloat), Timestamp::from_millis(200));
+        processing.start(JournalSeq(3), Timestamp::from_millis(150));
+
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(400),
+            Ok(outcome(StageStatus::Completed)),
+        );
+        assert_eq!(processing.status, Some(ChallengeStatus::Reset));
+        assert_eq!(
+            processing.active(),
+            Some(&ProcessingRun {
+                trigger: trigger(7, Stage::TobBloat),
+                attempts: 0,
+                retriable: true,
+                state: ProcessingState::Idle {
+                    since: Timestamp::from_millis(400)
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn processing_failed_backs_off_until_exhausted() {
+        let mut processing = Processing::new(config(2));
+        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        processing.push(trigger(7, Stage::TobBloat), Timestamp::from_millis(200));
+
+        processing.start(JournalSeq(3), Timestamp::from_millis(150));
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(300),
+            Err(error(true)),
+        );
+        let run = processing.active().unwrap();
+        assert_eq!(run.trigger.seq(), JournalSeq(3));
+        assert_eq!(run.attempts, 1);
+        assert_eq!(
+            run.state,
+            ProcessingState::Idle {
+                since: Timestamp::from_millis(300)
+            },
+        );
+        assert!(!run.exhausted(&config(2)));
+
+        // The final allowed attempt fails; the run is abandoned and the next
+        // trigger activates with no status recorded.
+        processing.start(JournalSeq(3), Timestamp::from_millis(3_300));
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(3_400),
+            Err(error(true)),
+        );
+        assert_eq!(processing.status, None);
+        assert_eq!(processing.failed, vec![trigger(3, Stage::TobMaiden)]);
+        assert_eq!(processing.active().unwrap().trigger.seq(), JournalSeq(7));
+    }
+
+    #[test]
+    fn processing_non_retriable_failure_exhausts_immediately() {
+        let mut processing = Processing::new(config(5));
+        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        processing.start(JournalSeq(3), Timestamp::from_millis(150));
+
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(300),
+            Err(error(false)),
+        );
+        assert_eq!(processing.active(), None);
+        assert_eq!(processing.failed, vec![trigger(3, Stage::TobMaiden)]);
+        assert!(processing.settled());
+    }
+
+    #[test]
+    fn status_stays_in_progress_until_terminated() {
+        let mut state = ChallengeState {
+            challenge_type: ChallengeType::Tob,
+            stage: Stage::TobMaiden,
+            stage_status: StageStatus::Wiped,
+            ..ChallengeState::default()
+        };
+        assert_eq!(state.status(), ChallengeStatus::InProgress);
+
+        state.phase = PhaseState::Finishing {
+            since: Timestamp::from_millis(1_000),
+        };
+        assert_eq!(state.status(), ChallengeStatus::InProgress);
+
+        state.phase = PhaseState::Terminated;
+        assert_eq!(state.status(), ChallengeStatus::Wiped);
+    }
+
+    #[test]
+    fn terminated_status_prefers_processing_outcome() {
+        let mut state = ChallengeState {
+            challenge_type: ChallengeType::Tob,
+            stage: Stage::TobMaiden,
+            stage_status: StageStatus::Wiped,
+            phase: PhaseState::Terminated,
+            processing: Processing::new(config(2)),
+            ..ChallengeState::default()
+        };
+
+        state
+            .processing
+            .push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        state
+            .processing
+            .start(JournalSeq(3), Timestamp::from_millis(150));
+        state.processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(300),
+            Ok(outcome(StageStatus::Completed)),
+        );
+        assert_eq!(state.status(), ChallengeStatus::Reset);
+    }
+
+    #[test]
+    fn status_if_finished_now_reflects_stage_position_and_outcome() {
+        let cases = [
+            (
+                ChallengeType::Tob,
+                Stage::TobMaiden,
+                StageStatus::Started,
+                ChallengeStatus::Abandoned,
+            ),
+            (
+                ChallengeType::Tob,
+                Stage::TobMaiden,
+                StageStatus::Wiped,
+                ChallengeStatus::Wiped,
+            ),
+            (
+                ChallengeType::Tob,
+                Stage::TobBloat,
+                StageStatus::Completed,
+                ChallengeStatus::Reset,
+            ),
+            (
+                ChallengeType::Tob,
+                Stage::TobNylocas,
+                StageStatus::Entered,
+                ChallengeStatus::Reset,
+            ),
+            (
+                ChallengeType::Tob,
+                Stage::TobVerzik,
+                StageStatus::Completed,
+                ChallengeStatus::Completed,
+            ),
+            (
+                ChallengeType::Mokhaiotl,
+                Stage::MokhaiotlDelve8,
+                StageStatus::Started,
+                ChallengeStatus::Abandoned,
+            ),
+            (
+                ChallengeType::Mokhaiotl,
+                Stage::MokhaiotlDelve8plus,
+                StageStatus::Started,
+                ChallengeStatus::Completed,
+            ),
+            (
+                ChallengeType::Mokhaiotl,
+                Stage::MokhaiotlDelve8plus,
+                StageStatus::Wiped,
+                ChallengeStatus::Completed,
+            ),
+        ];
+        for (challenge_type, stage, stage_status, expected) in cases {
+            assert_eq!(
+                status_if_finished_now(challenge_type, stage, stage_status),
+                expected,
+                "{challenge_type:?} at {stage:?} with {stage_status:?}",
+            );
+        }
+    }
 }

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -109,7 +109,9 @@ impl TryFrom<String> for MsgId {
 }
 
 /// Position of an entry in a challenge journal.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub struct JournalSeq(pub u64);
 
 /// Unique identifier for a Blert client.
@@ -194,17 +196,21 @@ pub struct ReportedTimes {
     pub overall: u32,
 }
 
-/// Result from the stage processing pipeline.
+/// Result of a completed processing run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StageProcessingOutcome {
-    pub status: StageStatus,
-    pub ticks: u32,
+pub enum ProcessingOutcome {
+    /// A stage's events were processed.
+    Stage { status: StageStatus, ticks: u32 },
+    /// A challenge creation or termination boundary ran its effects.
+    Boundary,
 }
 
 /// Serializable error from the stage processing pipeline.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StageProcessingError {
+pub struct ProcessingError {
     pub message: String,
+    /// Whether the failure is transient and could succeed on retry.
+    pub retriable: bool,
 }
 
 pub trait StageExt {

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -10,7 +10,7 @@
 mod scenarios;
 
 use core::time::Duration;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::ops::Index;
 use std::slice;
 use std::sync::{Arc, Mutex};
@@ -32,11 +32,15 @@ use super::core::command::{
 };
 use super::core::deadline::LifecycleConfig;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
-use super::core::state::{ChallengePhase, ChallengeState, PublishedClient, Snapshot};
-use super::core::types::{
-    ChallengeMode, ChallengeType, ClientId, MsgId, RecordingType, ReportedTimes, SessionToken,
-    Stage, StageExt, UserId, Uuid,
+use super::core::state::{
+    ChallengePhase, ChallengeState, Processing, PublishedClient, Snapshot, Trigger,
 };
+use super::core::types::{
+    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, MsgId, ProcessingError,
+    ProcessingOutcome, RecordingType, ReportedTimes, SessionToken, Stage, StageExt, StageStatus,
+    UserId, Uuid,
+};
+use crate::processing::{ProcessingRequest, StageProcessor};
 
 /// A scripted client action, issued at a scenario-relative time.
 pub enum Action {
@@ -152,6 +156,12 @@ impl ScenarioResult {
         );
         let (uuid, journal) = self.journals.into_iter().next().unwrap();
         (*uuid, journal)
+    }
+
+    /// Final projected status of the scenario's only challenge.
+    pub fn only_status(&self) -> ChallengeStatus {
+        let (uuid, _) = self.only_challenge();
+        self.projections[&uuid].status
     }
 
     /// A canonical serialization of every challenge's journal.
@@ -283,6 +293,36 @@ pub(crate) struct Collector {
 }
 
 impl Collector {
+    /// The journal of challenge `uuid`, in order.
+    pub fn journal(&self, uuid: Uuid) -> Vec<JournalEntry> {
+        self.journals
+            .lock()
+            .expect("collector lock poisoned")
+            .journals
+            .get(&uuid)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Whether the state of challenge `uuid` has been deleted.
+    pub fn is_deleted(&self, uuid: Uuid) -> bool {
+        self.routing
+            .lock()
+            .expect("collector lock poisoned")
+            .deleted
+            .contains(&uuid)
+    }
+
+    /// How many times the finish of challenge `uuid` has been announced.
+    pub fn finish_announcements(&self, uuid: Uuid) -> usize {
+        self.updates
+            .lock()
+            .expect("collector lock poisoned")
+            .iter()
+            .filter(|(id, update)| *id == uuid && *update == ChallengeServerUpdate::Finish)
+            .count()
+    }
+
     fn collector_claim(&self, uuid: Uuid) -> CollectorClaim {
         CollectorClaim {
             uuid,
@@ -637,19 +677,107 @@ impl ChallengeClaim for CollectorClaim {
     }
 }
 
+/// A scripted resolution of a processing run.
+pub(crate) enum ProcessingAttempt {
+    /// Resolve with `result` after a delay in virtual milliseconds.
+    Resolve(u64, Result<ProcessingOutcome, ProcessingError>),
+    /// Hang until aborted.
+    Hang,
+}
+
+/// A scripted [`StageProcessor`], resolving each attempt with the next
+/// scripted result in order. Attempts past the script's end complete
+/// instantly.
+#[derive(Default)]
+pub(crate) struct ScriptedProcessor {
+    script: Mutex<VecDeque<ProcessingAttempt>>,
+    requests: Mutex<Vec<ProcessingRequest>>,
+}
+
+impl ScriptedProcessor {
+    pub fn new(script: Vec<ProcessingAttempt>) -> Arc<Self> {
+        Arc::new(ScriptedProcessor {
+            script: Mutex::new(script.into()),
+            requests: Mutex::default(),
+        })
+    }
+
+    /// Every processing request received, in arrival order.
+    pub fn requests(&self) -> Vec<ProcessingRequest> {
+        self.requests
+            .lock()
+            .expect("processor lock poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl StageProcessor for ScriptedProcessor {
+    async fn process(
+        &self,
+        request: ProcessingRequest,
+    ) -> Result<ProcessingOutcome, ProcessingError> {
+        self.requests
+            .lock()
+            .expect("processor lock poisoned")
+            .push(request);
+        let attempt = self
+            .script
+            .lock()
+            .expect("processor lock poisoned")
+            .pop_front();
+        match attempt {
+            Some(ProcessingAttempt::Resolve(delay_ms, result)) => {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                result
+            }
+            Some(ProcessingAttempt::Hang) => std::future::pending().await,
+            None => Ok(match request.trigger {
+                Trigger::Stage { .. } => ProcessingOutcome::Stage {
+                    status: StageStatus::Completed,
+                    ticks: 0,
+                },
+                Trigger::Create { .. } | Trigger::Finish { .. } => ProcessingOutcome::Boundary,
+            }),
+        }
+    }
+}
+
 /// Runs a scenario to completion under default lifecycle timings and checks
 /// structural invariants.
 pub async fn run(scenario: Scenario) -> ScenarioResult {
-    run_with(LifecycleConfig::default(), scenario).await
+    run_with(RunOptions::default(), scenario).await
 }
 
-/// Runs a scenario to completion under specific lifecycle timings and checks
+#[derive(Default)]
+pub struct RunOptions {
+    /// Lifecycle timings for every challenge in the scenario.
+    pub config: LifecycleConfig,
+    /// Serves the challenges' stage processing runs.
+    pub processor: Option<Arc<dyn StageProcessor>>,
+}
+
+impl From<LifecycleConfig> for RunOptions {
+    fn from(config: LifecycleConfig) -> Self {
+        RunOptions {
+            config,
+            processor: None,
+        }
+    }
+}
+
+/// Runs a scenario to completion under specific options and checks
 /// structural invariants.
-pub async fn run_with(config: LifecycleConfig, scenario: Scenario) -> ScenarioResult {
+pub async fn run_with(options: impl Into<RunOptions>, scenario: Scenario) -> ScenarioResult {
+    let RunOptions { config, processor } = options.into();
     let collector = Collector::default();
     let (_tx, rx) = watch::channel(false);
-    let coordinator =
-        Arc::new(Coordinator::with_store(Arc::new(collector.clone()), rx).with_config(config));
+    let mut coordinator =
+        Coordinator::with_store(Arc::new(collector.clone()), rx).with_config(config.clone());
+    if let Some(processor) = processor {
+        coordinator = coordinator.with_processor(processor);
+    }
+    let coordinator = Arc::new(coordinator);
     let started = Instant::now();
 
     let mut identities = Vec::new();
@@ -735,7 +863,7 @@ pub async fn run_with(config: LifecycleConfig, scenario: Scenario) -> ScenarioRe
         inboxes,
         deleted,
     };
-    check_invariants(&result);
+    check_invariants(&result, &config);
     result
 }
 
@@ -862,11 +990,11 @@ fn current_challenge(identity: &Identity, current_uuid: &Mutex<Option<Uuid>>) ->
 }
 
 #[allow(clippy::too_many_lines)]
-fn check_invariants(result: &ScenarioResult) {
+fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
     for (uuid, journal) in &result.journals {
         let terminated = journal
-            .last()
-            .is_some_and(|entry| matches!(entry.event, LifecycleEvent::ChallengeTerminated { .. }));
+            .iter()
+            .any(|entry| matches!(entry.event, LifecycleEvent::ChallengeTerminated { .. }));
         if terminated {
             assert!(
                 !result.snapshots.contains_key(uuid),
@@ -879,10 +1007,22 @@ fn check_invariants(result: &ScenarioResult) {
             );
         }
 
-        // A terminated challenge is deleted and announces its finish exactly once.
+        // Compare computed state to what the journal produces.
+        let mut folded = ChallengeState {
+            uuid: *uuid,
+            processing: Processing::new(config.processing.clone()),
+            ..ChallengeState::default()
+        };
+        for entry in journal {
+            apply(&mut folded, entry.clone());
+        }
+
+        // A challenge whose processing completed after termination is deleted
+        // and announces its finish exactly once.
+        let concluded = terminated && folded.processing.settled();
         assert_eq!(
             result.deleted.contains(uuid),
-            terminated,
+            concluded,
             "deletion mismatch: {uuid}",
         );
         let finishes = result
@@ -892,18 +1032,9 @@ fn check_invariants(result: &ScenarioResult) {
             .count();
         assert_eq!(
             finishes,
-            usize::from(terminated),
+            usize::from(concluded),
             "finish announcements: {uuid}",
         );
-
-        // Compare computed state to what the journal produces.
-        let mut folded = ChallengeState {
-            uuid: *uuid,
-            ..ChallengeState::default()
-        };
-        for entry in journal {
-            apply(&mut folded, entry.clone());
-        }
 
         if let Some(snapshot) = result.snapshots.get(uuid) {
             assert_eq!(
@@ -933,7 +1064,7 @@ fn check_invariants(result: &ScenarioResult) {
         );
         assert_eq!(
             projection.status,
-            folded.phase.status(),
+            folded.status(),
             "projected status: {uuid}",
         );
         assert_eq!(projection.stage, folded.stage, "projected stage: {uuid}");
@@ -957,20 +1088,43 @@ fn check_invariants(result: &ScenarioResult) {
         }
 
         let mut seals = Vec::new();
-        for (position, entry) in journal.iter().enumerate() {
+        let mut trigger_seqs = HashSet::new();
+        let mut terminated = false;
+
+        for entry in journal {
+            let processing_event = matches!(
+                entry.event,
+                LifecycleEvent::ProcessingStarted { .. }
+                    | LifecycleEvent::ProcessingFinished { .. }
+                    | LifecycleEvent::ProcessingFailed { .. }
+                    | LifecycleEvent::ProcessingTimedOut { .. }
+            );
+            assert!(
+                !terminated || processing_event,
+                "non-processing entry recorded after termination: {uuid}",
+            );
+            terminated |= matches!(entry.event, LifecycleEvent::ChallengeTerminated { .. });
+
             match &entry.event {
+                LifecycleEvent::ChallengeCreated { .. }
+                | LifecycleEvent::ChallengeTerminated { .. } => {
+                    trigger_seqs.insert(entry.seq);
+                }
                 LifecycleEvent::StageSealed { stage, attempt, .. } => {
                     assert!(
                         !seals.contains(&(*stage, *attempt)),
                         "stage {stage:?} attempt {attempt:?} sealed twice: {uuid}",
                     );
                     seals.push((*stage, *attempt));
+                    trigger_seqs.insert(entry.seq);
                 }
-                LifecycleEvent::ChallengeTerminated { .. } => {
-                    assert_eq!(
-                        position,
-                        journal.len() - 1,
-                        "entries recorded after termination: {uuid}",
+                LifecycleEvent::ProcessingStarted { trigger }
+                | LifecycleEvent::ProcessingFinished { trigger, .. }
+                | LifecycleEvent::ProcessingFailed { trigger, .. }
+                | LifecycleEvent::ProcessingTimedOut { trigger } => {
+                    assert!(
+                        trigger_seqs.contains(trigger),
+                        "processing entry references no trigger: {uuid}",
                     );
                 }
                 _ => {}

--- a/challenge-harder/src/lifecycle/sim/scenarios/challenge_end.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/challenge_end.rs
@@ -33,14 +33,7 @@ async fn each_finish_extends_the_grace_period() {
     assert_eq!(
         journal[9..],
         vec![
-            entry(
-                9,
-                1_100,
-                cmd(8),
-                LifecycleEvent::ChallengeFinishing {
-                    status: ChallengeStatus::Wiped,
-                },
-            ),
+            entry(9, 1_100, cmd(8), LifecycleEvent::ChallengeFinishing,),
             entry(
                 10,
                 1_100,
@@ -88,10 +81,7 @@ async fn each_finish_extends_the_grace_period() {
                 14,
                 8_500,
                 cmd(10),
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Wiped,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ),
         ],
     );
@@ -118,14 +108,7 @@ async fn unfinished_client_cut_off_after_grace_period() {
     assert_eq!(
         journal[7..],
         vec![
-            entry(
-                7,
-                1_100,
-                cmd(6),
-                LifecycleEvent::ChallengeFinishing {
-                    status: ChallengeStatus::Wiped,
-                },
-            ),
+            entry(7, 1_100, cmd(6), LifecycleEvent::ChallengeFinishing,),
             entry(
                 8,
                 1_100,
@@ -159,10 +142,7 @@ async fn unfinished_client_cut_off_after_grace_period() {
                 11,
                 8_000,
                 Cause::Deadline(DeadlineKind::ChallengeEnd),
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Wiped,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ),
         ],
     );

--- a/challenge-harder/src/lifecycle/sim/scenarios/client_status.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/client_status.rs
@@ -101,11 +101,8 @@ fn client_finished(client: i64) -> LifecycleEvent {
     }
 }
 
-fn terminated(status: ChallengeStatus) -> LifecycleEvent {
-    LifecycleEvent::ChallengeTerminated {
-        status,
-        empty: false,
-    }
+fn terminated() -> LifecycleEvent {
+    LifecycleEvent::ChallengeTerminated { empty: false }
 }
 
 #[tokio::test(start_paused = true)]
@@ -154,10 +151,11 @@ async fn disconnect_without_finish_cleans_up_after_reconnection_window() {
                 9,
                 300_900,
                 fired(DeadlineKind::CleanupDisconnect),
-                terminated(ChallengeStatus::Abandoned)
+                terminated()
             ),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Abandoned);
 }
 
 #[tokio::test(start_paused = true)]
@@ -240,9 +238,10 @@ async fn rejoin_within_window_resumes_challenge() {
             ),
             entry(16, 62_000, cmd(10), sealed(Stage::TobNylocas, None, false)),
             entry(17, 62_100, cmd(11), client_finished(2)),
-            entry(18, 62_100, cmd(11), terminated(ChallengeStatus::Wiped)),
+            entry(18, 62_100, cmd(11), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
 #[tokio::test(start_paused = true)]
@@ -292,10 +291,11 @@ async fn logout_without_return_cleans_up_after_inactivity_window() {
                 10,
                 905_000,
                 fired(DeadlineKind::CleanupAllIdle),
-                terminated(ChallengeStatus::Abandoned)
+                terminated()
             ),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Abandoned);
 }
 
 #[tokio::test(start_paused = true)]
@@ -352,9 +352,10 @@ async fn logout_and_return_resumes_challenge() {
             ),
             entry(11, 10_400, cmd(7), sealed(Stage::InfernoWave2, None, false)),
             entry(12, 10_500, cmd(8), client_finished(1)),
-            entry(13, 10_500, cmd(8), terminated(ChallengeStatus::Wiped)),
+            entry(13, 10_500, cmd(8), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
 #[tokio::test(start_paused = true)]
@@ -395,10 +396,11 @@ async fn wipe_then_crash_before_finish_is_wiped() {
                 7,
                 300_700,
                 fired(DeadlineKind::CleanupDisconnect),
-                terminated(ChallengeStatus::Wiped)
+                terminated()
             ),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
 #[tokio::test(start_paused = true)]
@@ -485,10 +487,11 @@ async fn deep_delve_disconnect_completes() {
                 13,
                 301_200,
                 fired(DeadlineKind::CleanupDisconnect),
-                terminated(ChallengeStatus::Completed)
+                terminated()
             ),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Completed);
 }
 
 #[tokio::test(start_paused = true)]
@@ -545,20 +548,14 @@ async fn partner_finish_between_idle_and_return() {
             ),
             entry(8, 520, cmd(6), sealed(Stage::TobMaiden, None, false)),
             entry(9, 1_000, cmd(7), idled(1)),
-            entry(
-                10,
-                8_000,
-                cmd(8),
-                LifecycleEvent::ChallengeFinishing {
-                    status: ChallengeStatus::Wiped,
-                }
-            ),
+            entry(10, 8_000, cmd(8), LifecycleEvent::ChallengeFinishing),
             entry(11, 8_000, cmd(8), client_finished(2)),
             entry(12, 8_100, cmd(9), activated(1)),
             entry(13, 8_200, cmd(10), client_finished(1)),
-            entry(14, 8_200, cmd(10), terminated(ChallengeStatus::Wiped)),
+            entry(14, 8_200, cmd(10), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
 #[tokio::test(start_paused = true)]
@@ -623,9 +620,10 @@ async fn partial_disconnect_does_not_arm_cleanup() {
             ),
             entry(12, 345_000, cmd(8), sealed(Stage::TobBloat, None, false)),
             entry(13, 345_500, cmd(9), client_finished(2)),
-            entry(14, 345_500, cmd(9), terminated(ChallengeStatus::Wiped)),
+            entry(14, 345_500, cmd(9), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
 #[tokio::test(start_paused = true)]
@@ -677,7 +675,7 @@ async fn rejoin_after_window_starts_fresh() {
                 5,
                 300_700,
                 fired(DeadlineKind::CleanupDisconnect),
-                terminated(ChallengeStatus::Abandoned)
+                terminated()
             ),
         ],
     );
@@ -702,7 +700,13 @@ async fn rejoin_after_window_starts_fresh() {
             ),
             entry(5, 500, cmd(3), sealed(Stage::TobMaiden, None, false)),
             entry(6, 600, cmd(4), client_finished(2)),
-            entry(7, 600, cmd(4), terminated(ChallengeStatus::Wiped)),
+            entry(7, 600, cmd(4), terminated()),
         ],
     );
+
+    assert_eq!(
+        result.projections[&first].status,
+        ChallengeStatus::Abandoned
+    );
+    assert_eq!(result.projections[&second].status, ChallengeStatus::Wiped);
 }

--- a/challenge-harder/src/lifecycle/sim/scenarios/creation.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/creation.rs
@@ -146,13 +146,12 @@ async fn terminated_incumbent_is_superseded() {
     assert_ne!(first, second);
 
     // First challenge ended before any stage began.
-    assert!(result.journals[&first].iter().any(|e| matches!(
-        e.event,
-        LifecycleEvent::ChallengeTerminated {
-            status: ChallengeStatus::Reset,
-            ..
-        },
-    )));
+    assert!(
+        result.journals[&first]
+            .iter()
+            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated { .. },))
+    );
+    assert_eq!(result.projections[&first].status, ChallengeStatus::Reset);
 }
 
 #[tokio::test(start_paused = true)]
@@ -197,10 +196,7 @@ async fn finishing_challenge_is_not_joined() {
                 6,
                 5_100,
                 Cause::Deadline(DeadlineKind::ChallengeEnd),
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Reset,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ),
         ],
     );

--- a/challenge-harder/src/lifecycle/sim/scenarios/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/mod.rs
@@ -6,6 +6,7 @@ mod challenge_end;
 mod client_status;
 mod creation;
 mod determinism;
+mod processing;
 mod progression;
 mod recovery;
 mod rejoin;

--- a/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
@@ -1,0 +1,738 @@
+//! Stage processing machinery scenarios, driven by a scripted processor.
+
+use std::sync::Arc;
+
+use tokio::sync::watch;
+
+use super::*;
+use crate::lifecycle::challenge::{ChallengeServerUpdate, ChallengeStore, run_challenge};
+use crate::lifecycle::coordinator::Coordinator;
+use crate::lifecycle::core::command::{Create, Finish, Update};
+use crate::lifecycle::core::deadline::{DeadlineKind, LifecycleConfig};
+use crate::lifecycle::core::state::{ProcessingConfig, Trigger};
+use crate::lifecycle::core::types::{ChallengeStatus, ProcessingError, ProcessingOutcome, Uuid};
+use crate::lifecycle::sim::{
+    Collector, ProcessingAttempt, RunOptions, Scenario, ScriptedProcessor, run_with,
+};
+use crate::processing::StageProcessor;
+
+use core::time::Duration;
+
+fn config() -> LifecycleConfig {
+    LifecycleConfig {
+        processing: ProcessingConfig {
+            max_attempts: 2,
+            run_timeout: Duration::from_secs(10),
+            retry_backoff: Duration::from_secs(3),
+        },
+        ..LifecycleConfig::default()
+    }
+}
+
+fn options(processor: &Arc<ScriptedProcessor>) -> RunOptions {
+    RunOptions {
+        config: config(),
+        processor: Some(Arc::clone(processor) as Arc<dyn StageProcessor>),
+    }
+}
+
+fn solo_hmt_start() -> Action {
+    Action::Start {
+        challenge_type: ChallengeType::Tob,
+        mode: ChallengeMode::TobHard,
+        party: vec!["aSaradomin".into()],
+        stage: Stage::TobMaiden,
+    }
+}
+
+fn outcome(status: StageStatus, ticks: u32) -> ProcessingOutcome {
+    ProcessingOutcome::Stage { status, ticks }
+}
+
+fn boundary() -> ProcessingAttempt {
+    ProcessingAttempt::Resolve(0, Ok(ProcessingOutcome::Boundary))
+}
+
+fn retriable_failure() -> ProcessingError {
+    ProcessingError {
+        message: "scripted".into(),
+        retriable: true,
+    }
+}
+
+fn started(trigger: u64) -> LifecycleEvent {
+    LifecycleEvent::ProcessingStarted {
+        trigger: JournalSeq(trigger),
+    }
+}
+
+fn finished(trigger: u64, outcome: ProcessingOutcome) -> LifecycleEvent {
+    LifecycleEvent::ProcessingFinished {
+        trigger: JournalSeq(trigger),
+        outcome,
+    }
+}
+
+fn processing(trigger: u64) -> Cause {
+    Cause::Processing(JournalSeq(trigger))
+}
+
+/// A solo `ToB` wiping on Maiden at 1s, sealing the stage as journal entry 5.
+fn solo_maiden_wipe(finish_at: u64) -> Scenario {
+    Scenario {
+        clients: vec![
+            Client::participant("a", 1)
+                .at(0, solo_hmt_start())
+                .at(10, report(Stage::TobMaiden, StageStatus::Started))
+                .at(1_000, report(Stage::TobMaiden, StageStatus::Wiped))
+                .at(finish_at, finish(false)),
+        ],
+        run_until: finish_at + 30_000,
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn sealed_stage_processes_and_journals_its_run() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(500, Ok(outcome(StageStatus::Completed, 237))),
+    ]);
+    let result = run_with(options(&processor), solo_maiden_wipe(2_000)).await;
+
+    let (_, journal) = result.only_challenge();
+    assert_eq!(
+        journal[2..4],
+        vec![
+            entry(
+                2,
+                0,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(0)
+            ),
+            entry(
+                3,
+                0,
+                processing(0),
+                finished(0, ProcessingOutcome::Boundary)
+            ),
+        ],
+    );
+    assert_eq!(
+        journal[6..],
+        vec![
+            entry(
+                6,
+                1_000,
+                cmd(3),
+                reported(1, Stage::TobMaiden, StageStatus::Wiped)
+            ),
+            entry(
+                7,
+                1_000,
+                cmd(3),
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: false,
+                },
+            ),
+            entry(
+                8,
+                1_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(7)
+            ),
+            entry(
+                9,
+                1_500,
+                processing(7),
+                finished(7, outcome(StageStatus::Completed, 237)),
+            ),
+            entry(
+                10,
+                2_000,
+                cmd(4),
+                LifecycleEvent::ClientFinished {
+                    client_id: client_id(1),
+                    definitive: true,
+                    soft: false,
+                    times: None,
+                },
+            ),
+            entry(
+                11,
+                2_000,
+                cmd(4),
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+            entry(
+                12,
+                2_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(11)
+            ),
+            entry(
+                13,
+                2_000,
+                processing(11),
+                finished(11, ProcessingOutcome::Boundary),
+            ),
+        ],
+    );
+
+    assert_eq!(result.only_status(), ChallengeStatus::Reset);
+
+    let triggers: Vec<Trigger> = processor.requests().iter().map(|r| r.trigger).collect();
+    assert_eq!(
+        triggers,
+        vec![
+            Trigger::Create { seq: JournalSeq(0) },
+            Trigger::Stage {
+                seq: JournalSeq(7),
+                stage: Stage::TobMaiden,
+                attempt: None,
+            },
+            Trigger::Finish {
+                seq: JournalSeq(11)
+            },
+        ],
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn timed_out_run_retries_after_backoff() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Hang,
+        ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 180))),
+    ]);
+    let result = run_with(options(&processor), solo_maiden_wipe(20_000)).await;
+
+    let (_, journal) = result.only_challenge();
+    assert_eq!(
+        journal[8..11],
+        vec![
+            entry(
+                8,
+                1_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(7)
+            ),
+            entry(
+                9,
+                11_000,
+                Cause::Deadline(DeadlineKind::ProcessingTimeout),
+                LifecycleEvent::ProcessingTimedOut {
+                    trigger: JournalSeq(7),
+                },
+            ),
+            entry(
+                10,
+                14_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(7)
+            ),
+        ],
+    );
+    assert_eq!(
+        journal[11].event,
+        finished(7, outcome(StageStatus::Wiped, 180))
+    );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
+    assert_eq!(processor.requests().len(), 4);
+}
+
+#[tokio::test(start_paused = true)]
+async fn run_gives_up_after_max_retries_and_the_challenge_concludes() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(0, Err(retriable_failure())),
+        ProcessingAttempt::Resolve(0, Err(retriable_failure())),
+    ]);
+    let result = run_with(options(&processor), solo_maiden_wipe(10_000)).await;
+
+    let (uuid, journal) = result.only_challenge();
+    assert_eq!(
+        journal[8..12],
+        vec![
+            entry(
+                8,
+                1_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(7)
+            ),
+            entry(
+                9,
+                1_000,
+                processing(7),
+                LifecycleEvent::ProcessingFailed {
+                    trigger: JournalSeq(7),
+                    error: retriable_failure(),
+                },
+            ),
+            entry(
+                10,
+                4_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(7)
+            ),
+            entry(
+                11,
+                4_000,
+                processing(7),
+                LifecycleEvent::ProcessingFailed {
+                    trigger: JournalSeq(7),
+                    error: retriable_failure(),
+                },
+            ),
+        ],
+    );
+
+    // With no processed outcome, the status falls back to the challenge's
+    // own reported progress, and the challenge still concludes.
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
+    assert!(result.deleted.contains(&uuid));
+    assert_eq!(processor.requests().len(), 4);
+}
+
+#[tokio::test(start_paused = true)]
+async fn non_retriable_failure_gives_up_immediately() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(
+            0,
+            Err(ProcessingError {
+                message: "scripted".into(),
+                retriable: false,
+            }),
+        ),
+    ]);
+    let result = run_with(options(&processor), solo_maiden_wipe(5_000)).await;
+
+    let (uuid, _) = result.only_challenge();
+    assert!(result.deleted.contains(&uuid));
+    assert_eq!(processor.requests().len(), 3);
+}
+
+#[tokio::test(start_paused = true)]
+async fn finalization_waits_for_processing_to_finish_after_termination() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(5_000, Ok(outcome(StageStatus::Completed, 237))),
+    ]);
+    let result = run_with(options(&processor), solo_maiden_wipe(2_000)).await;
+
+    let (uuid, journal) = result.only_challenge();
+    assert_eq!(
+        journal[10..],
+        vec![
+            entry(
+                10,
+                2_000,
+                cmd(4),
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+            entry(
+                11,
+                6_000,
+                processing(7),
+                finished(7, outcome(StageStatus::Completed, 237)),
+            ),
+            entry(
+                12,
+                6_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(10)
+            ),
+            entry(
+                13,
+                6_000,
+                processing(10),
+                finished(10, ProcessingOutcome::Boundary),
+            ),
+        ],
+    );
+
+    assert!(result.deleted.contains(&uuid));
+    assert_eq!(result.updates, vec![(uuid, ChallengeServerUpdate::Finish)],);
+    assert_eq!(result.only_status(), ChallengeStatus::Reset);
+}
+
+#[tokio::test(start_paused = true)]
+async fn queued_trigger_processes_after_the_active_run() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(2_000, Ok(outcome(StageStatus::Completed, 100))),
+        ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 50))),
+    ]);
+    let result = run_with(
+        options(&processor),
+        Scenario {
+            clients: vec![
+                Client::participant("a", 1)
+                    .at(0, solo_hmt_start())
+                    .at(10, report(Stage::TobMaiden, StageStatus::Started))
+                    .at(1_000, report(Stage::TobMaiden, StageStatus::Completed))
+                    .at(1_100, report(Stage::TobBloat, StageStatus::Started))
+                    .at(1_600, report(Stage::TobBloat, StageStatus::Wiped))
+                    .at(10_000, finish(false)),
+            ],
+            run_until: 40_000,
+        },
+    )
+    .await;
+
+    // The second stage waits for the first's run to finish before starting.
+    let (_, journal) = result.only_challenge();
+    let processing_events: Vec<&JournalEntry> = journal
+        .iter()
+        .filter(|entry| {
+            matches!(entry.caused_by, Cause::Processing(_))
+                || matches!(
+                    entry.caused_by,
+                    Cause::Deadline(
+                        DeadlineKind::ProcessingRetry | DeadlineKind::ProcessingTimeout
+                    )
+                )
+        })
+        .collect();
+    assert_eq!(processing_events.len(), 8);
+    assert_eq!(processing_events[0].event, started(0));
+    assert_eq!(processing_events[0].at, Timestamp::ZERO);
+    assert_eq!(
+        processing_events[1].event,
+        finished(0, ProcessingOutcome::Boundary)
+    );
+    assert_eq!(processing_events[2].event, started(7));
+    assert_eq!(processing_events[2].at, Timestamp::from_millis(1_000));
+    assert_eq!(
+        processing_events[3].event,
+        finished(7, outcome(StageStatus::Completed, 100)),
+    );
+    assert_eq!(processing_events[3].at, Timestamp::from_millis(3_000));
+    assert_eq!(processing_events[4].at, Timestamp::from_millis(3_000));
+    assert_eq!(
+        processing_events[5].event,
+        finished(12, outcome(StageStatus::Wiped, 50)),
+    );
+    assert_eq!(processing_events[6].event, started(17));
+    assert_eq!(
+        processing_events[7].event,
+        finished(17, ProcessingOutcome::Boundary)
+    );
+
+    let triggers: Vec<Trigger> = processor.requests().iter().map(|r| r.trigger).collect();
+    assert_eq!(
+        triggers,
+        vec![
+            Trigger::Create { seq: JournalSeq(0) },
+            Trigger::Stage {
+                seq: JournalSeq(7),
+                stage: Stage::TobMaiden,
+                attempt: None,
+            },
+            Trigger::Stage {
+                seq: JournalSeq(12),
+                stage: Stage::TobBloat,
+                attempt: None,
+            },
+            Trigger::Finish {
+                seq: JournalSeq(17)
+            },
+        ],
+    );
+
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
+}
+
+#[tokio::test(start_paused = true)]
+async fn late_commands_post_termination_while_processing() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(5_000, Ok(outcome(StageStatus::Completed, 237))),
+    ]);
+    let result = run_with(
+        options(&processor),
+        Scenario {
+            clients: vec![
+                Client::participant("a", 1)
+                    .at(0, solo_hmt_start())
+                    .at(10, report(Stage::TobMaiden, StageStatus::Started))
+                    .at(1_000, report(Stage::TobMaiden, StageStatus::Wiped))
+                    .at(2_000, finish(false))
+                    // Lands while the stage run is still processing.
+                    .at(3_000, report(Stage::TobBloat, StageStatus::Started)),
+            ],
+            run_until: 40_000,
+        },
+    )
+    .await;
+
+    // The late report journals nothing, but its consumption advances the
+    // published cursor so its sender's applied wait resolves.
+    let (uuid, journal) = result.only_challenge();
+    assert_eq!(
+        journal[10..],
+        vec![
+            entry(
+                10,
+                2_000,
+                cmd(4),
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+            entry(
+                11,
+                6_000,
+                processing(7),
+                finished(7, outcome(StageStatus::Completed, 237)),
+            ),
+            entry(
+                12,
+                6_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(10)
+            ),
+            entry(
+                13,
+                6_000,
+                processing(10),
+                finished(10, ProcessingOutcome::Boundary),
+            ),
+        ],
+    );
+    assert!(journal.iter().all(|e| e.caused_by != cmd(5)));
+    assert_eq!(result.projections[&uuid].cursor, MsgId::sequence(5));
+    assert!(result.deleted.contains(&uuid));
+}
+
+#[tokio::test(start_paused = true)]
+async fn failed_finish_run_concludes_afterwards() {
+    let processor = ScriptedProcessor::new(vec![
+        boundary(),
+        ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 60))),
+        ProcessingAttempt::Resolve(0, Err(retriable_failure())),
+        ProcessingAttempt::Resolve(0, Err(retriable_failure())),
+    ]);
+    let result = run_with(options(&processor), solo_maiden_wipe(2_000)).await;
+
+    let (uuid, journal) = result.only_challenge();
+    assert_eq!(
+        journal[12..],
+        vec![
+            entry(
+                12,
+                2_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(11)
+            ),
+            entry(
+                13,
+                2_000,
+                processing(11),
+                LifecycleEvent::ProcessingFailed {
+                    trigger: JournalSeq(11),
+                    error: retriable_failure(),
+                },
+            ),
+            entry(
+                14,
+                5_000,
+                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                started(11)
+            ),
+            entry(
+                15,
+                5_000,
+                processing(11),
+                LifecycleEvent::ProcessingFailed {
+                    trigger: JournalSeq(11),
+                    error: retriable_failure(),
+                },
+            ),
+        ],
+    );
+
+    assert!(result.deleted.contains(&uuid));
+    assert_eq!(result.updates, vec![(uuid, ChallengeServerUpdate::Finish)]);
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
+}
+
+/// A fresh runtime starting with a paused clock. Dropping it kills every
+/// spawned actor, as a server crash would.
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .build()
+        .expect("runtime builds")
+}
+
+async fn claim_only(store: &Collector, uuid: Uuid) -> crate::lifecycle::challenge::Claim {
+    let mut claims = store
+        .claim_unowned(2, &[])
+        .await
+        .expect("claim should succeed");
+    assert_eq!(claims.len(), 1, "expected exactly one claimable challenge");
+    let claim = claims.remove(0);
+    assert_eq!(claim.uuid(), uuid);
+    claim
+}
+
+fn hmt_creat() -> Create {
+    Create {
+        user_id: UserId(1),
+        client_id: ClientId(10),
+        session_token: "tok1".into(),
+        plugin_version: "0.9.14".into(),
+        runelite_version: "1.12.31.1".into(),
+        challenge_type: ChallengeType::Tob,
+        mode: ChallengeMode::TobHard,
+        party: vec!["aSaradomin".into()],
+        stage: Stage::TobMaiden,
+        recording_type: RecordingType::Participant,
+    }
+}
+
+fn maiden_wipe() -> Update {
+    Update {
+        user_id: UserId(1),
+        client_id: ClientId(10),
+        session_token: "tok1".into(),
+        mode: None,
+        stage: Some(StageProgress {
+            stage: Stage::TobMaiden,
+            status: StageStatus::Wiped,
+        }),
+        party: None,
+    }
+}
+
+fn finish_request() -> Finish {
+    Finish {
+        user_id: UserId(1),
+        client_id: ClientId(10),
+        session_token: "tok1".into(),
+        times: None,
+        soft: false,
+    }
+}
+
+async fn wipe_maiden(coordinator: &Coordinator) -> Uuid {
+    let snapshot = coordinator
+        .create_or_join_challenge(hmt_creat())
+        .await
+        .expect("create should apply");
+    coordinator
+        .update(snapshot.uuid, maiden_wipe())
+        .await
+        .expect("update should apply");
+    snapshot.uuid
+}
+
+#[test]
+fn killed_run_respawns_on_resume() {
+    let collector = Collector::default();
+    let (_tx, rx) = watch::channel(false);
+
+    // The first server's stage run hangs, and the server dies mid-attempt.
+    let store = collector.clone();
+    let r1 = rx.clone();
+    let first = ScriptedProcessor::new(vec![boundary(), ProcessingAttempt::Hang]);
+    let processor = Arc::clone(&first) as Arc<dyn StageProcessor>;
+    let uuid = runtime().block_on(async move {
+        let coordinator = Coordinator::with_store(Arc::new(store), r1)
+            .with_config(config())
+            .with_processor(processor);
+        let uuid = wipe_maiden(&coordinator).await;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        uuid
+    });
+
+    let journal = collector.journal(uuid);
+    assert_eq!(journal.last().unwrap().event, started(5));
+    assert_eq!(first.requests().len(), 2);
+
+    // A new server resumes and the journal's unfinished run respawns without
+    // repeating its `Started` entry.
+    let second = ScriptedProcessor::new(vec![ProcessingAttempt::Resolve(
+        0,
+        Ok(outcome(StageStatus::Wiped, 60)),
+    )]);
+    let store = collector.clone();
+    let r2 = rx.clone();
+    let processor = Arc::clone(&second) as Arc<dyn StageProcessor>;
+    runtime().block_on(async move {
+        let claim = claim_only(&store, uuid).await;
+        tokio::spawn(run_challenge(config(), claim, Some(processor), r2));
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+
+    let journal = collector.journal(uuid);
+    let starts = journal.iter().filter(|e| e.event == started(5)).count();
+    assert_eq!(starts, 1);
+    assert_eq!(
+        journal.last().unwrap().event,
+        finished(5, outcome(StageStatus::Wiped, 60)),
+    );
+    assert_eq!(second.requests().len(), 1);
+}
+
+#[test]
+fn final_processing_concludes_exactly_once_on_resume() {
+    let collector = Collector::default();
+    let (_tx, rx) = watch::channel(false);
+
+    // The challenge terminates while its last stage run hangs; the server
+    // dies before the run settles.
+    let store = collector.clone();
+    let r1 = rx.clone();
+    let first = ScriptedProcessor::new(vec![boundary(), ProcessingAttempt::Hang]);
+    let processor = Arc::clone(&first) as Arc<dyn StageProcessor>;
+    let uuid = runtime().block_on(async move {
+        let coordinator = Coordinator::with_store(Arc::new(store), r1)
+            .with_config(config())
+            .with_processor(processor);
+        let uuid = wipe_maiden(&coordinator).await;
+        coordinator
+            .finish(uuid, finish_request())
+            .await
+            .expect("finish should queue");
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        uuid
+    });
+
+    let journal = collector.journal(uuid);
+    assert!(
+        journal
+            .iter()
+            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated { .. })),
+    );
+    assert_eq!(collector.finish_announcements(uuid), 0);
+    assert!(!collector.is_deleted(uuid));
+
+    // Resume and finish processing.
+    let second = ScriptedProcessor::new(vec![ProcessingAttempt::Resolve(
+        0,
+        Ok(outcome(StageStatus::Wiped, 60)),
+    )]);
+    let store = collector.clone();
+    let r2 = rx.clone();
+    let processor = Arc::clone(&second) as Arc<dyn StageProcessor>;
+    runtime().block_on(async move {
+        run_challenge(
+            config(),
+            claim_only(&store, uuid).await,
+            Some(processor),
+            r2,
+        )
+        .await;
+    });
+
+    assert_eq!(collector.finish_announcements(uuid), 1);
+    assert!(collector.is_deleted(uuid));
+    assert_eq!(
+        collector.journal(uuid).last().unwrap().event,
+        finished(8, ProcessingOutcome::Boundary),
+    );
+    assert_eq!(second.requests().len(), 2);
+}

--- a/challenge-harder/src/lifecycle/sim/scenarios/progression.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/progression.rs
@@ -100,10 +100,7 @@ async fn solo_colosseum_wipe_full_trace() {
                 11,
                 1_000,
                 cmd(6),
-                LifecycleEvent::ChallengeTerminated {
-                    status: ChallengeStatus::Wiped,
-                    empty: false,
-                },
+                LifecycleEvent::ChallengeTerminated { empty: false },
             ),
         ],
     );

--- a/challenge-harder/src/lifecycle/sim/scenarios/recovery.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/recovery.rs
@@ -156,6 +156,7 @@ fn killed_server_resumes_windows_with_time_to_run() {
         tokio::spawn(run_challenge(
             config(),
             expect_claimable(&store, uuid).await,
+            None,
             r2,
         ));
 
@@ -173,10 +174,7 @@ fn killed_server_resumes_windows_with_time_to_run() {
         seq: JournalSeq(3),
         at: Timestamp::from_millis(61_000),
         caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-        event: LifecycleEvent::ChallengeTerminated {
-            status: ChallengeStatus::Reset,
-            empty: false,
-        },
+        event: LifecycleEvent::ChallengeTerminated { empty: false },
     });
     assert_eq!(journal(&collector, uuid), expected);
     assert!(deleted(&collector, uuid));
@@ -211,10 +209,7 @@ fn finished_entries(uuid: Uuid, finish_id: MsgId) -> Vec<JournalEntry> {
         seq: JournalSeq(3),
         at: Timestamp::ZERO,
         caused_by: Cause::Command(finish_id),
-        event: LifecycleEvent::ChallengeTerminated {
-            status: ChallengeStatus::Reset,
-            empty: false,
-        },
+        event: LifecycleEvent::ChallengeTerminated { empty: false },
     });
     entries
 }
@@ -252,7 +247,7 @@ fn killed_server_drains_backlogged_commands_on_resume() {
     let store = collector.clone();
     let r2 = rx.clone();
     runtime().block_on(async {
-        run_challenge(config(), expect_claimable(&store, uuid).await, r2).await;
+        run_challenge(config(), expect_claimable(&store, uuid).await, None, r2).await;
     });
 
     assert_eq!(journal(&collector, uuid), finished_entries(uuid, finish_id));
@@ -313,10 +308,7 @@ fn shutdown_server_hands_over_resumable_state() {
         seq: JournalSeq(3),
         at: Timestamp::from_millis(61_000),
         caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-        event: LifecycleEvent::ChallengeTerminated {
-            status: ChallengeStatus::Reset,
-            empty: false,
-        },
+        event: LifecycleEvent::ChallengeTerminated { empty: false },
     });
     assert_eq!(journal(&collector, uuid), expected);
     assert!(deleted(&collector, uuid));

--- a/challenge-harder/src/lifecycle/sim/scenarios/rejoin.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/rejoin.rs
@@ -61,11 +61,8 @@ fn client_finished(client: i64) -> LifecycleEvent {
     }
 }
 
-fn terminated(status: ChallengeStatus) -> LifecycleEvent {
-    LifecycleEvent::ChallengeTerminated {
-        status,
-        empty: false,
-    }
+fn terminated() -> LifecycleEvent {
+    LifecycleEvent::ChallengeTerminated { empty: false }
 }
 
 #[tokio::test(start_paused = true)]
@@ -115,9 +112,10 @@ async fn overlapping_socket_rejoin_fences_the_old_socket() {
             ),
             entry(6, 8_000, cmd(5), sealed(Stage::TobMaiden, None, false)),
             entry(7, 9_000, cmd(6), client_finished(1)),
-            entry(8, 9_000, cmd(6), terminated(ChallengeStatus::Reset)),
+            entry(8, 9_000, cmd(6), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Reset);
 }
 
 #[tokio::test(start_paused = true)]
@@ -165,9 +163,10 @@ async fn removed_client_rejoins_inside_the_window() {
             ),
             entry(8, 60_500, cmd(6), sealed(Stage::TobMaiden, None, false)),
             entry(9, 60_600, cmd(7), client_finished(1)),
-            entry(10, 60_600, cmd(7), terminated(ChallengeStatus::Wiped)),
+            entry(10, 60_600, cmd(7), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
 #[tokio::test(start_paused = true)]
@@ -197,7 +196,8 @@ async fn rejoin_after_termination_is_refused() {
         vec![
             entry(1, 0, cmd(1), joined(1, RecordingType::Participant)),
             entry(2, 500, cmd(2), client_finished(1)),
-            entry(3, 500, cmd(2), terminated(ChallengeStatus::Reset)),
+            entry(3, 500, cmd(2), terminated()),
         ],
     );
+    assert_eq!(result.only_status(), ChallengeStatus::Reset);
 }

--- a/challenge-harder/src/lifecycle/sim/scenarios/retries.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/retries.rs
@@ -51,10 +51,7 @@ fn completed(seq: u64, at_ms: u64, caused_by: Cause) -> JournalEntry {
         seq,
         at_ms,
         caused_by,
-        LifecycleEvent::ChallengeTerminated {
-            status: ChallengeStatus::Completed,
-            empty: false,
-        },
+        LifecycleEvent::ChallengeTerminated { empty: false },
     )
 }
 

--- a/challenge-harder/src/lifecycle/sim/scenarios/sweep.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/sweep.rs
@@ -13,6 +13,7 @@ use core::time::Duration;
 use super::*;
 use crate::lifecycle::core::command::ClientStatus;
 use crate::lifecycle::core::deadline::LifecycleConfig;
+use crate::lifecycle::core::state::ProcessingConfig;
 use crate::lifecycle::sim::{Rng, Scenario, ScenarioResult, hash, perturb, run_with};
 
 const BASE_SEED: u64 = 0xb1e47;
@@ -24,6 +25,11 @@ const SWEEP_CONFIG: LifecycleConfig = LifecycleConfig {
     reconnection_window: Duration::from_secs(30),
     inactivity_timeout: Duration::from_mins(1),
     lease_renewal_interval: Duration::from_secs(10),
+    processing: ProcessingConfig {
+        max_attempts: 0,
+        run_timeout: Duration::from_secs(30),
+        retry_backoff: Duration::from_secs(5),
+    },
 };
 
 fn ms(duration: Duration) -> u64 {

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -9,6 +9,7 @@
 mod api;
 mod lifecycle;
 mod players;
+mod processing;
 mod proto;
 mod shadow;
 mod store;
@@ -20,8 +21,12 @@ use std::time::Duration;
 use clap::{Parser, Subcommand};
 use lifecycle::coordinator::Coordinator;
 use lifecycle::core::deadline::LifecycleConfig;
+use lifecycle::core::state::ProcessingConfig;
 
 const CLAIM_SCAN_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Run attempts allowed per processing trigger.
+const PROCESSING_MAX_ATTEMPTS: u32 = 3;
 
 #[derive(Parser)]
 struct Cli {
@@ -42,7 +47,14 @@ enum Command {
 async fn main() -> ExitCode {
     match Cli::parse().command {
         None | Some(Command::Serve) => {
-            serve(LifecycleConfig::default()).await;
+            serve(LifecycleConfig {
+                processing: ProcessingConfig {
+                    max_attempts: PROCESSING_MAX_ATTEMPTS,
+                    ..ProcessingConfig::default()
+                },
+                ..LifecycleConfig::default()
+            })
+            .await;
             ExitCode::SUCCESS
         }
         Some(Command::Shadow(command)) => shadow::run(command).await,
@@ -71,8 +83,11 @@ async fn serve(config: LifecycleConfig) {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
-    let coordinator =
-        Arc::new(Coordinator::with_store(Arc::new(store), shutdown_rx).with_config(config));
+    let coordinator = Arc::new(
+        Coordinator::with_store(Arc::new(store), shutdown_rx)
+            .with_config(config)
+            .with_processor(Arc::new(processing::Pipeline)),
+    );
     coordinator.start_scan(CLAIM_SCAN_INTERVAL);
 
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -1,0 +1,46 @@
+//! Challenge processing pipeline.
+
+use async_trait::async_trait;
+
+use crate::lifecycle::core::state::Trigger;
+use crate::lifecycle::core::types::{ProcessingError, ProcessingOutcome, StageStatus, Uuid};
+
+/// A request to process the data demanded by a run trigger.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessingRequest {
+    pub uuid: Uuid,
+    pub trigger: Trigger,
+}
+
+/// Processes events for a completed challenge stage.
+#[async_trait]
+pub trait StageProcessor: Send + Sync + 'static {
+    async fn process(
+        &self,
+        request: ProcessingRequest,
+    ) -> Result<ProcessingOutcome, ProcessingError>;
+}
+
+/// Complete event processing pipeline.
+pub struct Pipeline;
+
+#[async_trait]
+impl StageProcessor for Pipeline {
+    async fn process(
+        &self,
+        request: ProcessingRequest,
+    ) -> Result<ProcessingOutcome, ProcessingError> {
+        tracing::info!(
+            uuid = %request.uuid,
+            trigger = ?request.trigger,
+            "processing_started",
+        );
+        Ok(match request.trigger {
+            Trigger::Stage { .. } => ProcessingOutcome::Stage {
+                status: StageStatus::Completed,
+                ticks: 0,
+            },
+            Trigger::Create { .. } | Trigger::Finish { .. } => ProcessingOutcome::Boundary,
+        })
+    }
+}

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -1694,9 +1694,7 @@ fn terminated_state(uuid: Uuid, create: &Create) -> ChallengeState {
         challenge_type: create.challenge_type,
         mode: create.mode,
         party: create.party.clone(),
-        phase: PhaseState::Terminated {
-            status: ChallengeStatus::Wiped,
-        },
+        phase: PhaseState::Terminated,
         recorded_by: [create.client_id].into(),
         ..ChallengeState::default()
     }


### PR DESCRIPTION
Adds a data processing state to challenges, with corresponding journal entries signalling, start, completion, and failures. Following challenge lifecycle events (start, stage end, finish), the processing state is set to indicate the event that triggered it, with a payload defining the processing operation.

The main challenge task launches a child task for data processing in response to processing entries, running each processing step in the order they appear. Processing occurs through an injected processor trait, which consumes a request and results an output result that gets written back to the journal.

Processing can either fail or time out. Each failure is classified as either retriable or non-retriable. Tasks that fail in a retriable way are re-run after a short backoff. A scripted processor added to the sim exercises these failures.

A stub processor is added for the live path, that simply returns a successful result immediately.