### PR TITLE
web: Add page for colosseum wave percentiles

### DIFF
--- a/web/__tests__/actions/split-distributions.test.ts
+++ b/web/__tests__/actions/split-distributions.test.ts
@@ -1,0 +1,196 @@
+import {
+  ChallengeMode,
+  ChallengeStatus,
+  ChallengeType,
+  SplitType,
+} from '@blert/common';
+
+import { sql } from '@/actions/db';
+import { getSplitPercentiles } from '@/actions/split-distributions';
+
+afterAll(async () => {
+  await sql.end();
+});
+
+describe('getSplitPercentiles', () => {
+  beforeEach(async () => {
+    const challenge = (uuid: string, startTime: string, overrides = {}) => ({
+      uuid,
+      start_time: new Date(startTime),
+      type: ChallengeType.TOB,
+      mode: ChallengeMode.TOB_REGULAR,
+      status: ChallengeStatus.RESET,
+      scale: 2,
+      challenge_ticks: 500,
+      total_deaths: 0,
+      ...overrides,
+    });
+
+    const challenges = [
+      challenge('11111111-1111-1111-1111-111111111111', '2026-03-19'),
+      challenge('22222222-2222-2222-2222-222222222222', '2026-04-19'),
+      challenge('33333333-3333-3333-3333-333333333333', '2026-05-19'),
+      challenge('44444444-4444-4444-4444-444444444444', '2026-06-19'),
+      challenge('55555555-5555-5555-5555-555555555555', '2026-07-19', {
+        status: ChallengeStatus.WIPED,
+      }),
+      challenge('66666666-6666-6666-6666-666666666666', '2026-03-24', {
+        scale: 3,
+      }),
+      challenge('77777777-7777-7777-7777-777777777777', '2026-03-28'),
+    ];
+
+    const results =
+      await sql`INSERT INTO challenges ${sql(challenges)} RETURNING id`;
+    const ids = results.map((r) => r.id);
+
+    const splits = [
+      { challenge_id: ids[0], type: SplitType.TOB_REG_MAIDEN, ticks: 210 },
+      { challenge_id: ids[1], type: SplitType.TOB_REG_MAIDEN, ticks: 210 },
+      { challenge_id: ids[2], type: SplitType.TOB_REG_MAIDEN, ticks: 230 },
+      { challenge_id: ids[3], type: SplitType.TOB_REG_MAIDEN, ticks: 250 },
+      { challenge_id: ids[4], type: SplitType.TOB_REG_MAIDEN, ticks: 290 },
+      { challenge_id: ids[0], type: SplitType.TOB_REG_BLOAT, ticks: 125 },
+      { challenge_id: ids[1], type: SplitType.TOB_REG_BLOAT, ticks: 135 },
+      { challenge_id: ids[2], type: SplitType.TOB_REG_BLOAT, ticks: 145 },
+      { challenge_id: ids[3], type: SplitType.TOB_REG_BLOAT, ticks: 155 },
+      // Excluded rows: different split, different scale, inaccurate split.
+      {
+        challenge_id: ids[0],
+        type: SplitType.TOB_REG_MAIDEN_70S,
+        ticks: 53,
+      },
+      {
+        challenge_id: ids[5],
+        type: SplitType.TOB_REG_MAIDEN,
+        ticks: 1,
+        scale: 3,
+      },
+      {
+        challenge_id: ids[4],
+        type: SplitType.TOB_REG_BLOAT,
+        ticks: 165,
+        accurate: false,
+      },
+    ].map((s) => ({ scale: 2, accurate: true, ...s }));
+
+    await sql`INSERT INTO challenge_splits ${sql(splits)}`;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM challenge_splits`;
+    await sql`DELETE FROM challenges`;
+  });
+
+  it('computes percentiles per requested type over accurate splits', async () => {
+    const result = await getSplitPercentiles(
+      [
+        SplitType.TOB_REG_MAIDEN,
+        SplitType.TOB_REG_BLOAT,
+        SplitType.TOB_REG_XARPUS,
+      ],
+      2,
+      [0, 25, 50, 75, 100],
+    );
+
+    expect(result).toEqual([
+      {
+        splitType: SplitType.TOB_REG_MAIDEN,
+        count: 5,
+        percentiles: { 0: 210, 25: 210, 50: 230, 75: 250, 100: 290 },
+      },
+      {
+        splitType: SplitType.TOB_REG_BLOAT,
+        count: 4,
+        percentiles: { 0: 125, 25: 132.5, 50: 140, 75: 147.5, 100: 155 },
+      },
+    ]);
+  });
+
+  it('interpolates fractional percentiles', async () => {
+    const result = await getSplitPercentiles(
+      [SplitType.TOB_REG_MAIDEN],
+      2,
+      [12.5, 87.5],
+    );
+
+    expect(result).toEqual([
+      {
+        splitType: SplitType.TOB_REG_MAIDEN,
+        count: 5,
+        percentiles: { 12.5: 210, 87.5: 270 },
+      },
+    ]);
+  });
+
+  it('restricts to challenges within the time window', async () => {
+    const after = await getSplitPercentiles(
+      [SplitType.TOB_REG_MAIDEN],
+      2,
+      [50],
+      new Date('2026-04-01'),
+    );
+    expect(after).toEqual([
+      {
+        splitType: SplitType.TOB_REG_MAIDEN,
+        count: 4,
+        percentiles: { 50: 240 },
+      },
+    ]);
+
+    const before = await getSplitPercentiles(
+      [SplitType.TOB_REG_MAIDEN],
+      2,
+      [50],
+      undefined,
+      new Date('2026-07-01'),
+    );
+    expect(before).toEqual([
+      {
+        splitType: SplitType.TOB_REG_MAIDEN,
+        count: 4,
+        percentiles: { 50: 220 },
+      },
+    ]);
+
+    const windowed = await getSplitPercentiles(
+      [SplitType.TOB_REG_MAIDEN],
+      2,
+      [50],
+      new Date('2026-04-01'),
+      new Date('2026-07-01'),
+    );
+    expect(windowed).toEqual([
+      {
+        splitType: SplitType.TOB_REG_MAIDEN,
+        count: 3,
+        percentiles: { 50: 230 },
+      },
+    ]);
+  });
+
+  it('filters splits by scale', async () => {
+    const result = await getSplitPercentiles(
+      [SplitType.TOB_REG_MAIDEN],
+      3,
+      [0, 50, 100],
+    );
+
+    expect(result).toEqual([
+      {
+        splitType: SplitType.TOB_REG_MAIDEN,
+        count: 1,
+        percentiles: { 0: 1, 50: 1, 100: 1 },
+      },
+    ]);
+  });
+
+  it('returns an empty array when no requested type has data', async () => {
+    const result = await getSplitPercentiles(
+      [SplitType.TOB_REG_XARPUS],
+      2,
+      [50],
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/web/__tests__/api/v1/splits/percentiles/route.test.ts
+++ b/web/__tests__/api/v1/splits/percentiles/route.test.ts
@@ -1,0 +1,129 @@
+import { SplitType } from '@blert/common';
+import { NextRequest } from 'next/server';
+
+jest.mock('@/actions/split-distributions', () => ({
+  getSplitPercentiles: jest.fn(),
+}));
+jest.mock('@/utils/metrics', () => ({
+  observeHttpRequest: jest.fn(),
+}));
+
+import { getSplitPercentiles } from '@/actions/split-distributions';
+import { GET } from '@/api/v1/splits/percentiles/route';
+
+const mockedGetSplitPercentiles = getSplitPercentiles as jest.MockedFunction<
+  typeof getSplitPercentiles
+>;
+
+function createRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/v1/splits/percentiles');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+const SAMPLE_RESULT = [
+  {
+    splitType: SplitType.TOB_REG_MAIDEN,
+    count: 5,
+    percentiles: { 5: 210, 50: 230, 95: 274 },
+  },
+];
+
+describe('GET /api/v1/splits/percentiles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetSplitPercentiles.mockResolvedValue(SAMPLE_RESULT);
+  });
+
+  it('requires types and scale', async () => {
+    const missingTypes = await GET(createRequest({ scale: '1' }));
+    expect(missingTypes.status).toBe(400);
+
+    const missingScale = await GET(createRequest({ types: '152' }));
+    expect(missingScale.status).toBe(400);
+
+    const emptyTypes = await GET(createRequest({ types: '', scale: '1' }));
+    expect(emptyTypes.status).toBe(400);
+
+    expect(mockedGetSplitPercentiles).not.toHaveBeenCalled();
+  });
+
+  it.each(['0', '6', 'abc'])('rejects scale %s', async (scale) => {
+    const response = await GET(createRequest({ types: '152', scale }));
+    expect(response.status).toBe(400);
+    expect(mockedGetSplitPercentiles).not.toHaveBeenCalled();
+  });
+
+  it.each(['abc', '101', '-1', '5,,25', '5,', '1,2,3,4,5,6,7,8,9,10,11'])(
+    'rejects percentiles %s',
+    async (percentiles) => {
+      const response = await GET(
+        createRequest({ types: '152', scale: '1', percentiles }),
+      );
+      expect(response.status).toBe(400);
+      expect(mockedGetSplitPercentiles).not.toHaveBeenCalled();
+    },
+  );
+
+  it('applies default percentiles', async () => {
+    const response = await GET(createRequest({ types: '152,153', scale: '1' }));
+
+    expect(response.status).toBe(200);
+    expect(mockedGetSplitPercentiles).toHaveBeenCalledWith(
+      [152, 153],
+      1,
+      [5, 25, 50, 75, 95],
+      undefined,
+      undefined,
+    );
+    expect(await response.json()).toEqual(SAMPLE_RESULT);
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=3600, stale-while-revalidate=86400',
+    );
+  });
+
+  it('passes through custom fractional percentiles', async () => {
+    const response = await GET(
+      createRequest({ types: '152', scale: '1', percentiles: '12.5,87.5' }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedGetSplitPercentiles).toHaveBeenCalledWith(
+      [152],
+      1,
+      [12.5, 87.5],
+      undefined,
+      undefined,
+    );
+  });
+
+  it('parses a time window', async () => {
+    const response = await GET(
+      createRequest({
+        types: '152',
+        scale: '1',
+        after: '2026-01-01',
+        before: '2026-07-01',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockedGetSplitPercentiles).toHaveBeenCalledWith(
+      [152],
+      1,
+      [5, 25, 50, 75, 95],
+      new Date('2026-01-01'),
+      new Date('2026-07-01'),
+    );
+  });
+
+  it.each(['after', 'before'])('rejects an invalid %s date', async (key) => {
+    const response = await GET(
+      createRequest({ types: '152', scale: '1', [key]: 'not-a-date' }),
+    );
+    expect(response.status).toBe(400);
+    expect(mockedGetSplitPercentiles).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/actions/split-distributions.ts
+++ b/web/app/actions/split-distributions.ts
@@ -3,6 +3,7 @@
 import { ChallengeType, SplitType, normalizeRsn } from '@blert/common';
 
 import { sql } from './db';
+import { Join, join, where } from './query';
 
 type DistributionRow = {
   type: number;
@@ -22,6 +23,13 @@ export type SplitDistribution = {
 };
 
 export type SplitTier = 'standard' | 'speedrun';
+
+export type SplitPercentiles = {
+  splitType: number;
+  count: number;
+  /** Map of requested percentile to its computed value. */
+  percentiles: Record<number, number>;
+};
 
 // 1-down bloat threshold in ticks (matches the MV definition).
 const SPEEDRUN_BLOAT_THRESHOLD = 100;
@@ -171,4 +179,76 @@ export async function getFilteredSplitDistributions(
   }
 
   return rowsToDistributions(rows, types);
+}
+
+type PercentileRow = {
+  type: number;
+  count: number;
+  percentiles: number[];
+};
+
+/**
+ * Computes percentile tick values for accurate splits of the requested types.
+ *
+ * @param types The mode-specific split types to fetch.
+ * @param scale The challenge scale.
+ * @param percentiles Percentiles to compute, each in [0, 100].
+ * @param after Optional lower bound on challenge start time.
+ * @param before Optional upper bound on challenge start time.
+ * @returns Percentile data for each requested type that has data.
+ */
+export async function getSplitPercentiles(
+  types: SplitType[],
+  scale: number,
+  percentiles: number[],
+  after?: Date,
+  before?: Date,
+): Promise<SplitPercentiles[]> {
+  const fractions = percentiles.map((p) => p / 100);
+
+  const conditions = [
+    sql`challenge_splits.type = ANY(${types})`,
+    sql`challenge_splits.scale = ${scale}`,
+    sql`challenge_splits.accurate`,
+  ];
+  const joins: Join[] = [];
+
+  if (after !== undefined || before !== undefined) {
+    joins.push({
+      table: sql('challenges'),
+      on: sql`challenges.id = challenge_splits.challenge_id`,
+      tableName: 'challenges',
+    });
+    if (after !== undefined) {
+      conditions.push(sql`challenges.start_time >= ${after}`);
+    }
+    if (before !== undefined) {
+      conditions.push(sql`challenges.start_time < ${before}`);
+    }
+  }
+
+  const rows = await sql<PercentileRow[]>`
+    SELECT
+      challenge_splits.type,
+      COUNT(*)::int AS count,
+      PERCENTILE_CONT(${fractions}::float8[])
+        WITHIN GROUP (ORDER BY challenge_splits.ticks) AS percentiles
+    FROM challenge_splits
+    ${join(joins)}
+    ${where(conditions)}
+    GROUP BY challenge_splits.type
+  `;
+
+  const byType = new Map(rows.map((row) => [row.type, row]));
+
+  return types
+    .filter((t) => byType.has(t))
+    .map((t) => {
+      const row = byType.get(t)!;
+      const result: Record<number, number> = {};
+      percentiles.forEach((p, i) => {
+        result[p] = row.percentiles[i];
+      });
+      return { splitType: t, count: row.count, percentiles: result };
+    });
 }

--- a/web/app/api/v1/splits/percentiles/route.ts
+++ b/web/app/api/v1/splits/percentiles/route.ts
@@ -1,0 +1,76 @@
+import { SplitType } from '@blert/common';
+import { NextRequest } from 'next/server';
+
+import { InvalidQueryError } from '@/actions/errors';
+import { getSplitPercentiles } from '@/actions/split-distributions';
+import { withApiRoute } from '@/api/handler';
+import { expectSingle, numericListParam, numericParam } from '@/api/query';
+
+const DEFAULT_PERCENTILES = [5, 25, 50, 75, 95];
+const MAX_PERCENTILES = 10;
+
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+};
+
+export const GET = withApiRoute(
+  { route: '/api/v1/splits/percentiles' },
+  async (request: NextRequest) => {
+    const params = Object.fromEntries(request.nextUrl.searchParams);
+
+    const types = numericListParam<SplitType>(params, 'types');
+    const scale = numericParam(params, 'scale');
+
+    if (types === undefined || types.length === 0 || scale === undefined) {
+      throw new InvalidQueryError('Missing required parameters: types, scale');
+    }
+
+    if (scale < 1 || scale > 5) {
+      throw new InvalidQueryError('scale must be between 1 and 5');
+    }
+
+    let percentiles = DEFAULT_PERCENTILES;
+    const percentilesParam = expectSingle(params, 'percentiles');
+    if (percentilesParam !== undefined) {
+      // Parsed manually rather than via numericListParam, which truncates
+      // fractional values and silently discards malformed entries.
+      const tokens = percentilesParam.split(',');
+      percentiles = tokens.map(Number);
+      const valid =
+        tokens.length > 0 &&
+        tokens.length <= MAX_PERCENTILES &&
+        tokens.every((t) => t.trim() !== '') &&
+        percentiles.every((p) => !isNaN(p) && p >= 0 && p <= 100);
+      if (!valid) {
+        throw new InvalidQueryError('percentiles must be between 0 and 100');
+      }
+    }
+
+    let after: Date | undefined;
+    const afterParam = expectSingle(params, 'after');
+    if (afterParam !== undefined) {
+      after = new Date(afterParam);
+      if (isNaN(after.getTime())) {
+        throw new InvalidQueryError('Invalid after date');
+      }
+    }
+
+    let before: Date | undefined;
+    const beforeParam = expectSingle(params, 'before');
+    if (beforeParam !== undefined) {
+      before = new Date(beforeParam);
+      if (isNaN(before.getTime())) {
+        throw new InvalidQueryError('Invalid before date');
+      }
+    }
+
+    const result = await getSplitPercentiles(
+      types,
+      scale,
+      percentiles,
+      after,
+      before,
+    );
+    return Response.json(result, { headers: CACHE_HEADERS });
+  },
+);

--- a/web/app/components/distribution-chart/distribution-chart.tsx
+++ b/web/app/components/distribution-chart/distribution-chart.tsx
@@ -15,7 +15,7 @@ import {
 
 import { ticksToFormattedSeconds } from '@/utils/tick';
 
-import { DistributionBin } from './types';
+import { DistributionBin } from '@/actions/split-distributions';
 
 import styles from './style.module.scss';
 
@@ -106,7 +106,7 @@ function generateProbTicks(maxProb: number): number[] {
 
 const CDF_TICKS = [0, 25, 50, 75, 100];
 
-export function DistributionChart({
+export default function DistributionChart({
   bins,
   referenceTicks,
   tickCycle = 1,

--- a/web/app/components/distribution-chart/index.ts
+++ b/web/app/components/distribution-chart/index.ts
@@ -1,0 +1,1 @@
+export { default } from './distribution-chart';

--- a/web/app/components/distribution-chart/style.module.scss
+++ b/web/app/components/distribution-chart/style.module.scss
@@ -1,0 +1,13 @@
+.chartContainer {
+  width: 100%;
+  height: 360px;
+}
+
+.noData {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.9rem;
+}

--- a/web/app/components/percentile-chart/index.ts
+++ b/web/app/components/percentile-chart/index.ts
@@ -1,0 +1,6 @@
+export {
+  default,
+  type PercentileCategory,
+  type PercentileStats,
+  type PlayerMark,
+} from './percentile-chart';

--- a/web/app/components/percentile-chart/percentile-chart.tsx
+++ b/web/app/components/percentile-chart/percentile-chart.tsx
@@ -1,0 +1,384 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  Bar,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  ErrorBar,
+  ResponsiveContainer,
+  Scatter,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { ticksToFormattedSeconds } from '@/utils/tick';
+
+import styles from './style.module.scss';
+
+export type PercentileStats = {
+  p5: number;
+  p25: number;
+  p50: number;
+  p75: number;
+  p95: number;
+};
+
+export type PlayerMark = {
+  /** Median ticks across the player's own runs. */
+  median: number;
+  /** Number of the player's runs contributing to the median. */
+  count: number;
+  /** The player's standing within the global distribution, as "top X%". */
+  percentile?: number;
+};
+
+export type PercentileCategory = {
+  key: number | string;
+  /** Short axis label. */
+  label: string;
+  /** Full name shown in the tooltip. Defaults to `label`. */
+  name?: string;
+  /** Number of samples in the distribution. */
+  count: number;
+  stats: PercentileStats;
+  player?: PlayerMark;
+};
+
+type PercentileChartProps = {
+  categories: PercentileCategory[];
+  /** Title displayed above the chart. */
+  title?: string;
+  /** Name of the overlaid player, shown in the legend and tooltip. */
+  playerName?: string;
+  onCategoryClick?: (key: number | string) => void;
+  /** Key of the currently selected category, highlighted in the chart. */
+  selectedKey?: number | string | null;
+  height?: number;
+  /** Y axis tick interval in game ticks. Defaults to 50. */
+  yTickInterval?: number;
+};
+
+type ChartRow = {
+  key: number | string;
+  label: string;
+  name: string;
+  count: number;
+  stats: PercentileStats;
+  base: number;
+  box: number;
+  median: number;
+  whisker: [number, number];
+  player: number | null;
+  playerMark: PlayerMark | null;
+};
+
+const AXIS_TICK = { fontSize: 11, fill: 'var(--blert-font-color-secondary)' };
+
+function CategoryTick({
+  x,
+  y,
+  payload,
+  data,
+  onCategoryClick,
+  selectedKey,
+}: {
+  x?: number;
+  y?: number;
+  payload?: { value: string };
+  data: ChartRow[];
+  onCategoryClick?: (key: number | string) => void;
+  selectedKey?: number | string | null;
+}) {
+  const row = data.find((r) => r.label === payload?.value);
+  const clickable = onCategoryClick !== undefined && row !== undefined;
+  const selected =
+    row !== undefined &&
+    selectedKey !== undefined &&
+    selectedKey !== null &&
+    row.key === selectedKey;
+
+  const classNames = [
+    styles.axisTick,
+    clickable && styles.clickable,
+    selected && styles.active,
+  ].filter(Boolean);
+
+  return (
+    <text
+      x={x}
+      y={(y ?? 0) + 12}
+      textAnchor="middle"
+      className={classNames.join(' ')}
+      onClick={clickable ? () => onCategoryClick(row.key) : undefined}
+    >
+      {payload?.value}
+    </text>
+  );
+}
+
+function formatTicks(ticks: number): string {
+  return ticksToFormattedSeconds(Math.round(ticks));
+}
+
+function MedianDot(props: { cx?: number; cy?: number }) {
+  const { cx, cy } = props;
+  if (cx === undefined || cy === undefined) {
+    return null;
+  }
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={4.5}
+      fill="var(--blert-font-color-primary)"
+      stroke="var(--blert-panel-background-color)"
+      strokeWidth={2}
+    />
+  );
+}
+
+function PlayerDot(props: { cx?: number; cy?: number }) {
+  const { cx, cy } = props;
+  if (cx === undefined || cy === undefined) {
+    return null;
+  }
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={5}
+      fill="var(--blert-yellow)"
+      stroke="var(--blert-panel-background-color)"
+      strokeWidth={2}
+    />
+  );
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  playerName,
+}: {
+  active?: boolean;
+  payload?: { payload: ChartRow }[];
+  playerName?: string;
+}) {
+  if (!active || payload === undefined || payload.length === 0) {
+    return null;
+  }
+
+  const row = payload[0].payload;
+  const percentiles: [string, number][] = [
+    ['5th', row.stats.p5],
+    ['25th', row.stats.p25],
+    ['Median', row.stats.p50],
+    ['75th', row.stats.p75],
+    ['95th', row.stats.p95],
+  ];
+
+  return (
+    <div className={styles.tooltip}>
+      <div className={styles.tooltipHeader}>
+        {row.name}
+        <span className={styles.tooltipCount}>
+          {row.count} sample{row.count === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div className={styles.tooltipBody}>
+        {percentiles.map(([label, value]) => (
+          <div key={label} className={styles.tooltipRow}>
+            <span>{label}</span>
+            <span className={styles.tooltipValue}>{formatTicks(value)}</span>
+          </div>
+        ))}
+      </div>
+      {row.playerMark !== null && (
+        <div className={styles.tooltipPlayer}>
+          <div className={styles.tooltipRow}>
+            <span>
+              <i className={styles.playerSwatch} />
+              {playerName ?? 'Player'}
+            </span>
+            <span className={styles.tooltipValue}>
+              {formatTicks(row.playerMark.median)}
+            </span>
+          </div>
+          {row.playerMark.percentile !== undefined && (
+            <div className={styles.tooltipStanding}>
+              Top {row.playerMark.percentile.toFixed(1)}% of{' '}
+              {row.count.toLocaleString()} samples
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function PercentileChart({
+  categories,
+  title,
+  playerName,
+  onCategoryClick,
+  selectedKey = null,
+  height = 500,
+  yTickInterval = 50,
+}: PercentileChartProps) {
+  const data: ChartRow[] = useMemo(
+    () =>
+      categories.map((c) => ({
+        key: c.key,
+        label: c.label,
+        name: c.name ?? c.label,
+        count: c.count,
+        stats: c.stats,
+        base: c.stats.p25,
+        box: c.stats.p75 - c.stats.p25,
+        median: c.stats.p50,
+        whisker: [c.stats.p50 - c.stats.p5, c.stats.p95 - c.stats.p50],
+        player: c.player?.median ?? null,
+        playerMark: c.player ?? null,
+      })),
+    [categories],
+  );
+
+  const hasPlayer = data.some((row) => row.player !== null);
+
+  // The auto domain only considers plotted data keys, not ErrorBar extents,
+  // so the p95 whiskers would clip without an explicit maximum.
+  const { yMax, yTicks } = useMemo(() => {
+    const max = data.reduce(
+      (acc, row) => Math.max(acc, row.stats.p95, row.player ?? 0),
+      0,
+    );
+    const yMax = (Math.floor(max / yTickInterval) + 1) * yTickInterval;
+    const yTicks = [];
+    for (let t = 0; t <= yMax; t += yTickInterval) {
+      yTicks.push(t);
+    }
+    return { yMax, yTicks };
+  }, [data, yTickInterval]);
+
+  const handleClick = (row: unknown) => {
+    if (onCategoryClick !== undefined) {
+      onCategoryClick((row as ChartRow).key);
+    }
+  };
+
+  return (
+    <div className={styles.percentileChart}>
+      <div className={styles.chartHeader}>
+        {title !== undefined && <h3 className={styles.title}>{title}</h3>}
+        <div className={styles.legend}>
+          <span className={styles.legendItem}>
+            <i className={styles.globalSwatch} />
+            25th&ndash;75th percentile
+          </span>
+          <span className={styles.legendItem}>
+            <i className={styles.whiskerSwatch} />
+            5th&ndash;95th percentile
+          </span>
+          <span className={styles.legendItem}>
+            <i className={styles.medianSwatch} />
+            Median
+          </span>
+          {hasPlayer && (
+            <span className={styles.legendItem}>
+              <i className={styles.playerSwatch} />
+              {playerName ?? 'Player'}
+            </span>
+          )}
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={height}>
+        <ComposedChart
+          data={data}
+          margin={{ top: 10, right: 10, bottom: 5, left: 5 }}
+        >
+          <CartesianGrid
+            horizontal
+            vertical={false}
+            stroke="rgba(var(--blert-divider-color-base), 0.3)"
+          />
+          <XAxis
+            dataKey="label"
+            interval={0}
+            tick={
+              <CategoryTick
+                data={data}
+                onCategoryClick={onCategoryClick}
+                selectedKey={selectedKey}
+              />
+            }
+            axisLine={{ stroke: 'var(--blert-divider-color)' }}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, yMax]}
+            ticks={yTicks}
+            tickFormatter={formatTicks}
+            tick={AXIS_TICK}
+            axisLine={false}
+            tickLine={false}
+            width={52}
+          />
+          <Tooltip
+            content={<ChartTooltip playerName={playerName} />}
+            cursor={{ fill: 'rgba(var(--blert-purple-base), 0.08)' }}
+          />
+          <Bar dataKey="base" stackId="box" fill="transparent" />
+          <Bar
+            dataKey="box"
+            stackId="box"
+            fill="rgba(var(--blert-purple-base), 0.45)"
+            stroke="var(--blert-purple)"
+            strokeWidth={1}
+            radius={3}
+            barSize={26}
+            onClick={handleClick}
+            className={onCategoryClick !== undefined ? styles.clickable : ''}
+            isAnimationActive={false}
+            activeBar={{
+              fill: 'rgba(var(--blert-purple-base), 0.65)',
+              strokeWidth: 1.5,
+            }}
+          >
+            {data.map((row) => (
+              <Cell
+                key={row.key}
+                fill={
+                  row.key === selectedKey
+                    ? 'rgba(var(--blert-purple-base), 0.7)'
+                    : 'rgba(var(--blert-purple-base), 0.45)'
+                }
+                strokeWidth={row.key === selectedKey ? 2 : 1}
+              />
+            ))}
+          </Bar>
+          <Scatter
+            dataKey="median"
+            shape={<MedianDot />}
+            isAnimationActive={false}
+          >
+            <ErrorBar
+              dataKey="whisker"
+              stroke="rgba(var(--blert-purple-base), 0.8)"
+              strokeWidth={1.5}
+              width={8}
+            />
+          </Scatter>
+          {hasPlayer && (
+            <Scatter
+              dataKey="player"
+              shape={<PlayerDot />}
+              isAnimationActive={false}
+            />
+          )}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/app/components/percentile-chart/style.module.scss
+++ b/web/app/components/percentile-chart/style.module.scss
@@ -1,0 +1,150 @@
+.percentileChart {
+  width: 100%;
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.axisTick {
+  font-size: 14px;
+  fill: var(--blert-font-color-secondary);
+
+  &.clickable {
+    cursor: pointer;
+    transition: fill 0.15s ease;
+
+    &:hover {
+      fill: var(--blert-font-color-primary);
+    }
+  }
+
+  &.active {
+    fill: var(--blert-purple);
+    font-weight: 600;
+  }
+}
+
+.chartHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+}
+
+.legend {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  margin-left: auto;
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.globalSwatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: rgba(var(--blert-purple-base), 0.45);
+  border: 1px solid var(--blert-purple);
+}
+
+.whiskerSwatch {
+  width: 2px;
+  height: 14px;
+  border-radius: 1px;
+  background: rgba(var(--blert-purple-base), 0.8);
+}
+
+.medianSwatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--blert-font-color-primary);
+  border: 2px solid var(--blert-panel-background-color);
+}
+
+.playerSwatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--blert-yellow);
+  border: 2px solid var(--blert-panel-background-color);
+}
+
+.tooltip {
+  background: var(--blert-panel-background-color);
+  border: 1px solid var(--blert-divider-color);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 0.85rem;
+  min-width: 180px;
+}
+
+.tooltipHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  font-weight: 600;
+  color: var(--blert-font-color-primary);
+  margin-bottom: 6px;
+}
+
+.tooltipCount {
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.tooltipBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tooltipRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--blert-font-color-secondary);
+
+  span:first-child {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+}
+
+.tooltipValue {
+  font-family: var(--font-roboto-mono), monospace;
+  color: var(--blert-font-color-primary);
+}
+
+.tooltipPlayer {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(var(--blert-divider-color-base), 0.5);
+}
+
+.tooltipStanding {
+  margin-top: 2px;
+  font-size: 0.8rem;
+  color: var(--blert-yellow);
+}

--- a/web/app/tools/split-calc/allocation.ts
+++ b/web/app/tools/split-calc/allocation.ts
@@ -1,5 +1,6 @@
+import { cdf } from '@/utils/probability';
+
 import { DistributionBin } from './types';
-import { cdf } from './probability';
 
 export type RoomAllocation = {
   key: string;

--- a/web/app/tools/split-calc/room-input.tsx
+++ b/web/app/tools/split-calc/room-input.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from 'react';
 
 import TickInput from '@/components/tick-input';
 import { GLOBAL_TOOLTIP_ID } from '@/components/tooltip';
+import { formatPercentile, percentile } from '@/utils/probability';
 
 import {
   RoomDefinition,
@@ -12,7 +13,6 @@ import {
   RoomSource,
   RoomState,
 } from './types';
-import { formatPercentile, percentile } from './probability';
 
 import styles from './style.module.scss';
 

--- a/web/app/tools/split-calc/split-calculator.tsx
+++ b/web/app/tools/split-calc/split-calculator.tsx
@@ -8,22 +8,23 @@ import { ChallengeOverview } from '@/actions/challenge';
 import { ConnectedPlayer } from '@/actions/users';
 import Card from '@/components/card';
 import Checkbox from '@/components/checkbox';
+import DistributionChart from '@/components/distribution-chart';
 import PlayerSearch from '@/components/player-search';
 import RadioInput from '@/components/radio-input';
 import TickInput from '@/components/tick-input';
 import { useToast } from '@/components/toast';
-import { ticksToFormattedSeconds } from '@/utils/tick';
-
-import { optimizeAllocation } from './allocation';
-import { DistributionChart } from './distribution-chart';
-import { ImportRaids } from './import-raids';
 import {
   convolveDistributions,
   convolvedPercentile,
+  distributionStats,
   formatPercentile,
   percentile,
   targetProbability,
-} from './probability';
+} from '@/utils/probability';
+import { ticksToFormattedSeconds } from '@/utils/tick';
+
+import { optimizeAllocation } from './allocation';
+import { ImportRaids } from './import-raids';
 import { ProbabilityHero } from './probability-hero';
 import { RoomInput } from './room-input';
 import {
@@ -426,32 +427,10 @@ export function SplitCalculator({ connectedPlayers }: SplitCalculatorProps) {
   }, [selectedRoom, getDistribution]);
 
   const distStats = useMemo(() => {
-    if (selectedDist === null || selectedDist.bins.length === 0) {
+    if (selectedDist === null) {
       return null;
     }
-    const { bins, total } = selectedDist;
-    const min = bins[0].ticks;
-    const max = bins[bins.length - 1].ticks;
-
-    let sum = 0;
-    for (const bin of bins) {
-      sum += bin.ticks * bin.count;
-    }
-    const mean = sum / total;
-
-    // Median: find the tick where cumulative count >= total / 2.
-    let cumulative = 0;
-    let median = min;
-    const half = total / 2;
-    for (const bin of bins) {
-      cumulative += bin.count;
-      if (cumulative >= half) {
-        median = bin.ticks;
-        break;
-      }
-    }
-
-    return { min, max, mean, median, total };
+    return distributionStats(selectedDist.bins, selectedDist.total);
   }, [selectedDist]);
 
   function handleRoomTicksChange(key: string, ticks: number | null) {

--- a/web/app/tools/split-calc/style.module.scss
+++ b/web/app/tools/split-calc/style.module.scss
@@ -464,12 +464,6 @@
   overflow-x: auto;
 }
 
-.chartContainer {
-  width: 100%;
-  min-width: 500px;
-  height: 360px;
-}
-
 .statsRow {
   display: flex;
   flex-wrap: wrap;

--- a/web/app/trends/colosseum/__tests__/data.test.ts
+++ b/web/app/trends/colosseum/__tests__/data.test.ts
@@ -1,0 +1,217 @@
+import { SplitType } from '@blert/common';
+
+import {
+  Distribution,
+  attachPlayerMarks,
+  playerWaveMarks,
+  sixMonthsAgo,
+  wavesToCategories,
+} from '../data';
+
+describe('wavesToCategories', () => {
+  it('drops non-wave splits and orders waves by number', () => {
+    const result = wavesToCategories([
+      {
+        splitType: SplitType.COLOSSEUM_WAVE_12,
+        count: 14,
+        percentiles: { 5: 183.15, 25: 193.25, 50: 209, 75: 227.5, 95: 257.1 },
+      },
+      {
+        splitType: SplitType.COLOSSEUM_CHALLENGE,
+        count: 39,
+        percentiles: { 5: 1689, 25: 1793, 50: 1955, 75: 2207.5, 95: 2481.3 },
+      },
+      {
+        splitType: SplitType.COLOSSEUM_WAVE_1,
+        count: 552,
+        percentiles: { 5: 27, 25: 30, 50: 34, 75: 39, 95: 48 },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        key: SplitType.COLOSSEUM_WAVE_1,
+        label: '1',
+        name: 'Wave 1',
+        count: 552,
+        stats: { p5: 27, p25: 30, p50: 34, p75: 39, p95: 48 },
+      },
+      {
+        key: SplitType.COLOSSEUM_WAVE_12,
+        label: 'Sol',
+        name: 'Sol Heredit',
+        count: 14,
+        stats: { p5: 183.15, p25: 193.25, p50: 209, p75: 227.5, p95: 257.1 },
+      },
+    ]);
+  });
+
+  it('returns an empty array when no wave splits are present', () => {
+    expect(
+      wavesToCategories([
+        {
+          splitType: SplitType.COLOSSEUM_CHALLENGE,
+          count: 39,
+          percentiles: { 5: 1689, 25: 1793, 50: 1955, 75: 2207.5, 95: 2481.3 },
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe('playerWaveMarks', () => {
+  const playerDistributions: Distribution[] = [
+    {
+      splitType: SplitType.COLOSSEUM_WAVE_1,
+      bins: [
+        { ticks: 30, count: 1 },
+        { ticks: 34, count: 2 },
+        { ticks: 40, count: 1 },
+      ],
+      total: 4,
+    },
+    {
+      splitType: SplitType.COLOSSEUM_WAVE_2,
+      bins: [{ ticks: 120, count: 1 }],
+      total: 1,
+    },
+    {
+      splitType: SplitType.COLOSSEUM_WAVE_3,
+      bins: [{ ticks: 95, count: 3 }],
+      total: 3,
+    },
+    {
+      splitType: SplitType.COLOSSEUM_WAVE_4,
+      bins: [],
+      total: 0,
+    },
+  ];
+
+  const globalDistributions: Distribution[] = [
+    {
+      splitType: SplitType.COLOSSEUM_WAVE_1,
+      bins: [
+        { ticks: 27, count: 5 },
+        { ticks: 30, count: 10 },
+        { ticks: 34, count: 20 },
+        { ticks: 39, count: 10 },
+        { ticks: 48, count: 5 },
+      ],
+      total: 50,
+    },
+    {
+      splitType: SplitType.COLOSSEUM_WAVE_2,
+      bins: [
+        { ticks: 60, count: 15 },
+        { ticks: 100, count: 5 },
+      ],
+      total: 20,
+    },
+  ];
+
+  it('computes medians and standings against global distributions', () => {
+    const marks = playerWaveMarks(
+      playerDistributions,
+      globalDistributions,
+      new Map([
+        [SplitType.COLOSSEUM_WAVE_1 as number, 56],
+        [SplitType.COLOSSEUM_WAVE_2 as number, 22],
+      ]),
+    );
+
+    expect(marks).toEqual(
+      new Map([
+        // Median 34 sits at a cumulative 35 of the wave's 56 full samples.
+        [
+          SplitType.COLOSSEUM_WAVE_1,
+          { median: 34, count: 4, percentile: 62.5 },
+        ],
+        // Median 120 is beyond the trimmed global bins.
+        [SplitType.COLOSSEUM_WAVE_2, { median: 120, count: 1 }],
+        // No global distribution for wave 3.
+        [SplitType.COLOSSEUM_WAVE_3, { median: 95, count: 3 }],
+      ]),
+    );
+  });
+
+  it('omits standings without a full sample count', () => {
+    const marks = playerWaveMarks(
+      playerDistributions,
+      globalDistributions,
+      new Map(),
+    );
+
+    expect(marks.get(SplitType.COLOSSEUM_WAVE_1)).toEqual({
+      median: 34,
+      count: 4,
+    });
+  });
+
+  it('omits standings without global distributions', () => {
+    const marks = playerWaveMarks(
+      playerDistributions,
+      null,
+      new Map([[SplitType.COLOSSEUM_WAVE_1 as number, 56]]),
+    );
+
+    expect(marks).toEqual(
+      new Map([
+        [SplitType.COLOSSEUM_WAVE_1, { median: 34, count: 4 }],
+        [SplitType.COLOSSEUM_WAVE_2, { median: 120, count: 1 }],
+        [SplitType.COLOSSEUM_WAVE_3, { median: 95, count: 3 }],
+      ]),
+    );
+  });
+});
+
+describe('sixMonthsAgo', () => {
+  // Values verified against Postgres' `timestamp - INTERVAL '6 months'`.
+  it.each([
+    ['2026-07-20T23:59:59Z', '2026-01-20T00:00:00.000Z'],
+    ['2026-08-31T15:30:00Z', '2026-02-28T00:00:00.000Z'],
+    ['2024-08-31T00:00:00Z', '2024-02-29T00:00:00.000Z'],
+    ['2026-05-31T12:00:00Z', '2025-11-30T00:00:00.000Z'],
+    ['2026-12-31T06:00:00Z', '2026-06-30T00:00:00.000Z'],
+  ])('maps %s to %s', (from, expected) => {
+    expect(sixMonthsAgo(new Date(from)).toISOString()).toBe(expected);
+  });
+});
+
+describe('attachPlayerMarks', () => {
+  it('attaches marks only to matching categories', () => {
+    const categories = wavesToCategories([
+      {
+        splitType: SplitType.COLOSSEUM_WAVE_1,
+        count: 552,
+        percentiles: { 5: 27, 25: 30, 50: 34, 75: 39, 95: 48 },
+      },
+      {
+        splitType: SplitType.COLOSSEUM_WAVE_2,
+        count: 505,
+        percentiles: { 5: 52, 25: 60, 50: 87, 75: 100, 95: 114 },
+      },
+    ]);
+
+    const marks = new Map([
+      [SplitType.COLOSSEUM_WAVE_1 as number, { median: 34, count: 4 }],
+    ]);
+
+    expect(attachPlayerMarks(categories, marks)).toEqual([
+      {
+        key: SplitType.COLOSSEUM_WAVE_1,
+        label: '1',
+        name: 'Wave 1',
+        count: 552,
+        stats: { p5: 27, p25: 30, p50: 34, p75: 39, p95: 48 },
+        player: { median: 34, count: 4 },
+      },
+      {
+        key: SplitType.COLOSSEUM_WAVE_2,
+        label: '2',
+        name: 'Wave 2',
+        count: 505,
+        stats: { p5: 52, p25: 60, p50: 87, p75: 100, p95: 114 },
+      },
+    ]);
+  });
+});

--- a/web/app/trends/colosseum/data.ts
+++ b/web/app/trends/colosseum/data.ts
@@ -1,0 +1,131 @@
+import { SplitType, splitName } from '@blert/common';
+
+import { PercentileCategory, PlayerMark } from '@/components/percentile-chart';
+import { distributionStats, percentile } from '@/utils/probability';
+
+export type WavePercentiles = {
+  splitType: SplitType;
+  count: number;
+  percentiles: Record<number, number>;
+};
+
+export type Distribution = {
+  splitType: SplitType;
+  bins: { ticks: number; count: number }[];
+  total: number;
+};
+
+export const COLOSSEUM_WAVE_SPLITS: SplitType[] = Array.from(
+  { length: 12 },
+  (_, i) => SplitType.COLOSSEUM_WAVE_1 + i,
+);
+
+const SOL_HEREDIT_WAVE = 12;
+
+function waveNumber(splitType: SplitType): number {
+  return splitType - SplitType.COLOSSEUM_WAVE_1 + 1;
+}
+
+/**
+ * Transforms Colosseum wave percentiles from the splits percentiles API into
+ * categories for a {@link PercentileChart}.
+ * The data must include the percentiles (5, 25, 50, 75, 95).
+ */
+export function wavesToCategories(
+  data: WavePercentiles[],
+): PercentileCategory[] {
+  return data
+    .filter(
+      (d) =>
+        d.splitType >= SplitType.COLOSSEUM_WAVE_1 &&
+        d.splitType <= SplitType.COLOSSEUM_WAVE_12,
+    )
+    .sort((a, b) => a.splitType - b.splitType)
+    .map((d) => {
+      const wave = waveNumber(d.splitType);
+      return {
+        key: d.splitType,
+        label: wave === SOL_HEREDIT_WAVE ? 'Sol' : wave.toString(),
+        name: splitName(d.splitType),
+        count: d.count,
+        stats: {
+          p5: d.percentiles[5],
+          p25: d.percentiles[25],
+          p50: d.percentiles[50],
+          p75: d.percentiles[75],
+          p95: d.percentiles[95],
+        },
+      };
+    });
+}
+
+/**
+ * Returns the date six months before `from`, truncated to UTC midnight so
+ * repeated requests share a cacheable URL, clamping to the target month's
+ * final day.
+ */
+export function sixMonthsAgo(from: Date = new Date()): Date {
+  const date = new Date(from);
+  date.setUTCHours(0, 0, 0, 0);
+
+  const targetMonth = (date.getUTCMonth() + 6) % 12;
+  date.setUTCMonth(date.getUTCMonth() - 6);
+  if (date.getUTCMonth() !== targetMonth) {
+    date.setUTCDate(0);
+  }
+  return date;
+}
+
+/**
+ * Builds per-wave player marks from a player's split distributions.
+ *
+ * When global distributions are provided, each mark includes the player's
+ * percentile within them. The global bins are trimmed above the 90th
+ * percentile, so the percentile is taken over the wave's full sample count.
+ * A percentile is omitted if the player's median lies beyond the global
+ * distribution's upper bound, or if the global distribution or sample count
+ * is missing.
+ */
+export function playerWaveMarks(
+  playerDistributions: Distribution[],
+  globalDistributions: Distribution[] | null,
+  sampleCounts: Map<number, number>,
+): Map<number, PlayerMark> {
+  const globalByType = new Map(
+    (globalDistributions ?? []).map((d) => [d.splitType, d]),
+  );
+
+  const marks = new Map<number, PlayerMark>();
+  for (const dist of playerDistributions) {
+    const median = distributionStats(dist.bins, dist.total)?.median ?? null;
+    if (median === null) {
+      continue;
+    }
+
+    const mark: PlayerMark = { median, count: dist.total };
+    const global = globalByType.get(dist.splitType);
+    const sampleCount = sampleCounts.get(dist.splitType);
+    if (
+      global !== undefined &&
+      sampleCount !== undefined &&
+      sampleCount > 0 &&
+      global.bins.length > 0 &&
+      median <= global.bins[global.bins.length - 1].ticks
+    ) {
+      mark.percentile = percentile(global.bins, sampleCount, median);
+    }
+    marks.set(dist.splitType, mark);
+  }
+  return marks;
+}
+
+/** Adds player marks onto percentile categories. */
+export function attachPlayerMarks(
+  categories: PercentileCategory[],
+  marks: Map<number, PlayerMark>,
+): PercentileCategory[] {
+  return categories.map((c) => {
+    const player = marks.get(c.key as number);
+    return player === undefined ? c : { ...c, player };
+  });
+}

--- a/web/app/trends/colosseum/page.tsx
+++ b/web/app/trends/colosseum/page.tsx
@@ -1,0 +1,43 @@
+import { ResolvingMetadata } from 'next';
+import { Suspense } from 'react';
+
+import { getConnectedPlayers } from '@/actions/users';
+import Card from '@/components/card';
+import Loading from '@/components/loading';
+import { basicMetadata } from '@/utils/metadata';
+
+import WaveTimes from './wave-times';
+
+import styles from './style.module.scss';
+
+export default async function ColosseumWaveTimesPage() {
+  const connectedPlayers = await getConnectedPlayers().catch(() => []);
+
+  return (
+    <div className={styles.colosseumWaves}>
+      <Card primary className={styles.header}>
+        <h1>Colosseum Wave Times</h1>
+        <p className={styles.subtitle}>
+          Analyze time percentiles across Colosseum runs
+        </p>
+      </Card>
+      <Card className={styles.mainPanel}>
+        <Suspense fallback={<Loading />}>
+          <WaveTimes connectedPlayers={connectedPlayers} />
+        </Suspense>
+      </Card>
+    </div>
+  );
+}
+
+export async function generateMetadata(
+  _props: unknown,
+  parent: ResolvingMetadata,
+) {
+  return basicMetadata(await parent, {
+    title: 'OSRS Colosseum Wave Times',
+    description:
+      'Explore wave time percentiles across Fortis Colosseum runs recorded ' +
+      'on Blert, Old School RuneScape’s premier PvM tracker.',
+  });
+}

--- a/web/app/trends/colosseum/style.module.scss
+++ b/web/app/trends/colosseum/style.module.scss
@@ -1,0 +1,281 @@
+@use '../../mixins.scss' as *;
+
+.colosseumWaves {
+  width: 100%;
+  max-width: 1200px;
+  padding-bottom: 2rem;
+
+  @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+    max-width: 100%;
+  }
+
+  .header {
+    text-align: center;
+    margin: 2rem 0;
+
+    h1 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.6rem;
+      color: var(--blert-font-color-primary);
+    }
+
+    .subtitle {
+      margin: 0;
+      color: var(--blert-font-color-secondary);
+    }
+  }
+
+  .mainPanel {
+    padding: 1.5rem;
+    min-width: 0;
+
+    @media (max-width: $COMPACT_WIDTH_THRESHOLD) {
+      padding: 1rem;
+    }
+  }
+}
+
+.waveTimes {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.controls {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.section {
+  .sectionTitle {
+    margin: 0 0 0.75rem 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--blert-font-color-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+}
+
+.filterRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1.25rem;
+}
+
+.filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.filterLabel {
+  font-size: 0.8rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.windowRadio {
+  margin: 10px 0 6px 0;
+  height: 42px;
+  width: 240px;
+}
+
+.playerControl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chartWrapper {
+  width: 100%;
+  transition: opacity 0.2s ease;
+
+  &.refreshing {
+    opacity: 0.6;
+  }
+}
+
+.drillDownHint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 1.25rem;
+  border: 1px dashed rgba(var(--blert-divider-color-base), 0.8);
+  border-radius: 6px;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.9rem;
+
+  i {
+    font-size: 1.1em;
+  }
+}
+
+.drillDown {
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(var(--blert-divider-color-base), 0.5);
+  transform-origin: top;
+  animation: expandDown 0.25s ease-out;
+
+  &.closing {
+    animation: shrinkUp 0.2s ease-in forwards;
+  }
+}
+
+@keyframes expandDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes shrinkUp {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+}
+
+.drillDownHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+
+  h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--blert-font-color-primary);
+  }
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--blert-red);
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  i {
+    position: relative;
+    top: 1px;
+  }
+
+  &:hover {
+    background: rgba(var(--blert-red-base), 0.1);
+  }
+}
+
+.drillDownChart {
+  width: 100%;
+}
+
+.statsRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.drillDownNote {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: var(--blert-font-color-secondary);
+}
+
+.skeletonChart {
+  width: 100%;
+  height: 360px;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 3rem 2rem;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+  gap: 1rem;
+
+  .errorIcon {
+    font-size: 2em;
+    color: var(--blert-red);
+  }
+
+  .errorContent {
+    h3 {
+      margin: 0 0 8px 0;
+      color: var(--blert-font-color-primary);
+      font-size: 1.1em;
+    }
+
+    p {
+      margin: 0;
+      color: var(--blert-font-color-secondary);
+      font-size: 0.9em;
+    }
+  }
+
+  .retryButton {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    border-radius: 4px;
+    background: var(--blert-panel-background-color);
+    color: var(--blert-font-color-primary);
+    font-size: 0.9em;
+    border: none;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--blert-surface-light);
+    }
+  }
+}
+
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 3rem 2rem;
+  color: var(--blert-font-color-secondary);
+  font-size: 0.95rem;
+  background: var(--blert-surface-dark);
+  border-radius: 6px;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/web/app/trends/colosseum/wave-times.tsx
+++ b/web/app/trends/colosseum/wave-times.tsx
@@ -1,0 +1,451 @@
+'use client';
+
+import { SplitType, splitName } from '@blert/common';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { ConnectedPlayer } from '@/actions/users';
+import DistributionChart from '@/components/distribution-chart';
+import PercentileChart from '@/components/percentile-chart';
+import PlayerSearch from '@/components/player-search';
+import RadioInput from '@/components/radio-input';
+import Statistic from '@/components/statistic';
+import { useToast } from '@/components/toast';
+import { distributionStats } from '@/utils/probability';
+import { ticksToFormattedSeconds } from '@/utils/tick';
+
+import {
+  COLOSSEUM_WAVE_SPLITS,
+  Distribution,
+  WavePercentiles,
+  attachPlayerMarks,
+  playerWaveMarks,
+  sixMonthsAgo,
+  wavesToCategories,
+} from './data';
+
+import styles from './style.module.scss';
+
+type TimeWindow = 'all' | '6m';
+
+const WAVE_TYPES_PARAM = COLOSSEUM_WAVE_SPLITS.join(',');
+
+function windowParam(window: TimeWindow): string {
+  return window === '6m' ? `&after=${sixMonthsAgo().toISOString()}` : '';
+}
+
+export default function WaveTimes({
+  connectedPlayers,
+}: {
+  connectedPlayers: ConnectedPlayer[];
+}) {
+  const defaultPlayer = connectedPlayers[0]?.username ?? null;
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const paramPlayer = searchParams.get('player');
+  const initialPlayer =
+    paramPlayer !== null && paramPlayer !== '' ? paramPlayer : defaultPlayer;
+
+  const showToast = useToast();
+
+  const [timeWindow, setTimeWindow] = useState<TimeWindow>('6m');
+  const [data, setData] = useState<WavePercentiles[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const hasDataRef = useRef(false);
+
+  const [playerInput, setPlayerInput] = useState(initialPlayer ?? '');
+  const [player, setPlayer] = useState<string | null>(initialPlayer);
+  const [playerDistributions, setPlayerDistributions] = useState<
+    Distribution[] | null
+  >(null);
+
+  const [globalBins, setGlobalBins] = useState<Distribution[] | null>(null);
+  const [binsError, setBinsError] = useState(false);
+  const binsAbortRef = useRef<AbortController | null>(null);
+  const [selectedWave, setSelectedWave] = useState<SplitType | null>(() => {
+    const wave = parseInt(searchParams.get('wave') ?? '', 10);
+    return wave >= 1 && wave <= 12
+      ? SplitType.COLOSSEUM_WAVE_1 + wave - 1
+      : null;
+  });
+  const [drillDownClosing, setDrillDownClosing] = useState(false);
+
+  const updateQueryParam = useCallback(
+    (key: string, value: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value === null) {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+      if (params.toString() !== searchParams.toString()) {
+        const query = params.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname, {
+          scroll: false,
+        });
+      }
+    },
+    [router, pathname, searchParams],
+  );
+
+  const setWaveParam = useCallback(
+    (splitType: SplitType | null) => {
+      updateQueryParam(
+        'wave',
+        splitType === null
+          ? null
+          : (splitType - SplitType.COLOSSEUM_WAVE_1 + 1).toString(),
+      );
+    },
+    [updateQueryParam],
+  );
+
+  // Previously loaded data is kept visible while a new time window loads.
+  const loadData = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(false);
+    try {
+      const response = await fetch(
+        `/api/v1/splits/percentiles?types=${WAVE_TYPES_PARAM}` +
+          `&scale=1${windowParam(timeWindow)}`,
+        { signal: controller.signal },
+      );
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+      setData((await response.json()) as WavePercentiles[]);
+      hasDataRef.current = true;
+      setLoading(false);
+    } catch {
+      if (controller.signal.aborted) {
+        return;
+      }
+      setLoading(false);
+      if (hasDataRef.current) {
+        showToast('Failed to update wave times.', 'error');
+      } else {
+        setError(true);
+      }
+    }
+  }, [timeWindow, showToast]);
+
+  useEffect(() => {
+    void loadData();
+    return () => abortRef.current?.abort();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (player === null) {
+      setPlayerDistributions(null);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(
+      `/api/v1/splits/distributions/query?party=${encodeURIComponent(player)}` +
+        `&types=${WAVE_TYPES_PARAM}&scale=1${windowParam(timeWindow)}`,
+    )
+      .then((res) => (res.ok ? res.json() : null))
+      .then((distributions: Distribution[] | null) => {
+        if (!cancelled) {
+          setPlayerDistributions(distributions);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPlayerDistributions(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [player, timeWindow]);
+
+  const loadGlobalBins = useCallback(async () => {
+    binsAbortRef.current?.abort();
+    const controller = new AbortController();
+    binsAbortRef.current = controller;
+
+    setBinsError(false);
+    try {
+      const response = await fetch(
+        `/api/v1/splits/distributions?types=${WAVE_TYPES_PARAM}&scale=1`,
+        { signal: controller.signal },
+      );
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+      setGlobalBins((await response.json()) as Distribution[]);
+    } catch {
+      if (!controller.signal.aborted) {
+        setBinsError(true);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => binsAbortRef.current?.abort();
+  }, []);
+
+  const needsGlobalBins =
+    selectedWave !== null || (player !== null && timeWindow === '6m');
+  useEffect(() => {
+    if (needsGlobalBins && globalBins === null && !binsError) {
+      void loadGlobalBins();
+    }
+  }, [needsGlobalBins, globalBins, binsError, loadGlobalBins]);
+
+  // Standings compare against the global distributions, whose window is
+  // fixed at six months, so they are omitted for other time windows.
+  const playerMarks = useMemo(() => {
+    const sampleCounts = new Map(
+      data?.map((d) => [d.splitType, d.count]) ?? [],
+    );
+    return playerWaveMarks(
+      playerDistributions ?? [],
+      timeWindow === '6m' ? globalBins : null,
+      sampleCounts,
+    );
+  }, [playerDistributions, globalBins, timeWindow, data]);
+
+  const categories = useMemo(() => {
+    if (data === null) {
+      return [];
+    }
+    return attachPlayerMarks(wavesToCategories(data), playerMarks);
+  }, [data, playerMarks]);
+
+  const selectPlayer = useCallback(
+    (username: string) => {
+      setPlayerInput(username);
+      setPlayer(username);
+      setPlayerDistributions(null);
+      updateQueryParam('player', username);
+    },
+    [updateQueryParam],
+  );
+
+  const clearPlayer = useCallback(() => {
+    setPlayerInput('');
+    setPlayer(null);
+    setPlayerDistributions(null);
+    updateQueryParam('player', null);
+  }, [updateQueryParam]);
+
+  if (error) {
+    return (
+      <div className={styles.errorState}>
+        <i className={`fa-solid fa-triangle-exclamation ${styles.errorIcon}`} />
+        <div className={styles.errorContent}>
+          <h3>Failed to load wave times</h3>
+          <p>Something went wrong fetching Colosseum data.</p>
+        </div>
+        <button className={styles.retryButton} onClick={() => void loadData()}>
+          <i className="fa-solid fa-rotate-right" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (data === null) {
+    return <div className={styles.skeletonChart} />;
+  }
+
+  if (categories.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        No Colosseum runs have been recorded yet.
+      </div>
+    );
+  }
+
+  const selectedBins =
+    selectedWave !== null
+      ? (globalBins?.find((d) => d.splitType === selectedWave) ?? null)
+      : null;
+  const selectedStats =
+    selectedBins !== null
+      ? distributionStats(selectedBins.bins, selectedBins.total)
+      : null;
+
+  return (
+    <div className={styles.waveTimes}>
+      <div className={styles.controls}>
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Filters</h3>
+          <div className={styles.filterRow}>
+            <div className={styles.filterGroup}>
+              <span className={styles.filterLabel}>Time period</span>
+              <div className={styles.windowRadio}>
+                <RadioInput.Group
+                  name="colo-time-window"
+                  compact
+                  joined
+                  onChange={(value) => setTimeWindow(value as TimeWindow)}
+                >
+                  <RadioInput.Option
+                    value="6m"
+                    id="colo-window-6m"
+                    label="Last 6 months"
+                    checked={timeWindow === '6m'}
+                  />
+                  <RadioInput.Option
+                    value="all"
+                    id="colo-window-all"
+                    label="All time"
+                    checked={timeWindow === 'all'}
+                  />
+                </RadioInput.Group>
+              </div>
+            </div>
+            <div className={styles.playerControl}>
+              <PlayerSearch
+                id="colo-player-search"
+                label="Compare player"
+                value={playerInput}
+                onChange={setPlayerInput}
+                onSelection={selectPlayer}
+                width={180}
+              />
+              {player !== null && (
+                <button
+                  className={styles.closeButton}
+                  onClick={clearPlayer}
+                  aria-label="Clear player"
+                >
+                  <i className="fa-solid fa-xmark" />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className={`${styles.chartWrapper} ${
+          loading && data !== null ? styles.refreshing : ''
+        }`}
+      >
+        <PercentileChart
+          categories={categories}
+          title="Wave completion times"
+          playerName={player ?? undefined}
+          selectedKey={selectedWave}
+          onCategoryClick={(key) => {
+            if (key === selectedWave) {
+              setDrillDownClosing(true);
+            } else {
+              setSelectedWave(key as SplitType);
+              setDrillDownClosing(false);
+              setWaveParam(key as SplitType);
+            }
+          }}
+        />
+      </div>
+      {selectedWave === null && (
+        <div className={styles.drillDownHint}>
+          <i className="fa-solid fa-hand-pointer" />
+          Click a wave in the chart to see its full time distribution.
+        </div>
+      )}
+      {selectedWave !== null && (
+        <div
+          className={`${styles.drillDown} ${
+            drillDownClosing ? styles.closing : ''
+          }`}
+          onAnimationEnd={() => {
+            if (drillDownClosing) {
+              setSelectedWave(null);
+              setDrillDownClosing(false);
+              setWaveParam(null);
+            }
+          }}
+        >
+          <div className={styles.drillDownHeader}>
+            <h3>{splitName(selectedWave)} time distribution</h3>
+            <button
+              className={styles.closeButton}
+              onClick={() => setDrillDownClosing(true)}
+              aria-label="Close distribution"
+            >
+              <i className="fa-solid fa-xmark" />
+            </button>
+          </div>
+          {binsError ? (
+            <div className={styles.emptyState}>
+              Failed to load the wave&apos;s distribution.
+              <button
+                className={styles.retryButton}
+                onClick={() => void loadGlobalBins()}
+              >
+                <i className="fa-solid fa-rotate-right" />
+                Retry
+              </button>
+            </div>
+          ) : globalBins === null ? (
+            <div className={styles.skeletonChart} />
+          ) : (
+            <>
+              <div className={styles.drillDownChart}>
+                <DistributionChart
+                  bins={selectedBins?.bins ?? []}
+                  referenceTicks={playerMarks.get(selectedWave)?.median ?? null}
+                />
+              </div>
+              {selectedStats !== null && (
+                <div className={styles.statsRow}>
+                  <Statistic
+                    name="Min"
+                    value={ticksToFormattedSeconds(selectedStats.min)}
+                    simple
+                    width={110}
+                  />
+                  <Statistic
+                    name="Median"
+                    value={ticksToFormattedSeconds(selectedStats.median)}
+                    simple
+                    width={110}
+                  />
+                  <Statistic
+                    name="Mean"
+                    value={ticksToFormattedSeconds(
+                      Math.round(selectedStats.mean),
+                    )}
+                    simple
+                    width={110}
+                  />
+                  <Statistic
+                    name="Max"
+                    value={ticksToFormattedSeconds(selectedStats.max)}
+                    simple
+                    width={110}
+                  />
+                  <Statistic
+                    name="Samples"
+                    value={selectedStats.total}
+                    simple
+                    width={110}
+                  />
+                </div>
+              )}
+              <p className={styles.drillDownNote}>
+                Based on runs from the last 6 months. Times above the 90th
+                percentile are not shown.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/trends/page.tsx
+++ b/web/app/trends/page.tsx
@@ -1,7 +1,9 @@
 import { ChallengeType } from '@blert/common';
 import { ResolvingMetadata } from 'next';
+import Image from 'next/image';
 
 import Card from '@/components/card';
+import { challengeLogo } from '@/logo';
 import BloatIcon from '@/svg/bloat.svg';
 import { basicMetadata } from '@/utils/metadata';
 
@@ -28,7 +30,20 @@ const TOB_ANALYSIS_LINKS: AnalysisLink[] = [
 ];
 
 const COLOSSEUM_ANALYSIS_LINKS: AnalysisLink[] = [
-  // Add Colosseum-specific analysis links here when they become available
+  {
+    href: '/trends/colosseum',
+    title: 'Wave Times',
+    description: 'Wave time percentiles across Fortis Colosseum runs',
+    icon: (
+      <Image
+        src={challengeLogo(ChallengeType.COLOSSEUM)}
+        alt="Fortis Colosseum"
+        width={32}
+        height={32}
+        style={{ objectFit: 'contain' }}
+      />
+    ),
+  },
 ];
 
 const INFERNO_ANALYSIS_LINKS: AnalysisLink[] = [

--- a/web/app/utils/__tests__/probability.test.ts
+++ b/web/app/utils/__tests__/probability.test.ts
@@ -1,12 +1,13 @@
+import { DistributionBin } from '@/actions/split-distributions';
 import {
   cdf,
   convolveDistributions,
   convolvedPercentile,
+  distributionStats,
   formatPercentile,
   percentile,
   targetProbability,
-} from '../probability';
-import { DistributionBin } from '../types';
+} from '@/utils/probability';
 
 describe('cdf', () => {
   const bins: DistributionBin[] = [
@@ -143,6 +144,55 @@ describe('convolvedPercentile', () => {
     const convolved = new Float64Array(3);
     convolved[0] = 1.0;
     expect(convolvedPercentile(convolved, 0.5)).toBe(0);
+  });
+});
+
+describe('distributionStats', () => {
+  it('computes summary statistics of a distribution', () => {
+    const bins: DistributionBin[] = [
+      { ticks: 30, count: 1 },
+      { ticks: 34, count: 2 },
+      { ticks: 40, count: 1 },
+    ];
+
+    expect(distributionStats(bins, 4)).toEqual({
+      min: 30,
+      max: 40,
+      mean: 34.5,
+      median: 34,
+      total: 4,
+    });
+  });
+
+  it('takes the lower tick when half the count falls on a bin boundary', () => {
+    const bins: DistributionBin[] = [
+      { ticks: 10, count: 1 },
+      { ticks: 20, count: 1 },
+    ];
+
+    expect(distributionStats(bins, 2)).toEqual({
+      min: 10,
+      max: 20,
+      mean: 15,
+      median: 10,
+      total: 2,
+    });
+  });
+
+  it('collapses to the single value of a one-bin distribution', () => {
+    const bins: DistributionBin[] = [{ ticks: 100, count: 5 }];
+
+    expect(distributionStats(bins, 5)).toEqual({
+      min: 100,
+      max: 100,
+      mean: 100,
+      median: 100,
+      total: 5,
+    });
+  });
+
+  it('returns null for an empty distribution', () => {
+    expect(distributionStats([], 0)).toBeNull();
   });
 });
 

--- a/web/app/utils/probability.ts
+++ b/web/app/utils/probability.ts
@@ -1,4 +1,4 @@
-import { DistributionBin } from './types';
+import { DistributionBin } from '@/actions/split-distributions';
 
 /**
  * Computes the CDF value at tick count `ticks` within a distribution.
@@ -35,6 +35,50 @@ export function percentile(
   ticks: number,
 ): number {
   return cdf(bins, total, ticks) * 100;
+}
+
+export type DistributionStats = {
+  min: number;
+  max: number;
+  mean: number;
+  median: number;
+  total: number;
+};
+
+/**
+ * Computes summary statistics of a binned distribution, or `null` if it is
+ * empty. The median is discrete, taking the tick at which the cumulative
+ * count reaches half the total.
+ */
+export function distributionStats(
+  bins: DistributionBin[],
+  total: number,
+): DistributionStats | null {
+  if (bins.length === 0 || total === 0) {
+    return null;
+  }
+
+  const min = bins[0].ticks;
+  const max = bins[bins.length - 1].ticks;
+
+  let sum = 0;
+  for (const bin of bins) {
+    sum += bin.ticks * bin.count;
+  }
+  const mean = sum / total;
+
+  let cumulative = 0;
+  let median = min;
+  const half = total / 2;
+  for (const bin of bins) {
+    cumulative += bin.count;
+    if (cumulative >= half) {
+      median = bin.ticks;
+      break;
+    }
+  }
+
+  return { min, max, mean, median, total };
 }
 
 /**


### PR DESCRIPTION
Creates a new trends page which displays global colosseum wave percentiles, with drilldowns into each individual wave's distribution. Reuses the distribution helpers and chart from the split calc, extracting them to a shared utils file and component, respectively.

Creates a new global split percentiles endpoint which returns a list of requested percentiles for a group of splits.