### PR TITLE
2c2s: Send disconnect to current challenge on start

### DIFF
--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -447,7 +447,7 @@ impl ChallengeStore for Collector {
     async fn start(&self, create: Create) -> Result<Start, StoreError> {
         let client_id = create.client_id;
         let party = party_identity(create.challenge_type, &create.party);
-        let (joined, uuid) = {
+        let (joined, uuid, left) = {
             let mut routing = self.routing.lock().expect("collector lock poisoned");
             let incumbent = routing.directory.get(&party).copied().filter(|incumbent| {
                 self.projections
@@ -460,16 +460,32 @@ impl ChallengeStore for Collector {
                     })
             });
             if let Some(incumbent) = incumbent {
-                routing.clients.insert(client_id, incumbent);
-                (true, incumbent)
+                let previous = routing.clients.insert(client_id, incumbent);
+                let left = previous.filter(|p| *p != incumbent && routing.existing.contains(p));
+                (true, incumbent, left)
             } else {
                 let uuid = Uuid::new_v4();
                 routing.directory.insert(party, uuid);
                 routing.existing.insert(uuid);
-                routing.clients.insert(client_id, uuid);
-                (false, uuid)
+                let previous = routing.clients.insert(client_id, uuid);
+                let left = previous.filter(|p| routing.existing.contains(p));
+                (false, uuid, left)
             }
         };
+
+        // The client leaves any challenge it was still recorded in.
+        if let Some(previous) = left {
+            self.enqueue(
+                previous,
+                Command::ClientStatus(ClientStatusChange {
+                    user_id: create.user_id,
+                    client_id,
+                    session_token: create.session_token.clone(),
+                    status: ClientStatus::Disconnected,
+                }),
+            )
+            .await;
+        }
 
         if joined {
             let id = self.enqueue(uuid, Command::Join(Join::from(&create))).await;

--- a/challenge-harder/src/lifecycle/sim/scenarios/creation.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/creation.rs
@@ -154,6 +154,179 @@ async fn terminated_incumbent_is_superseded() {
     assert_eq!(result.projections[&first].status, ChallengeStatus::Reset);
 }
 
+fn solo_start(name: &str) -> Action {
+    Action::Start {
+        challenge_type: ChallengeType::Tob,
+        mode: ChallengeMode::TobRegular,
+        party: vec![name.into()],
+        stage: Stage::TobMaiden,
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn start_for_another_party_leaves_the_recorded_challenge() {
+    let result = run(Scenario {
+        clients: vec![
+            Client::participant("a", 1)
+                .at(0, solo_start("715"))
+                .at(1_000, tob_start()),
+        ],
+        run_until: 302_000,
+    })
+    .await;
+
+    assert_eq!(result.journals.len(), 2);
+    let first = result.outcomes[0].response.as_ref().unwrap().uuid;
+    let second = result.outcomes[1].response.as_ref().unwrap().uuid;
+    assert_ne!(first, second);
+
+    // The first challenge loses its client and dies after the reconnection window.
+    assert_eq!(
+        result.journals[&first],
+        vec![
+            entry(
+                0,
+                0,
+                cmd(1),
+                LifecycleEvent::ChallengeCreated {
+                    uuid: first,
+                    challenge_type: ChallengeType::Tob,
+                    mode: ChallengeMode::TobRegular,
+                    party: vec!["715".into()],
+                    stage: Stage::TobMaiden,
+                },
+            ),
+            entry(1, 0, cmd(1), joined(1, RecordingType::Participant)),
+            entry(
+                2,
+                1_000,
+                cmd(2),
+                LifecycleEvent::ClientRemoved {
+                    client_id: client_id(1),
+                },
+            ),
+            entry(
+                3,
+                301_000,
+                Cause::Deadline(DeadlineKind::CleanupDisconnect),
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+        ],
+    );
+    assert!(result.deleted.contains(&first));
+    assert_eq!(result.projections[&first].status, ChallengeStatus::Reset);
+
+    assert!(!result.deleted.contains(&second));
+}
+
+#[tokio::test(start_paused = true)]
+async fn start_joins_the_left_challenge_within_its_window() {
+    // A spectator watching a duo hops to watching 1Ogp instead, then comes back
+    // within the reconnection window. The duo challenge continues and the 1Ogp
+    // challenge dies in its place.
+    let result = run(Scenario {
+        clients: vec![
+            Client::spectator("s", 1)
+                .at(0, tob_start())
+                .at(1_000, solo_start("1Ogp"))
+                .at(60_000, tob_start()),
+        ],
+        run_until: 400_000,
+    })
+    .await;
+
+    assert_eq!(result.journals.len(), 2);
+    let duo_watch = result.outcomes[0].response.as_ref().unwrap().uuid;
+    let solo_watch = result.outcomes[1].response.as_ref().unwrap().uuid;
+    let returned = result.outcomes[2].response.as_ref().unwrap().uuid;
+    assert_eq!(returned, duo_watch);
+
+    assert!(
+        result.journals[&duo_watch]
+            .iter()
+            .all(|e| !matches!(e.event, LifecycleEvent::ChallengeTerminated { .. }))
+    );
+    assert!(!result.deleted.contains(&duo_watch));
+    assert!(result.deleted.contains(&solo_watch));
+}
+
+#[tokio::test(start_paused = true)]
+async fn start_after_finishing_leaves_nothing() {
+    let result = run(Scenario {
+        clients: vec![
+            Client::spectator("s", 1)
+                .at(0, solo_start("1Ogp"))
+                .at(100, finish(true))
+                .at(200, tob_start()),
+        ],
+        run_until: 1_000,
+    })
+    .await;
+
+    assert_eq!(result.journals.len(), 2);
+    let first = result.outcomes[0].response.as_ref().unwrap().uuid;
+
+    assert_eq!(result.inboxes[&first].len(), 2);
+    assert!(
+        result.journals[&first]
+            .iter()
+            .all(|e| !matches!(e.event, LifecycleEvent::ClientRemoved { .. }))
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn start_attaching_to_an_incumbent_leaves_the_recorded_challenge() {
+    // 715 starts a solo, then starts a duo with WWWWWWWWWWQQ's raid without
+    // sending a finish for the solo. WWWWWWWWWWQQ's create event arrives first,
+    // starts, so the start attaches to it and the solo is left to expire.
+    let result = run(Scenario {
+        clients: vec![
+            Client::participant("a", 1).at(0, solo_start("715")),
+            Client::participant("b", 2).at(1_000, tob_start()),
+            Client::participant("a", 1).at(1_005, tob_start()),
+        ],
+        run_until: 302_000,
+    })
+    .await;
+
+    assert_eq!(result.journals.len(), 2);
+    let solo = result.outcomes[0].response.as_ref().unwrap().uuid;
+    let duo = result
+        .outcomes
+        .iter()
+        .find(|o| o.client == "b")
+        .and_then(|o| o.response.as_ref())
+        .expect("b's start should succeed")
+        .uuid;
+    let attached = result
+        .outcomes
+        .iter()
+        .find(|o| o.client == "a" && o.at == 1_005)
+        .and_then(|o| o.response.as_ref())
+        .expect("a's second start should succeed")
+        .uuid;
+    assert_eq!(attached, duo);
+
+    assert!(result.journals[&duo].iter().any(|e| {
+        matches!(
+            e.event,
+            LifecycleEvent::ClientJoined { client_id: joiner, .. } if joiner == client_id(1)
+        )
+    }));
+    assert!(result.journals[&solo].iter().any(|e| {
+        matches!(
+            e.event,
+            LifecycleEvent::ClientRemoved { client_id: removed } if removed == client_id(1)
+        )
+    }));
+    assert!(
+        result.journals[&solo]
+            .iter()
+            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated { .. }))
+    );
+    assert!(result.deleted.contains(&solo));
+}
+
 #[tokio::test(start_paused = true)]
 async fn finishing_challenge_is_not_joined() {
     let result = run(Scenario {

--- a/challenge-harder/src/store/mod.rs
+++ b/challenge-harder/src/store/mod.rs
@@ -14,7 +14,9 @@ use crate::lifecycle::challenge::{
     ChallengeClaim, ChallengeServerUpdate, ChallengeSignal, ChallengeStore, Claim, Rejoin, Start,
     StoreError,
 };
-use crate::lifecycle::core::command::{Command, Create, Envelope, Join};
+use crate::lifecycle::core::command::{
+    ClientStatus, ClientStatusChange, Command, Create, Envelope, Join,
+};
 use crate::lifecycle::core::event::JournalEntry;
 use crate::lifecycle::core::state::{ChallengePhase, ChallengeState, PublishedClient, Snapshot};
 use crate::lifecycle::core::types::{
@@ -309,6 +311,13 @@ impl ChallengeStore for Store {
 
         let join_payload =
             serde_json::to_string(&Command::Join(Join::from(&create))).expect("command serializes");
+        let removal_payload = serde_json::to_string(&Command::ClientStatus(ClientStatusChange {
+            user_id: create.user_id,
+            client_id: create.client_id,
+            session_token: create.session_token.clone(),
+            status: ClientStatus::Disconnected,
+        }))
+        .expect("command serializes");
         let create_payload =
             serde_json::to_string(&Command::Create(create)).expect("command serializes");
 
@@ -316,9 +325,10 @@ impl ChallengeStore for Store {
             .arg(uuid.to_string())
             .arg(&self.identity)
             .arg(lease_deadline())
+            .arg(later_stages)
             .arg(create_payload)
             .arg(join_payload)
-            .arg(later_stages);
+            .arg(removal_payload);
         let outcome: Vec<String> = invocation
             .invoke_async(&mut connection)
             .await

--- a/challenge-harder/src/store/scripts.rs
+++ b/challenge-harder/src/store/scripts.rs
@@ -223,6 +223,8 @@ pub(super) static ANNOUNCE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
 /// If joining, pushes the join command to the incumbent's inbox instead,
 /// leaving the player keys alone as the party is unchanged.
 ///
+/// If the client is listed in another challenge, sends a removal command to it.
+///
 /// ## Arguments
 ///
 /// - `KEYS[1]` = Party directory key
@@ -235,9 +237,10 @@ pub(super) static ANNOUNCE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
 /// - `ARGV[1]` = Fresh challenge uuid
 /// - `ARGV[2]` = Creating instance's identity
 /// - `ARGV[3]` = Lease deadline for the created challenge
-/// - `ARGV[4]` = Serialized create command
-/// - `ARGV[5]` = Serialized join command
-/// - `ARGV[6]` = List of stages for the challenge beyond the incoming one
+/// - `ARGV[4]` = List of stages for the challenge beyond the incoming one
+/// - `ARGV[5]` = Serialized create command
+/// - `ARGV[6]` = Serialized join command
+/// - `ARGV[7]` = Serialized removal command for an existing challenge
 ///
 /// ## Return value
 ///
@@ -248,6 +251,14 @@ pub(super) static ANNOUNCE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
 pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
     Script::new(&format!(
         r"
+        local function leave_previous(target)
+            local previous = redis.call('GET', KEYS[4])
+            if previous and previous ~= target
+                and redis.call('ZSCORE', KEYS[2], previous) then
+                redis.call('XADD', '{INBOX_KEY_PREFIX}' .. previous, '*', 'cmd', ARGV[7])
+            end
+        end
+
         local incumbent = redis.call('GET', KEYS[1])
         if incumbent then
             local challenge = '{CHALLENGE_KEY_PREFIX}' .. incumbent
@@ -255,14 +266,16 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
             local joinable = phase == false
             if phase == '{active}' then
                 local stage = redis.call('HGET', challenge, 'stage')
-                joinable = not (stage and string.find(ARGV[6], ',' .. stage .. ',', 1, true))
+                joinable = not (stage and string.find(ARGV[4], ',' .. stage .. ',', 1, true))
             end
             if joinable then
+                leave_previous(incumbent)
                 redis.call('SET', KEYS[4], incumbent)
-                local id = redis.call('XADD', '{INBOX_KEY_PREFIX}' .. incumbent, '*', 'cmd', ARGV[5])
+                local id = redis.call('XADD', '{INBOX_KEY_PREFIX}' .. incumbent, '*', 'cmd', ARGV[6])
                 return {{'JOIN', incumbent, id}}
             end
         end
+        leave_previous(ARGV[1])
         redis.call('SET', KEYS[1], ARGV[1])
         redis.call('HSET', KEYS[3], 'fence', {initial_epoch}, 'owner', ARGV[2])
         redis.call('ZADD', KEYS[2], ARGV[3], ARGV[1])
@@ -270,7 +283,7 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
         for i = 6, #KEYS do
             redis.call('SET', KEYS[i], ARGV[1])
         end
-        local id = redis.call('XADD', KEYS[5], '*', 'cmd', ARGV[4])
+        local id = redis.call('XADD', KEYS[5], '*', 'cmd', ARGV[5])
         return {{'CREATE', id}}
         ",
         active = ChallengePhase::Active.tag(),

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -1364,6 +1364,166 @@ async fn start_supersedes_a_finishing_incumbent() {
     .await;
 }
 
+/// The removal command a start queues to a challenge its client left.
+fn removal_command(create: &Create) -> Command {
+    Command::ClientStatus(ClientStatusChange {
+        user_id: create.user_id,
+        client_id: create.client_id,
+        session_token: create.session_token.clone(),
+        status: ClientStatus::Disconnected,
+    })
+}
+
+#[tokio::test]
+async fn start_sends_a_removal_to_an_existing_challenge() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let client = test_client();
+    let first_create = create_request(client);
+    let first_party = party_of(&first_create);
+
+    let Ok(Start::Created { claim, id }) = store.start(first_create.clone()).await else {
+        panic!("expected a creation");
+    };
+    let first = claim.uuid();
+
+    // The same client starts a challenge for a different party.
+    let second_create = Create {
+        party: vec![format!("Second {client}")],
+        ..create_request(client)
+    };
+    let second_party = party_of(&second_create);
+    let Ok(Start::Created {
+        claim: second_claim,
+        ..
+    }) = store.start(second_create.clone()).await
+    else {
+        panic!("expected a creation");
+    };
+    let second = second_claim.uuid();
+
+    let mut connection = store.connection.clone();
+    let routed: String = connection.get(client_key(client)).await.unwrap();
+    assert_eq!(routed, second.to_string());
+
+    // The left challenge received the client's removal after its create.
+    let inbox = read_inbox(&store, first).await;
+    assert_eq!(inbox.len(), 2);
+    assert_eq!(
+        inbox[0],
+        (id, vec![("cmd".to_string(), Command::Create(first_create))]),
+    );
+    assert_eq!(
+        inbox[1].1,
+        vec![("cmd".to_string(), removal_command(&second_create))],
+    );
+
+    clean_up_start(&store, &first_party, &[client], &[first]).await;
+    clean_up_start(&store, &second_party, &[], &[second]).await;
+}
+
+#[tokio::test]
+async fn start_sends_a_removal_to_an_existing_challenge_when_joining() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let creator_client = test_client();
+    let creator = create_request(creator_client);
+    let incumbent_party = party_of(&creator);
+
+    let Ok(Start::Created { claim, .. }) = store.start(creator.clone()).await else {
+        panic!("expected a creation");
+    };
+    let incumbent = claim.uuid();
+    claim
+        .project(&snapshot(incumbent, 1), &[])
+        .await
+        .expect("project should succeed");
+
+    let leaver_client = test_client();
+    let leaver_create = create_request(leaver_client);
+    let left_party = party_of(&leaver_create);
+    let Ok(Start::Created {
+        claim: left_claim,
+        id: left_create_id,
+    }) = store.start(leaver_create.clone()).await
+    else {
+        panic!("expected a creation");
+    };
+    let left = left_claim.uuid();
+
+    let attach = Create {
+        party: creator.party.clone(),
+        ..create_request(leaver_client)
+    };
+    let start = store.start(attach.clone()).await.expect("start succeeds");
+    let Start::Joined { uuid: target, .. } = start else {
+        panic!("expected a join");
+    };
+    assert_eq!(target, incumbent);
+
+    let inbox = read_inbox(&store, left).await;
+    assert_eq!(inbox.len(), 2);
+    assert_eq!(
+        inbox[0],
+        (
+            left_create_id,
+            vec![("cmd".to_string(), Command::Create(leaver_create))]
+        ),
+    );
+    assert_eq!(
+        inbox[1].1,
+        vec![("cmd".to_string(), removal_command(&attach))],
+    );
+
+    clean_up_start(
+        &store,
+        &incumbent_party,
+        &[creator_client, leaver_client],
+        &[incumbent],
+    )
+    .await;
+    clean_up_start(&store, &left_party, &[], &[left]).await;
+}
+
+#[tokio::test]
+async fn start_rejoining_the_same_challenge_sends_no_removal() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let client = test_client();
+    let create = create_request(client);
+    let party = party_of(&create);
+
+    let Ok(Start::Created { claim, .. }) = store.start(create.clone()).await else {
+        panic!("expected a creation");
+    };
+    let uuid = claim.uuid();
+    claim
+        .project(&snapshot(uuid, 1), &[])
+        .await
+        .expect("project should succeed");
+
+    // The same client starts the same party again and joins the same challenge.
+    let restart = create_request(client);
+    let start = store.start(restart).await.expect("start succeeds");
+    let Start::Joined { uuid: target, .. } = start else {
+        panic!("expected a join");
+    };
+    assert_eq!(target, uuid);
+
+    let inbox = read_inbox(&store, uuid).await;
+    assert_eq!(inbox.len(), 2);
+    for (_, entries) in &inbox {
+        for (_, command) in entries {
+            assert!(!matches!(command, Command::ClientStatus(_)));
+        }
+    }
+
+    clean_up_start(&store, &party, &[client], &[uuid]).await;
+}
+
 #[tokio::test]
 async fn send_to_an_unknown_challenge_is_rejected() {
     let Some(store) = test_store().await else {

--- a/socket-server/__tests__/remote-challenge-manager.test.ts
+++ b/socket-server/__tests__/remote-challenge-manager.test.ts
@@ -1,8 +1,15 @@
 import {
+  CHALLENGE_UPDATES_PUBSUB_KEY,
+  ChallengeMode,
+  ChallengeType,
+  ChallengeUpdateAction,
   CLIENT_EVENTS_KEY,
   ClientEventType,
   ClientStatus,
+  RecordingType,
+  Stage,
 } from '@blert/common';
+import { ServerMessage } from '@blert/common/generated/server_message_pb';
 import { RedisClientType } from 'redis';
 
 import Client from '../client';
@@ -10,6 +17,47 @@ import { RemoteOperation } from '../metrics';
 import { RemoteChallengeManager } from '../remote-challenge-manager';
 
 describe('RemoteChallengeManager', () => {
+  let manager: RemoteChallengeManager;
+  let fetchMock: jest.SpyInstance;
+  let lPush: jest.Mock;
+  let pubsubHandler: ((message: string, channel: string) => void) | null;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock = jest.spyOn(global, 'fetch');
+
+    lPush = jest.fn().mockResolvedValue(1);
+    pubsubHandler = null;
+    const duplicate = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
+      subscribe: jest
+        .fn()
+        .mockImplementation(
+          (_channel: string, handler: (m: string, c: string) => void) => {
+            pubsubHandler = handler;
+            return Promise.resolve();
+          },
+        ),
+    };
+    const redisClient = {
+      duplicate: () => duplicate,
+      get: jest.fn().mockResolvedValue(null),
+      lPush,
+    } as unknown as RedisClientType;
+
+    manager = new RemoteChallengeManager(
+      'http://challenge-server',
+      redisClient,
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.BLERT_CLIENT_STATUS_HTTP;
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
   function makeResponse(status: number, body: unknown = {}): Response {
     return {
       ok: status >= 200 && status < 300,
@@ -18,34 +66,40 @@ describe('RemoteChallengeManager', () => {
     } as unknown as Response;
   }
 
+  type MockClient = {
+    client: Client;
+    sendMessage: jest.Mock;
+    activeChallengeId: () => string | null;
+  };
+
+  function makeClient(): MockClient {
+    let activeChallengeId: string | null = null;
+    const sendMessage = jest.fn();
+    const client = {
+      getUserId: () => 435,
+      getClientId: () => 286,
+      getSessionToken: () => 'session-token',
+      getPluginVersions: () => ({
+        getVersion: () => '0.9.14',
+        getRuneLiteVersion: () => '1.12.33',
+      }),
+      getActiveChallengeId: () => activeChallengeId,
+      setActiveChallenge: (id: string) => {
+        activeChallengeId = id;
+      },
+      clearActiveChallenge: () => {
+        activeChallengeId = null;
+      },
+      sendMessage,
+    } as unknown as Client;
+    return {
+      client,
+      sendMessage,
+      activeChallengeId: () => activeChallengeId,
+    };
+  }
+
   describe('request retries', () => {
-    let manager: RemoteChallengeManager;
-    let fetchMock: jest.SpyInstance;
-
-    beforeEach(() => {
-      jest.useFakeTimers();
-      fetchMock = jest.spyOn(global, 'fetch');
-
-      const duplicate = {
-        connect: jest.fn().mockResolvedValue(undefined),
-        on: jest.fn(),
-        subscribe: jest.fn().mockResolvedValue(undefined),
-      };
-      const redisClient = {
-        duplicate: () => duplicate,
-      } as unknown as RedisClientType;
-
-      manager = new RemoteChallengeManager(
-        'http://challenge-server',
-        redisClient,
-      );
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-      jest.restoreAllMocks();
-    });
-
     function callRequest(): Promise<Response> {
       const init: RequestInit = { method: 'POST' };
       return (
@@ -111,51 +165,11 @@ describe('RemoteChallengeManager', () => {
   });
 
   describe('updateClientStatus', () => {
-    let manager: RemoteChallengeManager;
-    let fetchMock: jest.SpyInstance;
-    let lPush: jest.Mock;
-
-    function makeClient(): Client {
-      return {
-        getUserId: () => 435,
-        getClientId: () => 286,
-        getSessionToken: () => 'session-token',
-        getActiveChallengeId: () => null,
-      } as unknown as Client;
-    }
-
-    beforeEach(() => {
-      jest.useFakeTimers();
-      fetchMock = jest.spyOn(global, 'fetch');
-
-      lPush = jest.fn().mockResolvedValue(1);
-      const duplicate = {
-        connect: jest.fn().mockResolvedValue(undefined),
-        on: jest.fn(),
-        subscribe: jest.fn().mockResolvedValue(undefined),
-      };
-      const redisClient = {
-        duplicate: () => duplicate,
-        lPush,
-      } as unknown as RedisClientType;
-
-      manager = new RemoteChallengeManager(
-        'http://challenge-server',
-        redisClient,
-      );
-    });
-
-    afterEach(() => {
-      delete process.env.BLERT_CLIENT_STATUS_HTTP;
-      jest.useRealTimers();
-      jest.restoreAllMocks();
-    });
-
     test('posts the event over HTTP when enabled', async () => {
       process.env.BLERT_CLIENT_STATUS_HTTP = '1';
       fetchMock.mockResolvedValueOnce(makeResponse(200));
 
-      await manager.updateClientStatus(makeClient(), ClientStatus.IDLE);
+      await manager.updateClientStatus(makeClient().client, ClientStatus.IDLE);
 
       expect(lPush).not.toHaveBeenCalled();
       expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -175,7 +189,7 @@ describe('RemoteChallengeManager', () => {
         makeResponse(400, { error: { message: 'unknown client' } }),
       );
 
-      await manager.updateClientStatus(makeClient(), ClientStatus.IDLE);
+      await manager.updateClientStatus(makeClient().client, ClientStatus.IDLE);
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
@@ -185,7 +199,7 @@ describe('RemoteChallengeManager', () => {
       fetchMock.mockRejectedValue(new Error('connection refused'));
 
       const status = manager.updateClientStatus(
-        makeClient(),
+        makeClient().client,
         ClientStatus.IDLE,
       );
       await jest.advanceTimersByTimeAsync(10_000);
@@ -195,7 +209,10 @@ describe('RemoteChallengeManager', () => {
     });
 
     test('pushes the event to the queue by default', async () => {
-      await manager.updateClientStatus(makeClient(), ClientStatus.DISCONNECTED);
+      await manager.updateClientStatus(
+        makeClient().client,
+        ClientStatus.DISCONNECTED,
+      );
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(lPush).toHaveBeenCalledTimes(1);
@@ -208,6 +225,86 @@ describe('RemoteChallengeManager', () => {
         sessionToken: 'session-token',
         status: ClientStatus.DISCONNECTED,
       });
+    });
+  });
+
+  describe('challenge finish notifications', () => {
+    beforeEach(async () => {
+      // The manager defers its pubsub subscription, so run pending timers to
+      // capture the update handler.
+      await jest.advanceTimersByTimeAsync(100);
+    });
+
+    async function startChallenge(mock: MockClient, uuid: string) {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse(200, {
+          uuid,
+          mode: ChallengeMode.TOB_REGULAR,
+          stage: Stage.TOB_MAIDEN,
+          stageAttempt: null,
+        }),
+      );
+      const status = await manager.startOrJoin(
+        mock.client,
+        ChallengeType.TOB,
+        ChallengeMode.TOB_REGULAR,
+        ['1Ogp'],
+        Stage.TOB_MAIDEN,
+        RecordingType.PARTICIPANT,
+      );
+      // Mirrors the message handler, which activates the returned challenge
+      // after a successful start.
+      mock.client.setActiveChallenge(status.uuid);
+    }
+
+    function finishChallenge(uuid: string) {
+      pubsubHandler!(
+        JSON.stringify({ id: uuid, action: ChallengeUpdateAction.FINISH }),
+        CHALLENGE_UPDATES_PUBSUB_KEY,
+      );
+    }
+
+    test('notifies a recording client when its challenge finishes', async () => {
+      const mock = makeClient();
+      await startChallenge(mock, 'challenge-a');
+
+      finishChallenge('challenge-a');
+
+      expect(mock.sendMessage).toHaveBeenCalledTimes(1);
+      const message = mock.sendMessage.mock.calls[0][0] as ServerMessage;
+      expect(message.getType()).toBe(ServerMessage.Type.ERROR);
+      expect(message.getActiveChallengeId()).toBe('challenge-a');
+      expect(message.getError()!.getType()).toBe(
+        ServerMessage.Error.Type.CHALLENGE_RECORDING_ENDED,
+      );
+      expect(mock.activeChallengeId()).toBeNull();
+    });
+
+    test('ignores notifications from an old challenge if the client has moved on', async () => {
+      const mock = makeClient();
+      await startChallenge(mock, 'challenge-a');
+      await startChallenge(mock, 'challenge-b');
+
+      finishChallenge('challenge-a');
+
+      expect(mock.sendMessage).not.toHaveBeenCalled();
+      expect(mock.activeChallengeId()).toBe('challenge-b');
+
+      finishChallenge('challenge-b');
+
+      expect(mock.sendMessage).toHaveBeenCalledTimes(1);
+      const message = mock.sendMessage.mock.calls[0][0] as ServerMessage;
+      expect(message.getActiveChallengeId()).toBe('challenge-b');
+      expect(mock.activeChallengeId()).toBeNull();
+    });
+
+    test('ignores notifications from a challenge that a client is not in', async () => {
+      const mock = makeClient();
+      await startChallenge(mock, 'challenge-a');
+      mock.client.setActiveChallenge('challenge-b');
+      finishChallenge('challenge-a');
+      expect(mock.sendMessage).not.toHaveBeenCalled();
+      expect(mock.activeChallengeId()).toBe('challenge-b');
     });
   });
 });

--- a/socket-server/remote-challenge-manager.ts
+++ b/socket-server/remote-challenge-manager.ts
@@ -124,6 +124,9 @@ export class RemoteChallengeManager extends ChallengeManager {
     }
 
     const status = (await res.json()) as ChallengeStatusResponse;
+
+    // Move the client from any previous challenge into the new one.
+    this.removeClientFromChallenge(client);
     this.addClientToChallenge(client, status.uuid);
 
     this.markForCapture(status.uuid);
@@ -586,9 +589,14 @@ export class RemoteChallengeManager extends ChallengeManager {
       case ChallengeUpdateAction.FINISH: {
         const clients = this.clientsByChallenge.get(update.id);
         if (clients) {
+          // Only remove clients that are still tracking this challenge.
+          const activeClients = clients.filter(
+            (c) => c.getActiveChallengeId() === update.id,
+          );
+
           logger.info('remote_challenge_finished_notification', {
             challengeUuid: update.id,
-            clientCount: clients.length,
+            clientCount: activeClients.length,
           });
 
           const endMessage = new ServerMessage();
@@ -598,7 +606,7 @@ export class RemoteChallengeManager extends ChallengeManager {
           error.setType(ServerMessage.Error.Type.CHALLENGE_RECORDING_ENDED);
           endMessage.setError(error);
 
-          for (const client of clients) {
+          for (const client of activeClients) {
             client.sendMessage(endMessage);
             client.clearActiveChallenge();
           }


### PR DESCRIPTION
If a client starts a new challenge while still listed in an existing one (e.g. their finish was lost), queues a disconnect command to the first channel's inbox to ensure the client is removed to let it clean up.