### PR TITLE
web: Display idle ticks for solo challenges

### DIFF
--- a/web/app/(challenges)/challenges/colosseum/[id]/waves/[number]/page.tsx
+++ b/web/app/(challenges)/challenges/colosseum/[id]/waves/[number]/page.tsx
@@ -14,7 +14,9 @@ import { notFound, useRouter } from 'next/navigation';
 import { use, useCallback, useContext, useEffect, useMemo } from 'react';
 
 import { CustomState } from '@/components/attack-timeline';
-import BossFightOverview from '@/components/boss-fight-overview';
+import BossFightOverview, {
+  IdleTicksContent,
+} from '@/components/boss-fight-overview';
 import BossPageAttackTimeline, {
   CustomStateEntry,
 } from '@/components/boss-page-attack-timeline';
@@ -30,6 +32,7 @@ import {
 } from '@/components/map-renderer';
 import { useDisplay } from '@/display';
 import {
+  computeIdleTickCounts,
   useMapEntities,
   usePreloads,
   usePlayingState,
@@ -279,6 +282,11 @@ export default function ColosseumWavePage({ params }: ColosseumWavePageProps) {
     return items;
   }, [playerName, solCustomStates, eventsByType]);
 
+  const idleTickCounts = useMemo(
+    () => computeIdleTickCounts(playerState),
+    [playerState],
+  );
+
   if (challenge === null || loading) {
     return <Loading />;
   }
@@ -361,6 +369,14 @@ export default function ColosseumWavePage({ params }: ColosseumWavePageProps) {
           ))}
         </div>
       ),
+    });
+  }
+
+  const idleTickCount = idleTickCounts.get(username);
+  if (idleTickCount !== undefined) {
+    sections.push({
+      title: 'Idle Ticks',
+      content: <IdleTicksContent count={idleTickCount} />,
     });
   }
 

--- a/web/app/(challenges)/challenges/inferno/[id]/waves/[number]/page.tsx
+++ b/web/app/(challenges)/challenges/inferno/[id]/waves/[number]/page.tsx
@@ -15,6 +15,7 @@ import { use, useCallback, useContext, useEffect, useMemo } from 'react';
 import { TimelineSplit } from '@/components/attack-timeline';
 import BossFightOverview, {
   BossFightOverviewSection,
+  IdleTicksContent,
 } from '@/components/boss-fight-overview';
 import BossPageAttackTimeline from '@/components/boss-page-attack-timeline';
 import BossPageControls from '@/components/boss-page-controls';
@@ -29,6 +30,7 @@ import {
 } from '@/components/map-renderer';
 import { useDisplay } from '@/display';
 import {
+  computeIdleTickCounts,
   useMapEntities,
   usePreloads,
   usePlayingState,
@@ -213,6 +215,11 @@ export default function InfernoWavePage({ params }: InfernoWavePageProps) {
     return { sections, splits: zukSplits };
   }, [stage, eventsByType, setTick]);
 
+  const idleTickCounts = useMemo(
+    () => computeIdleTickCounts(playerState),
+    [playerState],
+  );
+
   if (challenge === null || loading) {
     return <Loading />;
   }
@@ -227,6 +234,15 @@ export default function InfernoWavePage({ params }: InfernoWavePageProps) {
     [username]: playerState.get(username)?.at(currentTick) ?? null,
   };
 
+  const overviewSections = [...sections];
+  const idleTickCount = idleTickCounts.get(username);
+  if (idleTickCount !== undefined) {
+    overviewSections.push({
+      title: 'Idle Ticks',
+      content: <IdleTicksContent count={idleTickCount} />,
+    });
+  }
+
   return (
     <div className={styles.wavePage}>
       <div className={styles.overview}>
@@ -234,7 +250,7 @@ export default function InfernoWavePage({ params }: InfernoWavePageProps) {
           name={stageName(stage)}
           image="/images/inferno.png"
           time={totalTicks}
-          sections={sections}
+          sections={overviewSections}
         />
       </div>
 

--- a/web/app/(challenges)/challenges/mokhaiotl/[id]/delves/[number]/page.tsx
+++ b/web/app/(challenges)/challenges/mokhaiotl/[id]/delves/[number]/page.tsx
@@ -13,7 +13,10 @@ import {
 import Image from 'next/image';
 import { use, useCallback, useContext, useMemo } from 'react';
 
-import BossFightOverview from '@/components/boss-fight-overview';
+import BossFightOverview, {
+  BossFightOverviewSection,
+  IdleTicksContent,
+} from '@/components/boss-fight-overview';
 import BossPageAttackTimeline from '@/components/boss-page-attack-timeline';
 import BossPageControls from '@/components/boss-page-controls';
 import BossPageParty from '@/components/boss-page-party';
@@ -27,6 +30,7 @@ import {
 } from '@/components/map-renderer';
 import { useDisplay } from '@/display';
 import {
+  computeIdleTickCounts,
   useMapEntities,
   usePreloads,
   usePlayingState,
@@ -369,6 +373,11 @@ export default function DelvePage({ params }: DelvePageProps) {
   );
   const preloads = usePreloads(npcState, isLive);
 
+  const idleTickCounts = useMemo(
+    () => computeIdleTickCounts(playerState),
+    [playerState],
+  );
+
   if (challenge === null || loading) {
     return <Loading />;
   }
@@ -381,6 +390,15 @@ export default function DelvePage({ params }: DelvePageProps) {
     {},
   );
 
+  const sections: BossFightOverviewSection[] = [];
+  const idleTickCount = idleTickCounts.get(challenge.party[0].username);
+  if (idleTickCount !== undefined) {
+    sections.push({
+      title: 'Idle Ticks',
+      content: <IdleTicksContent count={idleTickCount} />,
+    });
+  }
+
   return (
     <div className={styles.delvePage}>
       <div className={styles.overview}>
@@ -389,7 +407,7 @@ export default function DelvePage({ params }: DelvePageProps) {
           className={styles.overview}
           image="/images/mokhaiotl.webp"
           time={totalTicks}
-          sections={[]}
+          sections={sections}
         />
       </div>
 

--- a/web/app/components/boss-fight-overview/idle-ticks-content.tsx
+++ b/web/app/components/boss-fight-overview/idle-ticks-content.tsx
@@ -1,0 +1,34 @@
+import { IdleTickCount } from '@/utils/boss-room-state';
+
+import styles from './style.module.scss';
+
+type IdleTicksContentProps = {
+  count: IdleTickCount;
+};
+
+export function IdleTicksContent({ count }: IdleTicksContentProps) {
+  const { idleTicks, eligibleTicks, longestIdle, idlePeriods } = count;
+
+  const percentage =
+    eligibleTicks > 0 ? ((idleTicks / eligibleTicks) * 100).toFixed(1) : null;
+  const averageIdle =
+    idlePeriods > 0 ? (idleTicks / idlePeriods).toFixed(1) : null;
+
+  return (
+    <div className={styles.idleTicks}>
+      <div className={styles.total}>
+        <span className={styles.count}>{idleTicks}</span>
+        <span className={styles.eligible}>/ {eligibleTicks}</span>
+        {percentage !== null && (
+          <span className={styles.percentage}>({percentage}%)</span>
+        )}
+      </div>
+      {averageIdle !== null && (
+        <div className={styles.runs}>
+          {idlePeriods} idle period{idlePeriods === 1 ? '' : 's'} · longest{' '}
+          {longestIdle} · avg {averageIdle}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/components/boss-fight-overview/index.ts
+++ b/web/app/components/boss-fight-overview/index.ts
@@ -2,3 +2,4 @@ export {
   BossFightOverview as default,
   type BossFightOverviewSection,
 } from './boss-fight-overview';
+export { IdleTicksContent } from './idle-ticks-content';

--- a/web/app/components/boss-fight-overview/style.module.scss
+++ b/web/app/components/boss-fight-overview/style.module.scss
@@ -118,3 +118,35 @@
   font-size: 0.95em;
   line-height: 1.4;
 }
+
+.idleTicks {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: var(--font-roboto-mono), monospace;
+
+  .total {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+
+    .count {
+      font-size: 1.5em;
+      font-weight: 600;
+    }
+
+    .eligible {
+      color: var(--blert-font-color-secondary);
+    }
+
+    .percentage {
+      color: var(--blert-font-color-secondary);
+      font-size: 0.9em;
+    }
+  }
+
+  .runs {
+    color: var(--blert-font-color-secondary);
+    font-size: 0.9em;
+  }
+}

--- a/web/app/utils/stage-state/__tests__/idle-ticks.test.ts
+++ b/web/app/utils/stage-state/__tests__/idle-ticks.test.ts
@@ -1,0 +1,224 @@
+import {
+  DataSource,
+  Event,
+  EventType,
+  PlayerAttackEvent,
+  PlayerDeathEvent,
+  PlayerUpdateEvent,
+} from '@blert/common';
+
+import { buildEventMaps } from '../event-maps';
+import { IdleTickCount, computeIdleTickCounts } from '../idle-ticks';
+import { computePlayerState } from '../player-state';
+
+function playerUpdate(
+  tick: number,
+  name: string,
+  offCooldownTick: number,
+): PlayerUpdateEvent {
+  return {
+    tick,
+    type: EventType.PLAYER_UPDATE as const,
+    stage: 0,
+    xCoord: 0,
+    yCoord: 0,
+    acc: true,
+    player: {
+      source: DataSource.PRIMARY,
+      name,
+      offCooldownTick,
+      prayerSet: 0,
+    },
+  };
+}
+
+function playerAttack(tick: number, name: string): PlayerAttackEvent {
+  return {
+    tick,
+    type: EventType.PLAYER_ATTACK as const,
+    stage: 0,
+    xCoord: 0,
+    yCoord: 0,
+    player: { name },
+    attack: { type: 1, distanceToTarget: 0 },
+  };
+}
+
+function playerDeath(tick: number, name: string): PlayerDeathEvent {
+  return {
+    tick,
+    type: EventType.PLAYER_DEATH as const,
+    stage: 0,
+    xCoord: 0,
+    yCoord: 0,
+    player: { name },
+  };
+}
+
+function idleTicksFor(
+  party: string[],
+  totalTicks: number,
+  events: Event[],
+): Map<string, IdleTickCount> {
+  const [eventsByTick, eventsByType] = buildEventMaps(events);
+  const playerState = computePlayerState(
+    party,
+    totalTicks,
+    eventsByTick,
+    eventsByType,
+  );
+  return computeIdleTickCounts(playerState);
+}
+
+describe('computeIdleTickCounts', () => {
+  // A 4-tick weapon attack on ticks 3 and 9.
+  const attackEvents = (name: string): Event[] => [
+    playerUpdate(0, name, 0),
+    playerUpdate(1, name, 0),
+    playerUpdate(2, name, 0),
+    playerUpdate(3, name, 7),
+    playerAttack(3, name),
+    playerUpdate(4, name, 7),
+    playerUpdate(5, name, 7),
+    playerUpdate(6, name, 7),
+    playerUpdate(7, name, 7),
+    playerUpdate(8, name, 7),
+    playerUpdate(9, name, 13),
+    playerAttack(9, name),
+    playerUpdate(10, name, 13),
+    playerUpdate(11, name, 13),
+  ];
+
+  it('counts off-cooldown ticks up to the final attack', () => {
+    const counts = idleTicksFor(['1Ogp'], 12, attackEvents('1Ogp'));
+    // Ticks 1-2 idle before the first attack, ticks 7-8 idle between attacks.
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 4,
+      eligibleTicks: 9,
+      longestIdle: 2,
+      idlePeriods: 2,
+    });
+  });
+
+  it('excludes ticks after the final attack', () => {
+    // Remove the tick 9 attack, leaving only the first attack on tick 3.
+    const events = attackEvents('1Ogp').filter(
+      (event) => !(event.type === EventType.PLAYER_ATTACK && event.tick === 9),
+    );
+    const counts = idleTicksFor(['1Ogp'], 12, events);
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 2,
+      eligibleTicks: 3,
+      longestIdle: 2,
+      idlePeriods: 1,
+    });
+  });
+
+  it('counts every eligible tick for a player who never attacks', () => {
+    const events: Event[] = [];
+    for (let tick = 0; tick < 6; tick++) {
+      events.push(playerUpdate(tick, '1Ogp', 0));
+    }
+    const counts = idleTicksFor(['1Ogp'], 6, events);
+
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 5,
+      eligibleTicks: 5,
+      longestIdle: 5,
+      idlePeriods: 1,
+    });
+  });
+
+  it('stops counting when the player dies', () => {
+    const events: Event[] = [];
+    for (let tick = 0; tick <= 4; tick++) {
+      events.push(playerUpdate(tick, '1Ogp', 0));
+    }
+    events.push(playerDeath(4, '1Ogp'));
+
+    const counts = idleTicksFor(['1Ogp'], 10, events);
+
+    // Ticks 1-3 are idle. Tick 4 is the death tick.
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 3,
+      eligibleTicks: 3,
+      longestIdle: 3,
+      idlePeriods: 1,
+    });
+  });
+
+  it('skips ticks without player state', () => {
+    const events: Event[] = [
+      playerUpdate(0, '1Ogp', 0),
+      playerUpdate(1, '1Ogp', 0),
+      playerUpdate(3, '1Ogp', 0),
+      playerUpdate(4, '1Ogp', 8),
+      playerAttack(4, '1Ogp'),
+    ];
+    const counts = idleTicksFor(['1Ogp'], 5, events);
+
+    // Tick 2 has no events for 1Ogp, so it is neither idle nor eligible, and
+    // it splits the surrounding idle ticks into separate periods.
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 2,
+      eligibleTicks: 3,
+      longestIdle: 1,
+      idlePeriods: 2,
+    });
+  });
+
+  it('computes counts independently per player', () => {
+    const events: Event[] = [
+      playerUpdate(0, '1Ogp', 0),
+      playerUpdate(1, '1Ogp', 0),
+      playerUpdate(2, '1Ogp', 6),
+      playerAttack(2, '1Ogp'),
+      playerUpdate(3, '1Ogp', 6),
+      playerUpdate(4, '1Ogp', 6),
+      playerUpdate(5, '1Ogp', 6),
+    ];
+    for (let tick = 0; tick < 6; tick++) {
+      events.push(playerUpdate(tick, 'WWWWWWWWWWQQ', 0));
+    }
+
+    const counts = idleTicksFor(['1Ogp', 'WWWWWWWWWWQQ'], 6, events);
+
+    expect(counts.size).toBe(2);
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 1,
+      eligibleTicks: 2,
+      longestIdle: 1,
+      idlePeriods: 1,
+    });
+    expect(counts.get('WWWWWWWWWWQQ')).toEqual({
+      idleTicks: 5,
+      eligibleTicks: 5,
+      longestIdle: 5,
+      idlePeriods: 1,
+    });
+  });
+
+  it('tracks runs of unequal length', () => {
+    const events: Event[] = [
+      playerUpdate(0, '1Ogp', 0),
+      playerUpdate(1, '1Ogp', 0),
+      playerUpdate(2, '1Ogp', 5),
+      playerAttack(2, '1Ogp'),
+      playerUpdate(3, '1Ogp', 5),
+      playerUpdate(4, '1Ogp', 5),
+      playerUpdate(5, '1Ogp', 5),
+      playerUpdate(6, '1Ogp', 5),
+      playerUpdate(7, '1Ogp', 5),
+      playerUpdate(8, '1Ogp', 12),
+      playerAttack(8, '1Ogp'),
+    ];
+    const counts = idleTicksFor(['1Ogp'], 9, events);
+
+    expect(counts.get('1Ogp')).toEqual({
+      idleTicks: 4,
+      eligibleTicks: 8,
+      longestIdle: 3,
+      idlePeriods: 2,
+    });
+  });
+});

--- a/web/app/utils/stage-state/idle-ticks.ts
+++ b/web/app/utils/stage-state/idle-ticks.ts
@@ -1,0 +1,67 @@
+import { PlayerStateMap } from './types';
+
+export type IdleTickCount = {
+  /** Ticks on which the player was off cooldown but did not attack. */
+  idleTicks: number;
+  /** Alive, observed ticks within the counting window. */
+  eligibleTicks: number;
+  /** Length of the longest consecutive run of idle ticks. */
+  longestIdle: number;
+  /** Number of distinct consecutive runs of idle ticks. */
+  idlePeriods: number;
+};
+
+/**
+ * Counts the number of ticks on which each player could have attacked but did
+ * not, up to their final attack, excluding the entry tick 0. Idle ticks are
+ * grouped into periods of consecutive runs.
+ *
+ * A player without attacks counts every valid tick.
+ */
+export function computeIdleTickCounts(
+  playerState: PlayerStateMap,
+): Map<string, IdleTickCount> {
+  const counts = new Map<string, IdleTickCount>();
+
+  for (const [player, states] of playerState) {
+    let lastAttackTick = Infinity;
+    for (let tick = states.length - 1; tick >= 0; tick--) {
+      if (states[tick]?.attack !== undefined) {
+        lastAttackTick = tick;
+        break;
+      }
+    }
+
+    const end = Math.min(lastAttackTick, states.length - 1);
+    let idleTicks = 0;
+    let eligibleTicks = 0;
+    let longestIdle = 0;
+    let idlePeriods = 0;
+    let currentRun = 0;
+
+    for (let tick = 1; tick <= end; tick++) {
+      const state = states[tick];
+      if (state === null || state.isDead) {
+        currentRun = 0;
+        continue;
+      }
+
+      eligibleTicks++;
+
+      if (state.attack === undefined && state.player.offCooldownTick <= tick) {
+        idleTicks++;
+        currentRun++;
+        if (currentRun === 1) {
+          idlePeriods++;
+        }
+        longestIdle = Math.max(longestIdle, currentRun);
+      } else {
+        currentRun = 0;
+      }
+    }
+
+    counts.set(player, { idleTicks, eligibleTicks, longestIdle, idlePeriods });
+  }
+
+  return counts;
+}

--- a/web/app/utils/stage-state/index.ts
+++ b/web/app/utils/stage-state/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './event-maps';
+export * from './idle-ticks';
 export * from './npc-map';
 export * from './player-state';
 export * from './npc-state';


### PR DESCRIPTION
Updates replays in solo challenges to count the number of ticks a player is idle out of all eligible attack ticks and display that in the overview.