### PR TITLE
2c2s: Begin database persistence in processing

### DIFF
--- a/.github/workflows/test-challenge-harder.yml
+++ b/.github/workflows/test-challenge-harder.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'challenge-harder/**'
+      - 'common/migrations/**'
       - 'proto/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -13,6 +14,7 @@ on:
       - main
     paths:
       - 'challenge-harder/**'
+      - 'common/migrations/**'
       - 'proto/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -28,6 +30,20 @@ jobs:
         ports:
           - 6379:6379
 
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: blert
+          POSTGRES_PASSWORD: blert
+          POSTGRES_DB: blert_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -36,6 +52,27 @@ jobs:
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24.8.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          npm_config_fetch_retries: 5
+          npm_config_fetch_retry_mintimeout: 20000
+          npm_config_fetch_retry_maxtimeout: 120000
+
+      - name: Build common
+        run: npm run -w common build
+
+      - name: Run database migrations
+        run: npm run -w common migration:run
+        env:
+          BLERT_DATABASE_URI: postgres://blert:blert@localhost:5432/blert_test
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -55,5 +92,6 @@ jobs:
       - name: Run tests
         run: cargo test -p challenge-harder
         env:
-          # Set a dedicated database for tests.
+          # Set dedicated databases for tests.
           BLERT_TEST_REDIS_URI: redis://localhost:6379/15
+          BLERT_TEST_DATABASE_URI: postgres://blert:blert@localhost:5432/blert_test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,10 +224,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -260,6 +275,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "challenge-harder"
 version = "0.1.0"
 dependencies = [
@@ -267,6 +293,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
+ "deadpool-postgres",
  "futures-util",
  "http-body-util",
  "hyper-util",
@@ -280,6 +307,7 @@ dependencies = [
  "serde_repr",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -338,6 +366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +401,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,10 +423,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime 0.1.4",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
 
 [[package]]
 name = "deadpool"
@@ -394,9 +473,23 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
 dependencies = [
- "deadpool-runtime",
+ "deadpool-runtime 0.3.1",
  "num_cpus",
  "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool 0.12.3",
+ "getrandom 0.2.17",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]
@@ -405,8 +498,17 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafa30c49dafe086d10116074e422ad7fc1c3cf554697e744a3ab112599ebd09"
 dependencies = [
- "deadpool",
+ "deadpool 0.13.0",
  "redis",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -416,6 +518,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
@@ -479,6 +593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -570,8 +691,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -595,6 +718,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -623,6 +747,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -668,6 +801,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -884,6 +1026,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1102,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -1040,6 +1201,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1283,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1312,36 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.10.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+ "uuid",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1266,7 +1494,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1276,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1289,13 +1528,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -1581,6 +1826,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1860,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1632,6 +1894,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -1745,6 +2018,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +2058,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -1954,7 +2268,7 @@ checksum = "0061c28f1469e94771bb8aa626ce6b29265c2fb5034115046a170b0cba2e33d2"
 dependencies = [
  "bytes",
  "indexmap",
- "rand",
+ "rand 0.9.4",
  "rand_distr",
  "scoped-tls",
  "tokio",
@@ -1962,10 +2276,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "untrusted"
@@ -2031,12 +2372,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2082,6 +2441,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/challenge-harder/Cargo.toml
+++ b/challenge-harder/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = "0.1.89"
 axum = { version = "0.8.9", features = ["macros"] }
 bytes = "1.12.1"
 clap = { version = "4.6", features = ["derive"] }
+deadpool-postgres = "0.14.1"
 futures-util = { version = "0.3.32", default-features = false, features = ["std", "async-await"] }
 http-body-util = "0.1.3"
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
@@ -28,6 +29,7 @@ tokio = { version = "1.52.3", features = [
   "sync",
   "time",
 ] }
+tokio-postgres = { version = "0.7.18", features = ["with-uuid-1"] }
 tower-http = { version = "0.7.0", features = ["trace"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }

--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -19,7 +19,7 @@ use super::core::state::{
     Snapshot,
 };
 use super::core::types::{ClientId, JournalSeq, MsgId, Timestamp, Uuid};
-use crate::processing::{ProcessingRequest, StageProcessor};
+use crate::processing::{ChallengeInfo, ProcessingRequest, StageProcessor};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum StoreError {
@@ -562,14 +562,23 @@ impl ActiveChallenge {
         let request = ProcessingRequest {
             uuid: self.state.uuid,
             trigger: run.trigger,
+            challenge: ChallengeInfo {
+                challenge_type: self.state.challenge_type,
+                mode: self.state.mode,
+                party: self.state.party.clone(),
+                stage: self.state.stage,
+                status: self.state.status(),
+                created_unix_ms: self.state.created_unix_ms,
+            },
         };
+        let trigger = request.trigger.seq();
         Some(ProcessingTask {
-            trigger: request.trigger.seq(),
+            trigger,
             handle: tokio::spawn(async move {
                 let result = processor.process(request).await;
                 let _ = chanel
                     .send(Processed {
-                        trigger: request.trigger.seq(),
+                        trigger,
                         attempt,
                         result,
                     })
@@ -924,6 +933,7 @@ mod tests {
 
         let expected = ChallengeState {
             uuid: outcome.uuid,
+            created_unix_ms: 0,
             challenge_type: ChallengeType::Tob,
             mode: ChallengeMode::TobRegular,
             party: vec!["a".into()],
@@ -1056,6 +1066,7 @@ mod tests {
         );
         let expected = ChallengeState {
             uuid,
+            created_unix_ms: 0,
             challenge_type: ChallengeType::Tob,
             mode: ChallengeMode::TobRegular,
             party: vec!["a".into()],

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -26,6 +26,9 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             stage,
         } => {
             state.uuid = uuid;
+            if let Cause::Command(id) = entry.caused_by {
+                state.created_unix_ms = id.unix_millis();
+            }
             state.challenge_type = challenge_type;
             state.mode = mode;
             state.party = party;
@@ -43,7 +46,17 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             session_token,
             recording_type,
         } => {
-            state.recorded_by.insert(client_id);
+            // Process each client the first time it joins.
+            if state.recorded_by.insert(client_id) {
+                state.processing.push(
+                    Trigger::Recorder {
+                        seq: entry.seq,
+                        user_id,
+                        recording_type,
+                    },
+                    entry.at,
+                );
+            }
             state.clients.insert(
                 client_id,
                 ClientState {
@@ -140,12 +153,12 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         }
         LifecycleEvent::ProcessingFinished {
             trigger: _,
-            outcome,
+            payload,
         } => {
             let challenge_type = state.challenge_type;
             state
                 .processing
-                .finish(challenge_type, entry.at, Ok(outcome));
+                .finish(challenge_type, entry.at, Ok(payload));
         }
         LifecycleEvent::ProcessingFailed { trigger: _, error } => {
             let challenge_type = state.challenge_type;
@@ -234,7 +247,7 @@ mod tests {
     use crate::lifecycle::core::state::{Processing, ProcessingConfig, ProcessingState, Trigger};
     use crate::lifecycle::core::types::{
         ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId,
-        ProcessingOutcome, RecordingType, ReportedTimes, Stage, Timestamp, UserId, Uuid,
+        ProcessingPayload, RecordingType, ReportedTimes, Stage, Timestamp, UserId, Uuid,
     };
 
     const CLIENT: ClientId = ClientId(10);
@@ -979,7 +992,7 @@ mod tests {
                 400,
                 LifecycleEvent::ProcessingFinished {
                     trigger: JournalSeq(0),
-                    outcome: ProcessingOutcome::Boundary,
+                    payload: ProcessingPayload::None,
                 },
             ),
         );
@@ -1081,7 +1094,7 @@ mod tests {
                 6_000,
                 LifecycleEvent::ProcessingFinished {
                     trigger: JournalSeq(5),
-                    outcome: ProcessingOutcome::Stage {
+                    payload: ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     },

--- a/challenge-harder/src/lifecycle/core/command.rs
+++ b/challenge-harder/src/lifecycle/core/command.rs
@@ -5,7 +5,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use super::deadline::Deadline;
 use super::types::{
-    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError, ProcessingOutcome,
+    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError, ProcessingPayload,
     RecordingType, ReportedTimes, SessionToken, Stage, StageStatus, UserId,
 };
 
@@ -110,7 +110,7 @@ pub struct Processed {
     pub trigger: JournalSeq,
     /// The run attempt which produced the result.
     pub attempt: u32,
-    pub result: Result<ProcessingOutcome, ProcessingError>,
+    pub result: Result<ProcessingPayload, ProcessingError>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/challenge-harder/src/lifecycle/core/deadline.rs
+++ b/challenge-harder/src/lifecycle/core/deadline.rs
@@ -21,7 +21,7 @@ pub enum DeadlineKind {
     /// Inactivity window while every client is idle.
     CleanupAllIdle,
     /// Delay before the next attempt of a failed processing run.
-    ProcessingRetry,
+    ProcessingDue,
     /// Cap on the duration of a processing run attempt.
     ProcessingTimeout,
 }
@@ -158,7 +158,7 @@ fn processing_deadline(state: &ChallengeState) -> Option<Deadline> {
                 config.retry_backoff
             };
             Some(Deadline {
-                kind: DeadlineKind::ProcessingRetry,
+                kind: DeadlineKind::ProcessingDue,
                 at: since + backoff,
             })
         }
@@ -436,7 +436,7 @@ mod tests {
         assert_eq!(
             next_deadline(&state, &test_config()),
             Some(Deadline {
-                kind: DeadlineKind::ProcessingRetry,
+                kind: DeadlineKind::ProcessingDue,
                 at: Timestamp::from_millis(5_000),
             }),
         );
@@ -451,7 +451,7 @@ mod tests {
         assert_eq!(
             next_deadline(&state, &test_config()),
             Some(Deadline {
-                kind: DeadlineKind::ProcessingRetry,
+                kind: DeadlineKind::ProcessingDue,
                 at: Timestamp::from_millis(8_000),
             }),
         );
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(
             next_deadline(&state, &test_config()),
             Some(Deadline {
-                kind: DeadlineKind::ProcessingRetry,
+                kind: DeadlineKind::ProcessingDue,
                 at: Timestamp::from_millis(5_500),
             }),
         );

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -296,7 +296,7 @@ fn deadline_fired(
             });
             events
         }
-        DeadlineKind::ProcessingRetry => {
+        DeadlineKind::ProcessingDue => {
             let Some(run) = state.processing.active() else {
                 unreachable!("processing deadlines imply an active run");
             };
@@ -376,9 +376,9 @@ fn processed(state: &ChallengeState, report: &Processed) -> Vec<LifecycleEvent> 
     }
 
     match &report.result {
-        Ok(outcome) => vec![LifecycleEvent::ProcessingFinished {
+        Ok(payload) => vec![LifecycleEvent::ProcessingFinished {
             trigger: report.trigger,
-            outcome: *outcome,
+            payload: *payload,
         }],
         Err(error) => vec![LifecycleEvent::ProcessingFailed {
             trigger: report.trigger,
@@ -395,7 +395,7 @@ mod tests {
     use crate::lifecycle::core::command::{Processed, StageProgress};
     use crate::lifecycle::core::state::{ClientState, Processing, ProcessingConfig, Trigger};
     use crate::lifecycle::core::types::{
-        ClientId, JournalSeq, ProcessingError, ProcessingOutcome, RecordingType, ReportedTimes,
+        ClientId, JournalSeq, ProcessingError, ProcessingPayload, RecordingType, ReportedTimes,
         Timestamp, UserId, Uuid,
     };
 
@@ -1716,7 +1716,7 @@ mod tests {
     fn processing_result(
         trigger: u64,
         attempt: u32,
-        result: Result<ProcessingOutcome, ProcessingError>,
+        result: Result<ProcessingPayload, ProcessingError>,
     ) -> Command {
         Command::Processed(Processed {
             trigger: JournalSeq(trigger),
@@ -1735,7 +1735,7 @@ mod tests {
                 &processing_result(
                     5,
                     1,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     })
@@ -1743,7 +1743,7 @@ mod tests {
             ),
             vec![LifecycleEvent::ProcessingFinished {
                 trigger: JournalSeq(5),
-                outcome: ProcessingOutcome::Stage {
+                payload: ProcessingPayload::Stage {
                     status: StageStatus::Completed,
                     ticks: 237,
                 },
@@ -1777,7 +1777,7 @@ mod tests {
                 &processing_result(
                     4,
                     1,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     })
@@ -1797,7 +1797,7 @@ mod tests {
                 &processing_result(
                     5,
                     1,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     })
@@ -1826,7 +1826,7 @@ mod tests {
                 &processing_result(
                     5,
                     1,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     })
@@ -1860,7 +1860,7 @@ mod tests {
                 &processing_result(
                     5,
                     1,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     })
@@ -1875,7 +1875,7 @@ mod tests {
                 &processing_result(
                     5,
                     2,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Wiped,
                         ticks: 180,
                     })
@@ -1883,7 +1883,7 @@ mod tests {
             ),
             vec![LifecycleEvent::ProcessingFinished {
                 trigger: JournalSeq(5),
-                outcome: ProcessingOutcome::Stage {
+                payload: ProcessingPayload::Stage {
                     status: StageStatus::Wiped,
                     ticks: 180,
                 },
@@ -1896,7 +1896,7 @@ mod tests {
         let state = sealed_tob_state();
         let fired = next_deadline(&state, &LifecycleConfig::default())
             .expect("a fresh run implies a deadline");
-        assert_eq!(fired.kind, DeadlineKind::ProcessingRetry);
+        assert_eq!(fired.kind, DeadlineKind::ProcessingDue);
         assert_eq!(
             decide(
                 &state,
@@ -1949,7 +1949,7 @@ mod tests {
                 &processing_result(
                     5,
                     1,
-                    Ok(ProcessingOutcome::Stage {
+                    Ok(ProcessingPayload::Stage {
                         status: StageStatus::Completed,
                         ticks: 237,
                     })
@@ -1957,7 +1957,7 @@ mod tests {
             ),
             vec![LifecycleEvent::ProcessingFinished {
                 trigger: JournalSeq(5),
-                outcome: ProcessingOutcome::Stage {
+                payload: ProcessingPayload::Stage {
                     status: StageStatus::Completed,
                     ticks: 237,
                 },

--- a/challenge-harder/src/lifecycle/core/event.rs
+++ b/challenge-harder/src/lifecycle/core/event.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::command::StageProgress;
 use super::deadline::DeadlineKind;
 use super::types::{
-    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError, ProcessingOutcome,
+    ChallengeMode, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError, ProcessingPayload,
     RecordingType, ReportedTimes, SessionToken, Stage, Timestamp, UserId, Uuid,
 };
 
@@ -85,7 +85,7 @@ pub enum LifecycleEvent {
     },
     ProcessingFinished {
         trigger: JournalSeq,
-        outcome: ProcessingOutcome,
+        payload: ProcessingPayload,
     },
     ProcessingFailed {
         trigger: JournalSeq,
@@ -165,7 +165,7 @@ mod tests {
             caused_by: Cause::Processing(JournalSeq(5)),
             event: LifecycleEvent::ProcessingFinished {
                 trigger: JournalSeq(5),
-                outcome: ProcessingOutcome::Stage {
+                payload: ProcessingPayload::Stage {
                     status: StageStatus::Completed,
                     ticks: 237,
                 },
@@ -174,30 +174,30 @@ mod tests {
         let json = serde_json::to_string(&processed).unwrap();
         assert_eq!(
             json,
-            r#"{"seq":6,"at":4000,"caused_by":5,"event":{"ProcessingFinished":{"trigger":5,"outcome":{"Stage":{"status":2,"ticks":237}}}}}"#
+            r#"{"seq":6,"at":4000,"caused_by":5,"event":{"ProcessingFinished":{"trigger":5,"payload":{"Stage":{"status":2,"ticks":237}}}}}"#
         );
         assert_eq!(
             serde_json::from_str::<JournalEntry>(&json).unwrap(),
             processed
         );
 
-        let boundary = JournalEntry {
+        let payloadless = JournalEntry {
             seq: JournalSeq(8),
             at: Timestamp::from_millis(4_200),
             caused_by: Cause::Processing(JournalSeq(0)),
             event: LifecycleEvent::ProcessingFinished {
                 trigger: JournalSeq(0),
-                outcome: ProcessingOutcome::Boundary,
+                payload: ProcessingPayload::None,
             },
         };
-        let json = serde_json::to_string(&boundary).unwrap();
+        let json = serde_json::to_string(&payloadless).unwrap();
         assert_eq!(
             json,
-            r#"{"seq":8,"at":4200,"caused_by":0,"event":{"ProcessingFinished":{"trigger":0,"outcome":"Boundary"}}}"#
+            r#"{"seq":8,"at":4200,"caused_by":0,"event":{"ProcessingFinished":{"trigger":0,"payload":"None"}}}"#
         );
         assert_eq!(
             serde_json::from_str::<JournalEntry>(&json).unwrap(),
-            boundary
+            payloadless
         );
 
         let failed = JournalEntry {

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -8,7 +8,7 @@ use core::time::Duration;
 
 use super::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, ClientId, JournalSeq, MsgId,
-    ProcessingError, ProcessingOutcome, RecordingType, ReportedTimes, SessionToken, Stage,
+    ProcessingError, ProcessingPayload, RecordingType, ReportedTimes, SessionToken, Stage,
     StageStatus, Timestamp, UserId, Uuid,
 };
 
@@ -77,6 +77,12 @@ impl Default for ProcessingConfig {
 pub enum Trigger {
     /// A new challenge was created.
     Create { seq: JournalSeq },
+    /// A new client joined the challenge.
+    Recorder {
+        seq: JournalSeq,
+        user_id: UserId,
+        recording_type: RecordingType,
+    },
     /// A stage completed.
     Stage {
         seq: JournalSeq,
@@ -92,7 +98,10 @@ impl Trigger {
     #[must_use]
     pub fn seq(self) -> JournalSeq {
         match self {
-            Trigger::Create { seq } | Trigger::Stage { seq, .. } | Trigger::Finish { seq } => seq,
+            Trigger::Create { seq }
+            | Trigger::Recorder { seq, .. }
+            | Trigger::Stage { seq, .. }
+            | Trigger::Finish { seq } => seq,
         }
     }
 }
@@ -182,18 +191,18 @@ impl Processing {
         &mut self,
         challenge_type: ChallengeType,
         at: Timestamp,
-        result: Result<ProcessingOutcome, ProcessingError>,
+        result: Result<ProcessingPayload, ProcessingError>,
     ) {
         let Some(run) = &mut self.active else {
             return;
         };
         match result {
-            Ok(ProcessingOutcome::Stage { status, .. }) => {
+            Ok(ProcessingPayload::Stage { status, .. }) => {
                 if let Trigger::Stage { stage, .. } = run.trigger {
                     self.status = Some(status_if_finished_now(challenge_type, stage, status));
                 }
             }
-            Ok(ProcessingOutcome::Boundary) => {}
+            Ok(ProcessingPayload::None) => {}
             Err(error) => {
                 run.retriable &= error.retriable;
                 if !run.exhausted(&self.config) {
@@ -357,6 +366,8 @@ impl Snapshot {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ChallengeState {
     pub uuid: Uuid,
+    /// Time at which the challenge's create command was queued.
+    pub created_unix_ms: u64,
     pub challenge_type: ChallengeType,
     pub mode: ChallengeMode,
     pub party: Vec<String>,
@@ -449,8 +460,8 @@ mod tests {
         }
     }
 
-    fn outcome(status: StageStatus) -> ProcessingOutcome {
-        ProcessingOutcome::Stage { status, ticks: 100 }
+    fn outcome(status: StageStatus) -> ProcessingPayload {
+        ProcessingPayload::Stage { status, ticks: 100 }
     }
 
     fn error(retriable: bool) -> ProcessingError {

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -73,6 +73,12 @@ impl MsgId {
     pub const fn sequence(seq: u64) -> Self {
         Self { ms: 0, seq }
     }
+
+    /// The id's timestamp component.
+    #[must_use]
+    pub const fn unix_millis(self) -> u64 {
+        self.ms
+    }
 }
 
 impl std::fmt::Display for MsgId {
@@ -177,6 +183,20 @@ pub enum RecordingType {
     Participant = 1,
 }
 
+/// The gear a player wears in a challenge.
+/// Matches `PrimaryMeleeGear` in `//common/challenge.ts`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum PrimaryMeleeGear {
+    #[default]
+    Unknown = 0,
+    EliteVoid = 1,
+    Bandos = 2,
+    Torva = 3,
+    Blorva = 4,
+    Oathplate = 5,
+}
+
 // Compile-time parity checks against the upstream TS values.
 const _: () = {
     assert!(ChallengeStatus::InProgress as u8 == 0);
@@ -187,6 +207,13 @@ const _: () = {
 
     assert!(RecordingType::Spectator as u8 == 0);
     assert!(RecordingType::Participant as u8 == 1);
+
+    assert!(PrimaryMeleeGear::Unknown as u8 == 0);
+    assert!(PrimaryMeleeGear::EliteVoid as u8 == 1);
+    assert!(PrimaryMeleeGear::Bandos as u8 == 2);
+    assert!(PrimaryMeleeGear::Torva as u8 == 3);
+    assert!(PrimaryMeleeGear::Blorva as u8 == 4);
+    assert!(PrimaryMeleeGear::Oathplate as u8 == 5);
 };
 
 /// Client-reported completion times, in ticks.
@@ -196,13 +223,13 @@ pub struct ReportedTimes {
     pub overall: u32,
 }
 
-/// Result of a completed processing run.
+/// Result that a completed processing run feeds back into the challenge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProcessingOutcome {
-    /// A stage's events were processed.
+pub enum ProcessingPayload {
+    /// A processed stage's summary.
     Stage { status: StageStatus, ticks: u32 },
-    /// A challenge creation or termination boundary ran its effects.
-    Boundary,
+    /// No additional data.
+    None,
 }
 
 /// Serializable error from the stage processing pipeline.

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -37,7 +37,7 @@ use super::core::state::{
 };
 use super::core::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ClientId, MsgId, ProcessingError,
-    ProcessingOutcome, RecordingType, ReportedTimes, SessionToken, Stage, StageExt, StageStatus,
+    ProcessingPayload, RecordingType, ReportedTimes, SessionToken, Stage, StageExt, StageStatus,
     UserId, Uuid,
 };
 use crate::processing::{ProcessingRequest, StageProcessor};
@@ -696,7 +696,7 @@ impl ChallengeClaim for CollectorClaim {
 /// A scripted resolution of a processing run.
 pub(crate) enum ProcessingAttempt {
     /// Resolve with `result` after a delay in virtual milliseconds.
-    Resolve(u64, Result<ProcessingOutcome, ProcessingError>),
+    Resolve(u64, Result<ProcessingPayload, ProcessingError>),
     /// Hang until aborted.
     Hang,
 }
@@ -732,7 +732,8 @@ impl StageProcessor for ScriptedProcessor {
     async fn process(
         &self,
         request: ProcessingRequest,
-    ) -> Result<ProcessingOutcome, ProcessingError> {
+    ) -> Result<ProcessingPayload, ProcessingError> {
+        let trigger = request.trigger;
         self.requests
             .lock()
             .expect("processor lock poisoned")
@@ -748,12 +749,14 @@ impl StageProcessor for ScriptedProcessor {
                 result
             }
             Some(ProcessingAttempt::Hang) => std::future::pending().await,
-            None => Ok(match request.trigger {
-                Trigger::Stage { .. } => ProcessingOutcome::Stage {
+            None => Ok(match trigger {
+                Trigger::Stage { .. } => ProcessingPayload::Stage {
                     status: StageStatus::Completed,
                     ticks: 0,
                 },
-                Trigger::Create { .. } | Trigger::Finish { .. } => ProcessingOutcome::Boundary,
+                Trigger::Create { .. } | Trigger::Recorder { .. } | Trigger::Finish { .. } => {
+                    ProcessingPayload::None
+                }
             }),
         }
     }
@@ -1105,6 +1108,7 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
 
         let mut seals = Vec::new();
         let mut trigger_seqs = HashSet::new();
+        let mut joined = HashSet::new();
         let mut terminated = false;
 
         for entry in journal {
@@ -1125,6 +1129,12 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
                 LifecycleEvent::ChallengeCreated { .. }
                 | LifecycleEvent::ChallengeTerminated { .. } => {
                     trigger_seqs.insert(entry.seq);
+                }
+                // Only a client's first join triggers processing.
+                LifecycleEvent::ClientJoined { client_id, .. } => {
+                    if joined.insert(*client_id) {
+                        trigger_seqs.insert(entry.seq);
+                    }
                 }
                 LifecycleEvent::StageSealed { stage, attempt, .. } => {
                     assert!(

--- a/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
@@ -10,7 +10,7 @@ use crate::lifecycle::coordinator::Coordinator;
 use crate::lifecycle::core::command::{Create, Finish, Update};
 use crate::lifecycle::core::deadline::{DeadlineKind, LifecycleConfig};
 use crate::lifecycle::core::state::{ProcessingConfig, Trigger};
-use crate::lifecycle::core::types::{ChallengeStatus, ProcessingError, ProcessingOutcome, Uuid};
+use crate::lifecycle::core::types::{ChallengeStatus, ProcessingError, ProcessingPayload, Uuid};
 use crate::lifecycle::sim::{
     Collector, ProcessingAttempt, RunOptions, Scenario, ScriptedProcessor, run_with,
 };
@@ -45,12 +45,13 @@ fn solo_hmt_start() -> Action {
     }
 }
 
-fn outcome(status: StageStatus, ticks: u32) -> ProcessingOutcome {
-    ProcessingOutcome::Stage { status, ticks }
+fn outcome(status: StageStatus, ticks: u32) -> ProcessingPayload {
+    ProcessingPayload::Stage { status, ticks }
 }
 
-fn boundary() -> ProcessingAttempt {
-    ProcessingAttempt::Resolve(0, Ok(ProcessingOutcome::Boundary))
+/// An instantly resolving attempt with nothing for the fold.
+fn no_payload() -> ProcessingAttempt {
+    ProcessingAttempt::Resolve(0, Ok(ProcessingPayload::None))
 }
 
 fn retriable_failure() -> ProcessingError {
@@ -66,10 +67,10 @@ fn started(trigger: u64) -> LifecycleEvent {
     }
 }
 
-fn finished(trigger: u64, outcome: ProcessingOutcome) -> LifecycleEvent {
+fn finished(trigger: u64, payload: ProcessingPayload) -> LifecycleEvent {
     LifecycleEvent::ProcessingFinished {
         trigger: JournalSeq(trigger),
-        outcome,
+        payload,
     }
 }
 
@@ -94,40 +95,43 @@ fn solo_maiden_wipe(finish_at: u64) -> Scenario {
 #[tokio::test(start_paused = true)]
 async fn sealed_stage_processes_and_journals_its_run() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(500, Ok(outcome(StageStatus::Completed, 237))),
     ]);
     let result = run_with(options(&processor), solo_maiden_wipe(2_000)).await;
 
     let (_, journal) = result.only_challenge();
     assert_eq!(
-        journal[2..4],
+        journal[2..6],
         vec![
             entry(
                 2,
                 0,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
+                Cause::Deadline(DeadlineKind::ProcessingDue),
                 started(0)
             ),
+            entry(3, 0, processing(0), finished(0, ProcessingPayload::None)),
             entry(
-                3,
+                4,
                 0,
-                processing(0),
-                finished(0, ProcessingOutcome::Boundary)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(1)
             ),
+            entry(5, 0, processing(1), finished(1, ProcessingPayload::None)),
         ],
     );
     assert_eq!(
-        journal[6..],
+        journal[8..],
         vec![
             entry(
-                6,
+                8,
                 1_000,
                 cmd(3),
                 reported(1, Stage::TobMaiden, StageStatus::Wiped)
             ),
             entry(
-                7,
+                9,
                 1_000,
                 cmd(3),
                 LifecycleEvent::StageSealed {
@@ -137,19 +141,19 @@ async fn sealed_stage_processes_and_journals_its_run() {
                 },
             ),
             entry(
-                8,
-                1_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(7)
-            ),
-            entry(
-                9,
-                1_500,
-                processing(7),
-                finished(7, outcome(StageStatus::Completed, 237)),
-            ),
-            entry(
                 10,
+                1_000,
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(9)
+            ),
+            entry(
+                11,
+                1_500,
+                processing(9),
+                finished(9, outcome(StageStatus::Completed, 237)),
+            ),
+            entry(
+                12,
                 2_000,
                 cmd(4),
                 LifecycleEvent::ClientFinished {
@@ -160,22 +164,22 @@ async fn sealed_stage_processes_and_journals_its_run() {
                 },
             ),
             entry(
-                11,
+                13,
                 2_000,
                 cmd(4),
                 LifecycleEvent::ChallengeTerminated { empty: false },
             ),
             entry(
-                12,
+                14,
                 2_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(11)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(13)
             ),
             entry(
-                13,
+                15,
                 2_000,
-                processing(11),
-                finished(11, ProcessingOutcome::Boundary),
+                processing(13),
+                finished(13, ProcessingPayload::None),
             ),
         ],
     );
@@ -187,13 +191,18 @@ async fn sealed_stage_processes_and_journals_its_run() {
         triggers,
         vec![
             Trigger::Create { seq: JournalSeq(0) },
+            Trigger::Recorder {
+                seq: JournalSeq(1),
+                user_id: UserId(1),
+                recording_type: RecordingType::Participant,
+            },
             Trigger::Stage {
-                seq: JournalSeq(7),
+                seq: JournalSeq(9),
                 stage: Stage::TobMaiden,
                 attempt: None,
             },
             Trigger::Finish {
-                seq: JournalSeq(11)
+                seq: JournalSeq(13)
             },
         ],
     );
@@ -202,7 +211,8 @@ async fn sealed_stage_processes_and_journals_its_run() {
 #[tokio::test(start_paused = true)]
 async fn timed_out_run_retries_after_backoff() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Hang,
         ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 180))),
     ]);
@@ -210,42 +220,43 @@ async fn timed_out_run_retries_after_backoff() {
 
     let (_, journal) = result.only_challenge();
     assert_eq!(
-        journal[8..11],
+        journal[10..13],
         vec![
             entry(
-                8,
+                10,
                 1_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(7)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(9)
             ),
             entry(
-                9,
+                11,
                 11_000,
                 Cause::Deadline(DeadlineKind::ProcessingTimeout),
                 LifecycleEvent::ProcessingTimedOut {
-                    trigger: JournalSeq(7),
+                    trigger: JournalSeq(9),
                 },
             ),
             entry(
-                10,
+                12,
                 14_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(7)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(9)
             ),
         ],
     );
     assert_eq!(
-        journal[11].event,
-        finished(7, outcome(StageStatus::Wiped, 180))
+        journal[13].event,
+        finished(9, outcome(StageStatus::Wiped, 180))
     );
     assert_eq!(result.only_status(), ChallengeStatus::Wiped);
-    assert_eq!(processor.requests().len(), 4);
+    assert_eq!(processor.requests().len(), 5);
 }
 
 #[tokio::test(start_paused = true)]
 async fn run_gives_up_after_max_retries_and_the_challenge_concludes() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(0, Err(retriable_failure())),
         ProcessingAttempt::Resolve(0, Err(retriable_failure())),
     ]);
@@ -253,35 +264,35 @@ async fn run_gives_up_after_max_retries_and_the_challenge_concludes() {
 
     let (uuid, journal) = result.only_challenge();
     assert_eq!(
-        journal[8..12],
+        journal[10..14],
         vec![
             entry(
-                8,
+                10,
                 1_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(7)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(9)
             ),
             entry(
-                9,
+                11,
                 1_000,
-                processing(7),
+                processing(9),
                 LifecycleEvent::ProcessingFailed {
-                    trigger: JournalSeq(7),
+                    trigger: JournalSeq(9),
                     error: retriable_failure(),
                 },
             ),
             entry(
-                10,
+                12,
                 4_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(7)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(9)
             ),
             entry(
-                11,
+                13,
                 4_000,
-                processing(7),
+                processing(9),
                 LifecycleEvent::ProcessingFailed {
-                    trigger: JournalSeq(7),
+                    trigger: JournalSeq(9),
                     error: retriable_failure(),
                 },
             ),
@@ -292,13 +303,14 @@ async fn run_gives_up_after_max_retries_and_the_challenge_concludes() {
     // own reported progress, and the challenge still concludes.
     assert_eq!(result.only_status(), ChallengeStatus::Wiped);
     assert!(result.deleted.contains(&uuid));
-    assert_eq!(processor.requests().len(), 4);
+    assert_eq!(processor.requests().len(), 5);
 }
 
 #[tokio::test(start_paused = true)]
 async fn non_retriable_failure_gives_up_immediately() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(
             0,
             Err(ProcessingError {
@@ -311,44 +323,45 @@ async fn non_retriable_failure_gives_up_immediately() {
 
     let (uuid, _) = result.only_challenge();
     assert!(result.deleted.contains(&uuid));
-    assert_eq!(processor.requests().len(), 3);
+    assert_eq!(processor.requests().len(), 4);
 }
 
 #[tokio::test(start_paused = true)]
 async fn finalization_waits_for_processing_to_finish_after_termination() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(5_000, Ok(outcome(StageStatus::Completed, 237))),
     ]);
     let result = run_with(options(&processor), solo_maiden_wipe(2_000)).await;
 
     let (uuid, journal) = result.only_challenge();
     assert_eq!(
-        journal[10..],
+        journal[12..],
         vec![
             entry(
-                10,
+                12,
                 2_000,
                 cmd(4),
                 LifecycleEvent::ChallengeTerminated { empty: false },
             ),
             entry(
-                11,
-                6_000,
-                processing(7),
-                finished(7, outcome(StageStatus::Completed, 237)),
-            ),
-            entry(
-                12,
-                6_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(10)
-            ),
-            entry(
                 13,
                 6_000,
-                processing(10),
-                finished(10, ProcessingOutcome::Boundary),
+                processing(9),
+                finished(9, outcome(StageStatus::Completed, 237)),
+            ),
+            entry(
+                14,
+                6_000,
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(12)
+            ),
+            entry(
+                15,
+                6_000,
+                processing(12),
+                finished(12, ProcessingPayload::None),
             ),
         ],
     );
@@ -361,7 +374,8 @@ async fn finalization_waits_for_processing_to_finish_after_termination() {
 #[tokio::test(start_paused = true)]
 async fn queued_trigger_processes_after_the_active_run() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(2_000, Ok(outcome(StageStatus::Completed, 100))),
         ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 50))),
     ]);
@@ -390,35 +404,38 @@ async fn queued_trigger_processes_after_the_active_run() {
             matches!(entry.caused_by, Cause::Processing(_))
                 || matches!(
                     entry.caused_by,
-                    Cause::Deadline(
-                        DeadlineKind::ProcessingRetry | DeadlineKind::ProcessingTimeout
-                    )
+                    Cause::Deadline(DeadlineKind::ProcessingDue | DeadlineKind::ProcessingTimeout)
                 )
         })
         .collect();
-    assert_eq!(processing_events.len(), 8);
+    assert_eq!(processing_events.len(), 10);
     assert_eq!(processing_events[0].event, started(0));
     assert_eq!(processing_events[0].at, Timestamp::ZERO);
     assert_eq!(
         processing_events[1].event,
-        finished(0, ProcessingOutcome::Boundary)
+        finished(0, ProcessingPayload::None)
     );
-    assert_eq!(processing_events[2].event, started(7));
-    assert_eq!(processing_events[2].at, Timestamp::from_millis(1_000));
+    assert_eq!(processing_events[2].event, started(1));
     assert_eq!(
         processing_events[3].event,
-        finished(7, outcome(StageStatus::Completed, 100)),
+        finished(1, ProcessingPayload::None)
     );
-    assert_eq!(processing_events[3].at, Timestamp::from_millis(3_000));
-    assert_eq!(processing_events[4].at, Timestamp::from_millis(3_000));
+    assert_eq!(processing_events[4].event, started(9));
+    assert_eq!(processing_events[4].at, Timestamp::from_millis(1_000));
     assert_eq!(
         processing_events[5].event,
-        finished(12, outcome(StageStatus::Wiped, 50)),
+        finished(9, outcome(StageStatus::Completed, 100)),
     );
-    assert_eq!(processing_events[6].event, started(17));
+    assert_eq!(processing_events[5].at, Timestamp::from_millis(3_000));
+    assert_eq!(processing_events[6].at, Timestamp::from_millis(3_000));
     assert_eq!(
         processing_events[7].event,
-        finished(17, ProcessingOutcome::Boundary)
+        finished(14, outcome(StageStatus::Wiped, 50)),
+    );
+    assert_eq!(processing_events[8].event, started(19));
+    assert_eq!(
+        processing_events[9].event,
+        finished(19, ProcessingPayload::None)
     );
 
     let triggers: Vec<Trigger> = processor.requests().iter().map(|r| r.trigger).collect();
@@ -426,18 +443,23 @@ async fn queued_trigger_processes_after_the_active_run() {
         triggers,
         vec![
             Trigger::Create { seq: JournalSeq(0) },
+            Trigger::Recorder {
+                seq: JournalSeq(1),
+                user_id: UserId(1),
+                recording_type: RecordingType::Participant,
+            },
             Trigger::Stage {
-                seq: JournalSeq(7),
+                seq: JournalSeq(9),
                 stage: Stage::TobMaiden,
                 attempt: None,
             },
             Trigger::Stage {
-                seq: JournalSeq(12),
+                seq: JournalSeq(14),
                 stage: Stage::TobBloat,
                 attempt: None,
             },
             Trigger::Finish {
-                seq: JournalSeq(17)
+                seq: JournalSeq(19)
             },
         ],
     );
@@ -448,7 +470,8 @@ async fn queued_trigger_processes_after_the_active_run() {
 #[tokio::test(start_paused = true)]
 async fn late_commands_post_termination_while_processing() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(5_000, Ok(outcome(StageStatus::Completed, 237))),
     ]);
     let result = run_with(
@@ -472,31 +495,31 @@ async fn late_commands_post_termination_while_processing() {
     // published cursor so its sender's applied wait resolves.
     let (uuid, journal) = result.only_challenge();
     assert_eq!(
-        journal[10..],
+        journal[12..],
         vec![
             entry(
-                10,
+                12,
                 2_000,
                 cmd(4),
                 LifecycleEvent::ChallengeTerminated { empty: false },
             ),
             entry(
-                11,
-                6_000,
-                processing(7),
-                finished(7, outcome(StageStatus::Completed, 237)),
-            ),
-            entry(
-                12,
-                6_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(10)
-            ),
-            entry(
                 13,
                 6_000,
-                processing(10),
-                finished(10, ProcessingOutcome::Boundary),
+                processing(9),
+                finished(9, outcome(StageStatus::Completed, 237)),
+            ),
+            entry(
+                14,
+                6_000,
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(12)
+            ),
+            entry(
+                15,
+                6_000,
+                processing(12),
+                finished(12, ProcessingPayload::None),
             ),
         ],
     );
@@ -508,7 +531,8 @@ async fn late_commands_post_termination_while_processing() {
 #[tokio::test(start_paused = true)]
 async fn failed_finish_run_concludes_afterwards() {
     let processor = ScriptedProcessor::new(vec![
-        boundary(),
+        no_payload(),
+        no_payload(),
         ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 60))),
         ProcessingAttempt::Resolve(0, Err(retriable_failure())),
         ProcessingAttempt::Resolve(0, Err(retriable_failure())),
@@ -517,35 +541,35 @@ async fn failed_finish_run_concludes_afterwards() {
 
     let (uuid, journal) = result.only_challenge();
     assert_eq!(
-        journal[12..],
+        journal[14..],
         vec![
             entry(
-                12,
+                14,
                 2_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(11)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(13)
             ),
             entry(
-                13,
+                15,
                 2_000,
-                processing(11),
+                processing(13),
                 LifecycleEvent::ProcessingFailed {
-                    trigger: JournalSeq(11),
+                    trigger: JournalSeq(13),
                     error: retriable_failure(),
                 },
             ),
             entry(
-                14,
+                16,
                 5_000,
-                Cause::Deadline(DeadlineKind::ProcessingRetry),
-                started(11)
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(13)
             ),
             entry(
-                15,
+                17,
                 5_000,
-                processing(11),
+                processing(13),
                 LifecycleEvent::ProcessingFailed {
-                    trigger: JournalSeq(11),
+                    trigger: JournalSeq(13),
                     error: retriable_failure(),
                 },
             ),
@@ -637,7 +661,7 @@ fn killed_run_respawns_on_resume() {
     // The first server's stage run hangs, and the server dies mid-attempt.
     let store = collector.clone();
     let r1 = rx.clone();
-    let first = ScriptedProcessor::new(vec![boundary(), ProcessingAttempt::Hang]);
+    let first = ScriptedProcessor::new(vec![no_payload(), no_payload(), ProcessingAttempt::Hang]);
     let processor = Arc::clone(&first) as Arc<dyn StageProcessor>;
     let uuid = runtime().block_on(async move {
         let coordinator = Coordinator::with_store(Arc::new(store), r1)
@@ -649,8 +673,8 @@ fn killed_run_respawns_on_resume() {
     });
 
     let journal = collector.journal(uuid);
-    assert_eq!(journal.last().unwrap().event, started(5));
-    assert_eq!(first.requests().len(), 2);
+    assert_eq!(journal.last().unwrap().event, started(7));
+    assert_eq!(first.requests().len(), 3);
 
     // A new server resumes and the journal's unfinished run respawns without
     // repeating its `Started` entry.
@@ -668,11 +692,11 @@ fn killed_run_respawns_on_resume() {
     });
 
     let journal = collector.journal(uuid);
-    let starts = journal.iter().filter(|e| e.event == started(5)).count();
+    let starts = journal.iter().filter(|e| e.event == started(7)).count();
     assert_eq!(starts, 1);
     assert_eq!(
         journal.last().unwrap().event,
-        finished(5, outcome(StageStatus::Wiped, 60)),
+        finished(7, outcome(StageStatus::Wiped, 60)),
     );
     assert_eq!(second.requests().len(), 1);
 }
@@ -686,7 +710,7 @@ fn final_processing_concludes_exactly_once_on_resume() {
     // dies before the run settles.
     let store = collector.clone();
     let r1 = rx.clone();
-    let first = ScriptedProcessor::new(vec![boundary(), ProcessingAttempt::Hang]);
+    let first = ScriptedProcessor::new(vec![no_payload(), no_payload(), ProcessingAttempt::Hang]);
     let processor = Arc::clone(&first) as Arc<dyn StageProcessor>;
     let uuid = runtime().block_on(async move {
         let coordinator = Coordinator::with_store(Arc::new(store), r1)
@@ -732,7 +756,7 @@ fn final_processing_concludes_exactly_once_on_resume() {
     assert!(collector.is_deleted(uuid));
     assert_eq!(
         collector.journal(uuid).last().unwrap().event,
-        finished(8, ProcessingOutcome::Boundary),
+        finished(10, ProcessingPayload::None),
     );
     assert_eq!(second.requests().len(), 2);
 }

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -28,6 +28,9 @@ const CLAIM_SCAN_INTERVAL: Duration = Duration::from_secs(5);
 /// Run attempts allowed per processing trigger.
 const PROCESSING_MAX_ATTEMPTS: u32 = 3;
 
+/// Connections held to the challenge database.
+const DEFAULT_DB_POOL_SIZE: usize = 8;
+
 #[derive(Parser)]
 struct Cli {
     #[command(subcommand)]
@@ -83,11 +86,22 @@ async fn serve(config: LifecycleConfig) {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
-    let coordinator = Arc::new(
-        Coordinator::with_store(Arc::new(store), shutdown_rx)
-            .with_config(config)
-            .with_processor(Arc::new(processing::Pipeline)),
-    );
+    let processing_enabled = config.processing.max_attempts > 0;
+    let mut coordinator = Coordinator::with_store(Arc::new(store), shutdown_rx).with_config(config);
+    if processing_enabled {
+        let database_uri =
+            std::env::var("BLERT_DATABASE_URI").expect("BLERT_DATABASE_URI must be set");
+        let pool_size = std::env::var("BLERT_DB_POOL_SIZE")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(DEFAULT_DB_POOL_SIZE);
+        let db = processing::db::Postgres::connect(&database_uri, pool_size)
+            .await
+            .expect("failed to connect to Postgres");
+        tracing::info!("postgres_connected");
+        coordinator = coordinator.with_processor(Arc::new(processing::Pipeline::new(db)));
+    }
+    let coordinator = Arc::new(coordinator);
     coordinator.start_scan(CLAIM_SCAN_INTERVAL);
 
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", port))

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -1,0 +1,128 @@
+//! Challenge data processing.
+
+use std::time::{Duration, UNIX_EPOCH};
+
+use crate::lifecycle::core::types::{
+    ChallengeStatus, PrimaryMeleeGear, RecordingType, UserId, Uuid,
+};
+use crate::players::normalize_rsn;
+
+use super::{ChallengeInfo, db};
+
+/// Initializes a new challenge.
+pub async fn create(
+    txn: &mut db::Transaction,
+    uuid: Uuid,
+    info: &ChallengeInfo,
+) -> Result<(), db::Error> {
+    let start_time = UNIX_EPOCH + Duration::from_millis(info.created_unix_ms);
+    let scale = i16::try_from(info.party.len()).expect("party fits in a smallint");
+    let row = txn
+        .query_one(
+            "INSERT INTO challenges (uuid, type, mode, scale, stage, status, start_time)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             RETURNING id",
+            &[
+                &uuid,
+                &(info.challenge_type as i16),
+                &(info.mode as i16),
+                &scale,
+                &(info.stage as i16),
+                &(ChallengeStatus::InProgress as i16),
+                &start_time,
+            ],
+        )
+        .await?;
+    txn.set_challenge_id(row.get(0));
+
+    let player_ids = start_player_challenges(txn, &info.party).await?;
+    let orbs: Vec<i16> = (0..info.party.len())
+        .map(|orb| i16::try_from(orb).expect("orb fits in a smallint"))
+        .collect();
+    txn.execute(
+        "INSERT INTO challenge_players (challenge_id, player_id, username, orb, primary_gear)
+         SELECT $1, player_id, username, orb, $2
+         FROM UNNEST($3::INT[], $4::TEXT[], $5::SMALLINT[]) AS input (player_id, username, orb)",
+        &[
+            &txn.challenge_id(),
+            &(PrimaryMeleeGear::Unknown as i16),
+            &player_ids,
+            &info.party,
+            &orbs,
+        ],
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Records that each player in `party` has started a challenge, creating
+/// their rows if they do not exist. Returns the players' database IDs, in
+/// party order.
+async fn start_player_challenges(
+    txn: &db::Transaction,
+    party: &[String],
+) -> Result<Vec<i32>, db::Error> {
+    let normalized: Vec<String> = party.iter().map(|name| normalize_rsn(name)).collect();
+    // The unique index on normalized_username is partial, so the conflict
+    // target must spell its predicate for Postgres.
+    let rows = txn
+        .query(
+            "INSERT INTO players (username, normalized_username, total_recordings)
+             SELECT username, normalized, 1
+             FROM UNNEST($1::TEXT[], $2::TEXT[]) AS input (username, normalized)
+             ON CONFLICT (normalized_username) WHERE NOT starts_with(normalized_username, '*')
+             DO UPDATE SET total_recordings = players.total_recordings + 1
+             RETURNING id, normalized_username",
+            &[&party, &normalized],
+        )
+        .await?;
+
+    let ids: std::collections::HashMap<String, i32> =
+        rows.iter().map(|row| (row.get(1), row.get(0))).collect();
+    normalized
+        .iter()
+        .map(|name| {
+            ids.get(name)
+                .copied()
+                .ok_or_else(|| db::Error::InvalidData(format!("no player row returned for {name}")))
+        })
+        .collect()
+}
+
+/// Records a user as a recorder of the challenge.
+pub async fn add_recorder(
+    txn: &db::Transaction,
+    user_id: UserId,
+    recording_type: RecordingType,
+) -> Result<(), db::Error> {
+    txn.execute(
+        "INSERT INTO recorded_challenges (challenge_id, recorder_id, recording_type)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (challenge_id, recorder_id)
+         DO UPDATE SET recording_type = GREATEST(
+             recorded_challenges.recording_type,
+             EXCLUDED.recording_type
+         )",
+        &[
+            &txn.challenge_id(),
+            &i32::try_from(user_id.0).expect("user id fits in an integer"),
+            &(recording_type as i16),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Finalizes a challenge, recording its ending status.
+pub async fn finish(txn: &db::Transaction, info: &ChallengeInfo) -> Result<(), db::Error> {
+    txn.execute(
+        "UPDATE challenges SET status = $1 WHERE id = $2",
+        &[&(info.status as i16), &txn.challenge_id()],
+    )
+    .await?;
+
+    // TODO(frolv): The rest of the owl
+
+    Ok(())
+}

--- a/challenge-harder/src/processing/db.rs
+++ b/challenge-harder/src/processing/db.rs
@@ -1,0 +1,388 @@
+//! Postgres persistence for data processing.
+
+use std::ops::Deref;
+
+use deadpool_postgres::{Manager, ManagerConfig, Object, Pool, RecyclingMethod};
+use tokio_postgres::NoTls;
+
+use crate::lifecycle::core::types::{
+    JournalSeq, ProcessingError, ProcessingPayload, StageStatus, Uuid,
+};
+
+/// A database operation failure.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// This processing step was previously applied, with the stored payload.
+    #[error("processing step already applied")]
+    AlreadyApplied(ProcessingPayload),
+    /// A database operation failed.
+    #[error("database: {0}")]
+    Database(String),
+    /// The data stored in the database is invalid.
+    #[error("invalid data: {0}")]
+    InvalidData(String),
+}
+
+impl From<tokio_postgres::Error> for Error {
+    fn from(error: tokio_postgres::Error) -> Self {
+        // The top-level Display is just a kind ("db error"); the Postgres
+        // message lives in the source.
+        match std::error::Error::source(&error) {
+            Some(source) => Error::Database(format!("{error}: {source}")),
+            None => Error::Database(error.to_string()),
+        }
+    }
+}
+
+impl From<deadpool_postgres::PoolError> for Error {
+    fn from(error: deadpool_postgres::PoolError) -> Self {
+        Error::Database(error.to_string())
+    }
+}
+
+impl From<deadpool_postgres::BuildError> for Error {
+    fn from(error: deadpool_postgres::BuildError) -> Self {
+        Error::Database(error.to_string())
+    }
+}
+
+impl From<Error> for ProcessingError {
+    fn from(error: Error) -> Self {
+        ProcessingError {
+            retriable: matches!(error, Error::Database(_)),
+            message: error.to_string(),
+        }
+    }
+}
+
+/// The challenge database.
+pub struct Postgres {
+    pool: Pool,
+}
+
+impl Postgres {
+    /// Opens a connection pool to the Postgres instance at `uri`.
+    pub async fn connect(uri: &str, pool_size: usize) -> Result<Postgres, Error> {
+        let config: tokio_postgres::Config = uri.parse()?;
+        let manager = Manager::from_config(
+            config,
+            NoTls,
+            ManagerConfig {
+                recycling_method: RecyclingMethod::Fast,
+            },
+        );
+        let pool = Pool::builder(manager).max_size(pool_size).build()?;
+        drop(pool.get().await?);
+        Ok(Postgres { pool })
+    }
+
+    /// Opens a guarded transaction for the processing stage triggered by `seq`,
+    /// failing with [`Error::AlreadyApplied`] if the processing step has
+    /// previously been applied to the database.
+    pub async fn start_transaction(
+        &self,
+        uuid: Uuid,
+        seq: JournalSeq,
+    ) -> Result<Transaction, Error> {
+        let client = self.pool.get().await?;
+        client.batch_execute("BEGIN").await?;
+        let mut txn = Transaction {
+            client: Some(client),
+            seq,
+            challenge_id: 0,
+        };
+
+        let guard = txn
+            .query_opt(
+                "SELECT c.id, s.processed_seq, s.outcome_status, s.outcome_ticks
+                 FROM challenges c
+                 LEFT JOIN challenge_processing_state s ON s.challenge_id = c.id
+                 WHERE c.uuid = $1",
+                &[&uuid],
+            )
+            .await?;
+        if let Some(row) = guard {
+            if let Some(processed_seq) = row.get::<_, Option<i64>>(1)
+                && processed_seq >= seq.0.cast_signed()
+            {
+                return Err(Error::AlreadyApplied(stored_payload(&row)?));
+            }
+            txn.challenge_id = row.get(0);
+        }
+
+        Ok(txn)
+    }
+}
+
+/// Reconstructs a processing outcome from a stored row.
+fn stored_payload(row: &tokio_postgres::Row) -> Result<ProcessingPayload, Error> {
+    // Either both status and ticks are present, or neither.
+    let Some(status) = row.get::<_, Option<i16>>(2) else {
+        return Ok(ProcessingPayload::None);
+    };
+
+    let status = StageStatus::try_from(i32::from(status))
+        .map_err(|_| Error::InvalidData(format!("stored outcome status {status}")))?;
+    let ticks = row.get::<_, Option<i32>>(3);
+    let ticks = ticks
+        .and_then(|t| u32::try_from(t).ok())
+        .ok_or_else(|| Error::InvalidData(format!("stored outcome ticks {ticks:?}")))?;
+    Ok(ProcessingPayload::Stage { status, ticks })
+}
+
+/// An active processing transaction wrapping a database connection. Committing
+/// advances the challenge's processing cursor.
+pub struct Transaction {
+    client: Option<Object>,
+    seq: JournalSeq,
+    /// Database ID of the challenge row.
+    challenge_id: i32,
+}
+
+impl Transaction {
+    /// Returns the database ID of the challenge row.
+    pub fn challenge_id(&self) -> i32 {
+        self.challenge_id
+    }
+
+    /// Sets the challenge ID after an initial insert.
+    pub fn set_challenge_id(&mut self, id: i32) {
+        debug_assert_eq!(self.challenge_id, 0);
+        self.challenge_id = id;
+    }
+
+    /// Commits the transaction, advancing the challenge's cursor and storing
+    /// the processed payload.
+    pub async fn commit(mut self, payload: &ProcessingPayload) -> Result<(), Error> {
+        let (status, ticks) = match payload {
+            ProcessingPayload::Stage { status, ticks } => {
+                (Some(*status as i16), Some(ticks.cast_signed()))
+            }
+            ProcessingPayload::None => (None, None),
+        };
+        let client = self.client.take().expect("transaction is active");
+        client
+            .execute(
+                "INSERT INTO challenge_processing_state
+                   (challenge_id, processed_seq, outcome_status, outcome_ticks)
+                 VALUES ($1, $2, $3, $4)
+                 ON CONFLICT (challenge_id)
+                 DO UPDATE SET processed_seq = EXCLUDED.processed_seq,
+                               outcome_status = EXCLUDED.outcome_status,
+                               outcome_ticks = EXCLUDED.outcome_ticks",
+                &[
+                    &self.challenge_id,
+                    &self.seq.0.cast_signed(),
+                    &status,
+                    &ticks,
+                ],
+            )
+            .await?;
+        client.batch_execute("COMMIT").await?;
+        Ok(())
+    }
+}
+
+impl Deref for Transaction {
+    type Target = tokio_postgres::Client;
+
+    fn deref(&self) -> &tokio_postgres::Client {
+        self.client.as_ref().expect("transaction is active")
+    }
+}
+
+impl Drop for Transaction {
+    fn drop(&mut self) {
+        // Closing the connection rolls the abandoned transaction back on the
+        // server; detaching keeps the aborted session out of the pool.
+        if let Some(client) = self.client.take() {
+            drop(Object::take(client));
+        }
+    }
+}
+
+/// Connects to the migrated Postgres database at `BLERT_TEST_DATABASE_URI`,
+/// or returns `None` when it is unset.
+#[cfg(test)]
+pub(crate) async fn test_database() -> Option<Postgres> {
+    let Ok(uri) = std::env::var("BLERT_TEST_DATABASE_URI") else {
+        eprintln!("BLERT_TEST_DATABASE_URI is not set; skipping Postgres tests");
+        return None;
+    };
+    Some(
+        Postgres::connect(&uri, 2)
+            .await
+            .expect("failed to connect to the test database"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lifecycle::core::types::StageStatus;
+
+    /// Inserts a bare challenge row to satisfy foreign keys.
+    async fn insert_challenge(db: &Postgres, uuid: Uuid) -> i32 {
+        let client = db.pool.get().await.expect("client");
+        let row = client
+            .query_one(
+                "INSERT INTO challenges (uuid, type, scale) VALUES ($1, $2, $3) RETURNING id",
+                &[&uuid, &1_i16, &1_i16],
+            )
+            .await
+            .expect("fixture challenge insert");
+        row.get(0)
+    }
+
+    async fn delete_challenge(db: &Postgres, uuid: Uuid) {
+        let client = db.pool.get().await.expect("client");
+        client
+            .execute("DELETE FROM challenges WHERE uuid = $1", &[&uuid])
+            .await
+            .expect("cleanup");
+    }
+
+    #[tokio::test]
+    async fn guard_passes_for_an_unknown_challenge() {
+        let Some(db) = test_database().await else {
+            return;
+        };
+        let uuid = Uuid::new_v4();
+
+        let txn = db
+            .start_transaction(uuid, JournalSeq(1))
+            .await
+            .expect("guard should pass");
+        assert_eq!(txn.challenge_id(), 0);
+    }
+
+    #[tokio::test]
+    async fn commit_records_the_cursor_and_payload() {
+        let Some(db) = test_database().await else {
+            return;
+        };
+        let uuid = Uuid::new_v4();
+        let id = insert_challenge(&db, uuid).await;
+
+        let txn = db
+            .start_transaction(uuid, JournalSeq(3))
+            .await
+            .expect("guard should pass");
+        assert_eq!(txn.challenge_id(), id);
+        txn.commit(&ProcessingPayload::Stage {
+            status: StageStatus::Wiped,
+            ticks: 180,
+        })
+        .await
+        .expect("commit failed");
+
+        let client = db.pool.get().await.expect("client");
+        let row = client
+            .query_one(
+                "SELECT processed_seq, outcome_status, outcome_ticks
+                 FROM challenge_processing_state WHERE challenge_id = $1",
+                &[&id],
+            )
+            .await
+            .expect("state row missing");
+        assert_eq!(row.get::<_, i64>(0), 3);
+        assert_eq!(
+            row.get::<_, Option<i16>>(1),
+            Some(StageStatus::Wiped as i16)
+        );
+        assert_eq!(row.get::<_, Option<i32>>(2), Some(180));
+
+        // Reopening the committed step returns its stored payload.
+        let replay = db.start_transaction(uuid, JournalSeq(3)).await;
+        assert!(matches!(
+            replay,
+            Err(Error::AlreadyApplied(ProcessingPayload::Stage {
+                status: StageStatus::Wiped,
+                ticks: 180,
+            }))
+        ));
+        let next = db.start_transaction(uuid, JournalSeq(4)).await;
+        assert!(next.is_ok());
+
+        // Free both held connections; the pool has two and cleanup needs one.
+        drop(next);
+        drop(client);
+        delete_challenge(&db, uuid).await;
+    }
+
+    #[tokio::test]
+    async fn commit_without_a_payload_stores_none() {
+        let Some(db) = test_database().await else {
+            return;
+        };
+        let uuid = Uuid::new_v4();
+        let id = insert_challenge(&db, uuid).await;
+
+        let txn = db
+            .start_transaction(uuid, JournalSeq(1))
+            .await
+            .expect("guard should pass");
+        txn.commit(&ProcessingPayload::None)
+            .await
+            .expect("commit failed");
+
+        let client = db.pool.get().await.expect("client");
+        let row = client
+            .query_one(
+                "SELECT processed_seq, outcome_status, outcome_ticks
+                 FROM challenge_processing_state WHERE challenge_id = $1",
+                &[&id],
+            )
+            .await
+            .expect("state row missing");
+        assert_eq!(row.get::<_, i64>(0), 1);
+        assert_eq!(row.get::<_, Option<i16>>(1), None);
+        assert_eq!(row.get::<_, Option<i32>>(2), None);
+
+        let replay = db.start_transaction(uuid, JournalSeq(1)).await;
+        assert!(matches!(
+            replay,
+            Err(Error::AlreadyApplied(ProcessingPayload::None))
+        ));
+
+        delete_challenge(&db, uuid).await;
+    }
+
+    #[tokio::test]
+    async fn dropped_transaction_abandons_its_writes() {
+        let Some(db) = test_database().await else {
+            return;
+        };
+        let uuid = Uuid::new_v4();
+        let id = insert_challenge(&db, uuid).await;
+
+        let txn = db
+            .start_transaction(uuid, JournalSeq(1))
+            .await
+            .expect("guard should pass");
+        txn.execute("UPDATE challenges SET scale = 5 WHERE id = $1", &[&id])
+            .await
+            .expect("update failed");
+        drop(txn);
+
+        let client = db.pool.get().await.expect("client");
+        let row = client
+            .query_one("SELECT scale FROM challenges WHERE id = $1", &[&id])
+            .await
+            .expect("challenge row missing");
+        assert_eq!(row.get::<_, i16>(0), 1);
+
+        delete_challenge(&db, uuid).await;
+    }
+
+    #[test]
+    fn errors_map_to_processing_errors() {
+        let error: ProcessingError = Error::Database("connection refused".into()).into();
+        assert!(error.retriable);
+        assert_eq!(error.message, "database: connection refused");
+
+        let error: ProcessingError = Error::InvalidData("bad status".into()).into();
+        assert!(!error.retriable);
+        assert_eq!(error.message, "invalid data: bad status");
+    }
+}

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -3,13 +3,32 @@
 use async_trait::async_trait;
 
 use crate::lifecycle::core::state::Trigger;
-use crate::lifecycle::core::types::{ProcessingError, ProcessingOutcome, StageStatus, Uuid};
+use crate::lifecycle::core::types::{
+    ChallengeMode, ChallengeStatus, ChallengeType, ProcessingError, ProcessingPayload, Stage,
+    StageStatus, Uuid,
+};
+
+pub mod db;
+
+mod challenge;
+
+/// Challenge state at the time a run is triggered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChallengeInfo {
+    pub challenge_type: ChallengeType,
+    pub mode: ChallengeMode,
+    pub party: Vec<String>,
+    pub stage: Stage,
+    pub status: ChallengeStatus,
+    pub created_unix_ms: u64,
+}
 
 /// A request to process the data demanded by a run trigger.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessingRequest {
     pub uuid: Uuid,
     pub trigger: Trigger,
+    pub challenge: ChallengeInfo,
 }
 
 /// Processes events for a completed challenge stage.
@@ -18,29 +37,69 @@ pub trait StageProcessor: Send + Sync + 'static {
     async fn process(
         &self,
         request: ProcessingRequest,
-    ) -> Result<ProcessingOutcome, ProcessingError>;
+    ) -> Result<ProcessingPayload, ProcessingError>;
 }
 
 /// Complete event processing pipeline.
-pub struct Pipeline;
+pub struct Pipeline {
+    db: db::Postgres,
+}
+
+impl Pipeline {
+    pub fn new(db: db::Postgres) -> Pipeline {
+        Pipeline { db }
+    }
+}
 
 #[async_trait]
 impl StageProcessor for Pipeline {
     async fn process(
         &self,
         request: ProcessingRequest,
-    ) -> Result<ProcessingOutcome, ProcessingError> {
+    ) -> Result<ProcessingPayload, ProcessingError> {
         tracing::info!(
             uuid = %request.uuid,
             trigger = ?request.trigger,
             "processing_started",
         );
-        Ok(match request.trigger {
-            Trigger::Stage { .. } => ProcessingOutcome::Stage {
+
+        let mut txn = match self
+            .db
+            .start_transaction(request.uuid, request.trigger.seq())
+            .await
+        {
+            Ok(txn) => txn,
+            Err(db::Error::AlreadyApplied(payload)) => {
+                tracing::debug!(uuid = %request.uuid, seq = ?request.trigger.seq(), "processing_step_already_applied");
+                return Ok(payload);
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        let payload = match request.trigger {
+            Trigger::Create { .. } => {
+                challenge::create(&mut txn, request.uuid, &request.challenge).await?;
+                ProcessingPayload::None
+            }
+            Trigger::Recorder {
+                user_id,
+                recording_type,
+                ..
+            } => {
+                challenge::add_recorder(&txn, user_id, recording_type).await?;
+                ProcessingPayload::None
+            }
+            Trigger::Finish { .. } => {
+                challenge::finish(&txn, &request.challenge).await?;
+                ProcessingPayload::None
+            }
+            Trigger::Stage { .. } => ProcessingPayload::Stage {
                 status: StageStatus::Completed,
                 ticks: 0,
             },
-            Trigger::Create { .. } | Trigger::Finish { .. } => ProcessingOutcome::Boundary,
-        })
+        };
+        txn.commit(&payload).await?;
+
+        Ok(payload)
     }
 }

--- a/common/migrations/20260719011913-create-challenge-processing-state-table.ts
+++ b/common/migrations/20260719011913-create-challenge-processing-state-table.ts
@@ -1,0 +1,14 @@
+import { TransactionSql } from 'postgres';
+
+export async function migrate(sql: TransactionSql) {
+  await sql`
+    CREATE TABLE challenge_processing_state (
+      challenge_id INT PRIMARY KEY REFERENCES challenges (id) ON DELETE CASCADE,
+      processed_seq BIGINT NOT NULL,
+      outcome_status SMALLINT,
+      outcome_ticks INT,
+      finalized_seq BIGINT,
+      custom_data JSONB
+    );
+  `;
+}


### PR DESCRIPTION
Adds tokio-postgres and updates the processing pipeline with basic, incomplete handing of three trigger types:

- Start: creates rows for the challenge and its party members
- New recorder: upserts a recorded_challenges row for the user
- Finish: sets the challenge's final status

DB writes are handled through a transaction wrapper that first checks if if the journal sequence has already been applied via a new processing table, then lets individual steps make queries, committing them and updating the sequence at the end.