### PR TITLE
2c2s: Begin stage processing pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,15 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,15 +194,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backon"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
-dependencies = [
- "fastrand",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +276,7 @@ dependencies = [
  "bytes",
  "clap",
  "deadpool-postgres",
+ "deadpool-redis",
  "futures-util",
  "http-body-util",
  "hyper-util",
@@ -1549,14 +1532,11 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa6f8e4b491d7a8ef3a9550a4d71969bd0064f46e32b8dbbcc7fc60dad94fed"
 dependencies = [
- "arc-swap",
  "arcstr",
  "async-lock",
- "backon",
  "bytes",
  "cfg-if",
  "combine",
- "futures-channel",
  "futures-util",
  "itoa",
  "num-bigint",

--- a/challenge-harder/Cargo.toml
+++ b/challenge-harder/Cargo.toml
@@ -9,13 +9,14 @@ axum = { version = "0.8.9", features = ["macros"] }
 bytes = "1.12.1"
 clap = { version = "4.6", features = ["derive"] }
 deadpool-postgres = "0.14.1"
+deadpool-redis = "0.23.0"
 futures-util = { version = "0.3.32", default-features = false, features = ["std", "async-await"] }
 http-body-util = "0.1.3"
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
 nix = { version = "0.31.3", features = ["process", "signal"] }
 prost = "0.14.4"
 prost-types = "0.14.4"
-redis = { version = "1.3.0", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "1.3.0", features = ["tokio-comp"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 serde_repr = "0.1.20"

--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -16,9 +16,9 @@ use super::core::decide::decide;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
 use super::core::state::{
     ChallengeState, LastCompleted, PhaseState, Processing, ProcessingState, PublishedClient,
-    Snapshot,
+    Snapshot, Trigger,
 };
-use super::core::types::{ClientId, JournalSeq, MsgId, Timestamp, Uuid};
+use super::core::types::{ClientId, JournalSeq, MsgId, Stage, Timestamp, Uuid};
 use crate::processing::{ChallengeInfo, ProcessingRequest, StageProcessor};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -182,6 +182,9 @@ pub trait ChallengeClaim: Send + Sync + 'static {
     /// Broadcasts a lifecycle milestone to consumers.
     async fn announce(&self, update: &ChallengeServerUpdate) -> Result<(), StoreError>;
 
+    /// Marks stages' event streams as sealed, blocking further writes.
+    async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError>;
+
     /// Extends this claim's hold on the challenge.
     async fn renew(&self) -> Result<(), StoreError>;
 
@@ -336,6 +339,20 @@ impl ActiveChallenge {
             return;
         }
 
+        // Re-seal every stream whose processing run is still outstanding.
+        let outstanding: Vec<(Stage, Option<u32>)> = self
+            .state
+            .processing
+            .outstanding()
+            .filter_map(|trigger| match trigger {
+                Trigger::Stage { stage, attempt, .. } => Some((stage, attempt)),
+                _ => None,
+            })
+            .collect();
+        if !self.mark_processed(&outstanding).await {
+            return;
+        }
+
         let (tx, mut inbox) = mpsc::channel(INBOX_BUFFER_LEN);
         self.claim.follow(self.state.cursor, tx);
 
@@ -420,6 +437,7 @@ impl ActiveChallenge {
                     tracing::error!(uuid = %self.state.uuid, %error, "journal_append_failed");
                     return;
                 }
+                let mut sealed = Vec::new();
                 for entry in batch {
                     tracing::info!(
                         uuid = %self.state.uuid,
@@ -451,12 +469,19 @@ impl ActiveChallenge {
                         }
                         _ => false,
                     };
+                    if let LifecycleEvent::StageSealed { stage, attempt, .. } = entry.event {
+                        sealed.push((stage, attempt));
+                    }
                     apply(&mut self.state, entry);
                     if starts_run {
                         _run_task = self.spawn_processing_run(chanel_tx.clone());
                     } else if ends_run {
                         _run_task = None;
                     }
+                }
+                // Close stage streams immediately after they're sealed.
+                if !self.mark_processed(&sealed).await {
+                    return;
                 }
             }
 
@@ -475,6 +500,21 @@ impl ActiveChallenge {
                 break;
             }
         }
+    }
+
+    /// Closes sealed stages' streams to further writes, returning false if
+    /// the markers could not be written. Marking nothing trivially succeeds.
+    async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> bool {
+        if stages.is_empty() {
+            return true;
+        }
+        if let Err(error) =
+            with_retries(self.state.uuid, || self.claim.mark_processed(stages)).await
+        {
+            tracing::error!(uuid = %self.state.uuid, %error, "mark_processed_failed");
+            return false;
+        }
+        true
     }
 
     /// Publishes a snapshot of the current state and its clients, returning
@@ -568,6 +608,7 @@ impl ActiveChallenge {
                 party: self.state.party.clone(),
                 stage: self.state.stage,
                 status: self.state.status(),
+                challenge_ticks: self.state.challenge_ticks,
                 created_unix_ms: self.state.created_unix_ms,
             },
         };
@@ -615,6 +656,7 @@ mod tests {
         appended: Mutex<Vec<JournalEntry>>,
         projected: Mutex<Vec<(Snapshot, Vec<PublishedClient>)>>,
         announced: Mutex<Vec<ChallengeServerUpdate>>,
+        marked: Mutex<Vec<(Stage, Option<u32>)>>,
         deleted: Mutex<Vec<ChallengeState>>,
         // Holds the inbox feed's sender when the run is deadline-driven,
         // as dropping it would close the actor's inbox and end the run.
@@ -684,6 +726,12 @@ mod tests {
         async fn announce(&self, update: &ChallengeServerUpdate) -> Result<(), StoreError> {
             self.log.next_result()?;
             self.log.announced.lock().unwrap().push(*update);
+            Ok(())
+        }
+
+        async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
+            self.log.next_result()?;
+            self.log.marked.lock().unwrap().extend_from_slice(stages);
             Ok(())
         }
 
@@ -945,6 +993,7 @@ mod tests {
             stage_status: StageStatus::Entered,
             stage_state: StageState::InProgress,
             clients: BTreeMap::new(),
+            challenge_ticks: 0,
             recorded_by: [ClientId(10)].into(),
             dormant_since: Some(Timestamp::ZERO),
             processing: Processing::default(),
@@ -1078,6 +1127,7 @@ mod tests {
             stage_status: StageStatus::Entered,
             stage_state: StageState::InProgress,
             clients: BTreeMap::new(),
+            challenge_ticks: 0,
             recorded_by: [ClientId(10)].into(),
             dormant_since: Some(Timestamp::from_millis(500)),
             processing: Processing::default(),

--- a/challenge-harder/src/lifecycle/coordinator.rs
+++ b/challenge-harder/src/lifecycle/coordinator.rs
@@ -701,6 +701,10 @@ mod tests {
             unreachable!();
         }
 
+        async fn mark_processed(&self, _: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
+            unreachable!();
+        }
+
         async fn renew(&self) -> Result<(), StoreError> {
             unreachable!();
         }

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -6,7 +6,9 @@
 use super::command::StageProgress;
 use super::event::{Cause, JournalEntry, LifecycleEvent};
 use super::state::{ChallengeState, ClientState, LastCompleted, PhaseState, StageState, Trigger};
-use super::types::{ClientId, ProcessingError, StageExt, StageStatus, StageStatusExt, Timestamp};
+use super::types::{
+    ClientId, ProcessingError, ProcessingPayload, StageExt, StageStatus, StageStatusExt, Timestamp,
+};
 
 // it's an exhaustive enum folks
 #[allow(clippy::too_many_lines)]
@@ -155,6 +157,18 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             trigger: _,
             payload,
         } => {
+            if let ProcessingPayload::Stage { status, ticks } = payload {
+                state.challenge_ticks += ticks;
+
+                // Update status unless the challenge has moved on.
+                if let Some(run) = state.processing.active()
+                    && let Trigger::Stage { stage, attempt, .. } = run.trigger
+                    && stage == state.stage
+                    && attempt == state.stage_attempt
+                {
+                    state.stage_status = status;
+                }
+            }
             let challenge_type = state.challenge_type;
             state
                 .processing
@@ -1102,6 +1116,8 @@ mod tests {
             ),
         );
         assert!(state.processing.settled());
+        assert_eq!(state.challenge_ticks, 237);
+        assert_eq!(state.stage_status, StageStatus::Completed);
 
         apply(
             &mut state,
@@ -1112,5 +1128,185 @@ mod tests {
             ),
         );
         assert_eq!(state.status(), ChallengeStatus::Reset);
+    }
+
+    #[test]
+    fn stage_outcomes_accumulate_ticks() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+        apply(
+            &mut state,
+            processing_entry(
+                5_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+
+        // The challenge moves on while the run is still processing; the
+        // outcome adds its ticks without touching the status.
+        apply(
+            &mut state,
+            entry(
+                6_000,
+                4,
+                LifecycleEvent::StageStarted {
+                    stage: Stage::TobBloat,
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                7_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(5),
+                    payload: ProcessingPayload::Stage {
+                        status: StageStatus::Wiped,
+                        ticks: 190,
+                    },
+                },
+            ),
+        );
+        assert_eq!(state.challenge_ticks, 190);
+        assert_eq!(state.stage_status, StageStatus::Started);
+
+        // The current stage's processing returns the definitive status.
+        apply(
+            &mut state,
+            JournalEntry {
+                seq: JournalSeq(12),
+                at: Timestamp::from_millis(8_000),
+                caused_by: Cause::Command(MsgId::sequence(5)),
+                event: LifecycleEvent::StageSealed {
+                    stage: Stage::TobBloat,
+                    attempt: None,
+                    forced: false,
+                },
+            },
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                8_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(12),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                9_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(12),
+                    payload: ProcessingPayload::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 150,
+                    },
+                },
+            ),
+        );
+        assert_eq!(state.challenge_ticks, 340);
+        assert_eq!(state.stage_status, StageStatus::Completed);
+    }
+
+    #[test]
+    fn empty_stage_outcome_invalidates_the_previous_status() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+        apply(
+            &mut state,
+            processing_entry(
+                5_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                6_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(5),
+                    payload: ProcessingPayload::Stage {
+                        status: StageStatus::Completed,
+                        ticks: 190,
+                    },
+                },
+            ),
+        );
+
+        apply(
+            &mut state,
+            entry(
+                7_000,
+                4,
+                LifecycleEvent::StageStarted {
+                    stage: Stage::TobBloat,
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            entry(
+                8_000,
+                5,
+                LifecycleEvent::ClientStageReported {
+                    client_id: CLIENT,
+                    attempt: None,
+                    update: StageProgress {
+                        stage: Stage::TobBloat,
+                        status: StageStatus::Wiped,
+                    },
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            JournalEntry {
+                seq: JournalSeq(12),
+                at: Timestamp::from_millis(8_000),
+                caused_by: Cause::Command(MsgId::sequence(6)),
+                event: LifecycleEvent::StageSealed {
+                    stage: Stage::TobBloat,
+                    attempt: None,
+                    forced: false,
+                },
+            },
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                9_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(12),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                10_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(12),
+                    payload: ProcessingPayload::None,
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            entry(
+                11_000,
+                7,
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+        );
+
+        // The final status falls back to the challenge's reported progress
+        // rather than the first stage's stale outcome.
+        assert_eq!(state.status(), ChallengeStatus::Wiped);
     }
 }

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -202,7 +202,13 @@ impl Processing {
                     self.status = Some(status_if_finished_now(challenge_type, stage, status));
                 }
             }
-            Ok(ProcessingPayload::None) => {}
+            Ok(ProcessingPayload::None) => {
+                // Stage processing always invalidates a previous status. If the
+                // run completed with no data, the status is just cleared.
+                if matches!(run.trigger, Trigger::Stage { .. }) {
+                    self.status = None;
+                }
+            }
             Err(error) => {
                 run.retriable &= error.retriable;
                 if !run.exhausted(&self.config) {
@@ -223,6 +229,14 @@ impl Processing {
     #[must_use]
     pub fn active(&self) -> Option<&ProcessingRun> {
         self.active.as_ref()
+    }
+
+    /// Triggers whose runs are in progress or queued.
+    pub fn outstanding(&self) -> impl Iterator<Item = Trigger> + '_ {
+        self.active
+            .iter()
+            .map(|run| run.trigger)
+            .chain(self.pending.iter().copied())
     }
 
     /// Triggers whose runs were abandoned after exhausting their attempts.
@@ -378,12 +392,13 @@ pub struct ChallengeState {
     pub reported_times: Option<ReportedTimes>,
     pub stage: Stage,
     pub stage_attempt: Option<u32>,
-    /// Status of the challenge's current stage.
-    // TODO(frolv): Derived from client reports until stage processing
-    // provides merged outcomes.
+    /// Status of the challenge's current stage. Client reports provide an
+    /// interim value mid-stage until processing runs.
     pub stage_status: StageStatus,
     pub stage_state: StageState,
     pub clients: BTreeMap<ClientId, ClientState>,
+    /// Total ticks across the challenge's processed stages.
+    pub challenge_ticks: u32,
     /// Every client that has recorded any part of the challenge.
     pub recorded_by: BTreeSet<ClientId>,
     /// When the challenge lost its last active client.

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -3,6 +3,7 @@
 use core::ops::Add;
 use core::time::Duration;
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -221,6 +222,63 @@ const _: () = {
 pub struct ReportedTimes {
     pub challenge: u32,
     pub overall: u32,
+}
+
+/// A client's reported completion state for a stage.
+/// Matches `StageUpdate` in `//common/db/redis.ts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StageUpdate {
+    pub stage: Stage,
+    pub status: StageStatus,
+    pub accurate: bool,
+    pub recorded_ticks: u32,
+    pub server_ticks: Option<ServerTicks>,
+}
+
+/// A client's report of the server's tick count for a stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerTicks {
+    pub count: u32,
+    pub precise: bool,
+}
+
+/// A single record in a stage's recorded event stream.
+/// Matches `ClientStageStream` in `//common/db/redis.ts`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientStageStream {
+    /// Identifies the plugin build behind a client's records.
+    Metadata {
+        client_id: ClientId,
+        user_id: UserId,
+        plugin_version: String,
+        runelite_version: String,
+    },
+    /// A batch of events recorded by a client, as a serialized
+    /// `ChallengeEvents` proto.
+    Events { client_id: ClientId, events: Bytes },
+    /// A client's end-of-stage report.
+    End {
+        client_id: ClientId,
+        update: StageUpdate,
+    },
+}
+
+impl ClientStageStream {
+    // Matches `StageStreamType` in `//common/db/redis.ts`.
+    pub const EVENTS_TAG: u8 = 0;
+    pub const STAGE_END_TAG: u8 = 1;
+    pub const METADATA_TAG: u8 = 2;
+
+    /// The client that produced this record.
+    #[must_use]
+    pub fn client_id(&self) -> ClientId {
+        match self {
+            ClientStageStream::Metadata { client_id, .. }
+            | ClientStageStream::Events { client_id, .. }
+            | ClientStageStream::End { client_id, .. } => *client_id,
+        }
+    }
 }
 
 /// Result that a completed processing run feeds back into the challenge.

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -141,6 +141,8 @@ pub struct ScenarioResult {
     pub updates: Vec<(Uuid, ChallengeServerUpdate)>,
     /// IDs of every command sent to each challenge's inbox, in send order.
     pub inboxes: BTreeMap<Uuid, Vec<MsgId>>,
+    /// Stage attempts whose streams were marked processed, per challenge.
+    pub marked: MarkedStages,
     /// Challenges whose state was deleted from the store.
     pub deleted: BTreeSet<Uuid>,
 }
@@ -255,6 +257,9 @@ pub fn perturb(scenario: &mut Scenario, rng: &mut Rng, jitter_ms: u64) {
 
 type SignalSink = Arc<Mutex<Option<mpsc::Sender<ChallengeSignal>>>>;
 
+/// Stage attempts whose streams were marked processed, per challenge.
+type MarkedStages = BTreeMap<Uuid, BTreeSet<(Stage, Option<u32>)>>;
+
 /// Identity of a party for routing, built from its raw names.
 fn party_identity(challenge_type: ChallengeType, party: &[String]) -> String {
     let mut sorted: Vec<&str> = party.iter().map(String::as_str).collect();
@@ -289,6 +294,7 @@ pub(crate) struct Collector {
     journals: Arc<Mutex<CollectedJournals>>,
     projections: Arc<Mutex<BTreeMap<Uuid, Snapshot>>>,
     updates: Arc<Mutex<Vec<(Uuid, ChallengeServerUpdate)>>>,
+    marked: Arc<Mutex<MarkedStages>>,
     signals: SignalSink,
 }
 
@@ -331,6 +337,7 @@ impl Collector {
             journals: self.journals.clone(),
             projections: self.projections.clone(),
             updates: self.updates.clone(),
+            marked: self.marked.clone(),
             signals: self.signals.clone(),
         }
     }
@@ -364,6 +371,7 @@ struct CollectorClaim {
     journals: Arc<Mutex<CollectedJournals>>,
     projections: Arc<Mutex<BTreeMap<Uuid, Snapshot>>>,
     updates: Arc<Mutex<Vec<(Uuid, ChallengeServerUpdate)>>>,
+    marked: Arc<Mutex<MarkedStages>>,
     signals: SignalSink,
 }
 
@@ -656,6 +664,16 @@ impl ChallengeClaim for CollectorClaim {
         Ok(())
     }
 
+    async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
+        self.marked
+            .lock()
+            .expect("collector lock poisoned")
+            .entry(self.uuid)
+            .or_default()
+            .extend(stages.iter().copied());
+        Ok(())
+    }
+
     async fn renew(&self) -> Result<(), StoreError> {
         Ok(())
     }
@@ -856,6 +874,11 @@ pub async fn run_with(options: impl Into<RunOptions>, scenario: Scenario) -> Sce
         .iter()
         .map(|(uuid, entries)| (*uuid, entries.iter().map(|e| e.id).collect()))
         .collect();
+    let marked = collector
+        .marked
+        .lock()
+        .expect("collector lock poisoned")
+        .clone();
     let deleted = collector
         .routing
         .lock()
@@ -880,6 +903,7 @@ pub async fn run_with(options: impl Into<RunOptions>, scenario: Scenario) -> Sce
         projections,
         updates,
         inboxes,
+        marked,
         deleted,
     };
     check_invariants(&result, &config);
@@ -1035,6 +1059,17 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
         for entry in journal {
             apply(&mut folded, entry.clone());
         }
+
+        // Every journaled seal closes its stage's stream.
+        let sealed: BTreeSet<(Stage, Option<u32>)> = journal
+            .iter()
+            .filter_map(|entry| match entry.event {
+                LifecycleEvent::StageSealed { stage, attempt, .. } => Some((stage, attempt)),
+                _ => None,
+            })
+            .collect();
+        let marked = result.marked.get(uuid).cloned().unwrap_or_default();
+        assert_eq!(marked, sealed, "seal markers mismatch: {uuid}");
 
         // A challenge whose processing completed after termination is deleted
         // and announces its finish exactly once.

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -31,6 +31,9 @@ const PROCESSING_MAX_ATTEMPTS: u32 = 3;
 /// Connections held to the challenge database.
 const DEFAULT_DB_POOL_SIZE: usize = 8;
 
+/// Connections held in the shared Redis pool.
+const DEFAULT_REDIS_POOL_SIZE: usize = 16;
+
 #[derive(Parser)]
 struct Cli {
     #[command(subcommand)]
@@ -79,15 +82,22 @@ async fn serve(config: LifecycleConfig) {
 
     let redis_uri = std::env::var("BLERT_REDIS_URI").expect("BLERT_REDIS_URI must be set");
     let identity = std::env::var("HOSTNAME").expect("HOSTNAME must be set");
-    let store = store::Store::connect(&redis_uri, identity.clone())
-        .await
-        .expect("failed to connect to Redis");
+    let redis_pool_size = std::env::var("BLERT_REDIS_POOL_SIZE")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(DEFAULT_REDIS_POOL_SIZE);
+    let store = Arc::new(
+        store::Store::connect(&redis_uri, identity.clone(), redis_pool_size)
+            .await
+            .expect("failed to connect to Redis"),
+    );
     tracing::info!(identity, "redis_connected");
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     let processing_enabled = config.processing.max_attempts > 0;
-    let mut coordinator = Coordinator::with_store(Arc::new(store), shutdown_rx).with_config(config);
+    let mut coordinator =
+        Coordinator::with_store(Arc::clone(&store) as _, shutdown_rx).with_config(config);
     if processing_enabled {
         let database_uri =
             std::env::var("BLERT_DATABASE_URI").expect("BLERT_DATABASE_URI must be set");
@@ -99,7 +109,7 @@ async fn serve(config: LifecycleConfig) {
             .await
             .expect("failed to connect to Postgres");
         tracing::info!("postgres_connected");
-        coordinator = coordinator.with_processor(Arc::new(processing::Pipeline::new(db)));
+        coordinator = coordinator.with_processor(Arc::new(processing::Pipeline::new(db, store)));
     }
     let coordinator = Arc::new(coordinator);
     coordinator.start_scan(CLAIM_SCAN_INTERVAL);

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -35,59 +35,41 @@ pub async fn create(
         .await?;
     txn.set_challenge_id(row.get(0));
 
-    let player_ids = start_player_challenges(txn, &info.party).await?;
-    let orbs: Vec<i16> = (0..info.party.len())
-        .map(|orb| i16::try_from(orb).expect("orb fits in a smallint"))
-        .collect();
-    txn.execute(
-        "INSERT INTO challenge_players (challenge_id, player_id, username, orb, primary_gear)
-         SELECT $1, player_id, username, orb, $2
-         FROM UNNEST($3::INT[], $4::TEXT[], $5::SMALLINT[]) AS input (player_id, username, orb)",
-        &[
-            &txn.challenge_id(),
-            &(PrimaryMeleeGear::Unknown as i16),
-            &player_ids,
-            &info.party,
-            &orbs,
-        ],
-    )
-    .await?;
+    for (orb, username) in info.party.iter().enumerate() {
+        let player_id = start_player_challenge(txn, username).await?;
+        txn.execute(
+            "INSERT INTO challenge_players (challenge_id, player_id, username, orb, primary_gear)
+             VALUES ($1, $2, $3, $4, $5)",
+            &[
+                &txn.challenge_id(),
+                &player_id,
+                &username,
+                &i16::try_from(orb).expect("orb fits in a smallint"),
+                &(PrimaryMeleeGear::Unknown as i16),
+            ],
+        )
+        .await?;
+    }
 
     Ok(())
 }
 
-/// Records that each player in `party` has started a challenge, creating
-/// their rows if they do not exist. Returns the players' database IDs, in
-/// party order.
-async fn start_player_challenges(
-    txn: &db::Transaction,
-    party: &[String],
-) -> Result<Vec<i32>, db::Error> {
-    let normalized: Vec<String> = party.iter().map(|name| normalize_rsn(name)).collect();
+/// Records that a player has started a challenge, creating their row if it
+/// does not exist. Returns the player's database ID.
+async fn start_player_challenge(txn: &db::Transaction, username: &str) -> Result<i32, db::Error> {
     // The unique index on normalized_username is partial, so the conflict
     // target must spell its predicate for Postgres.
-    let rows = txn
-        .query(
+    let row = txn
+        .query_one(
             "INSERT INTO players (username, normalized_username, total_recordings)
-             SELECT username, normalized, 1
-             FROM UNNEST($1::TEXT[], $2::TEXT[]) AS input (username, normalized)
+             VALUES ($1, $2, 1)
              ON CONFLICT (normalized_username) WHERE NOT starts_with(normalized_username, '*')
              DO UPDATE SET total_recordings = players.total_recordings + 1
-             RETURNING id, normalized_username",
-            &[&party, &normalized],
+             RETURNING id",
+            &[&username, &normalize_rsn(username)],
         )
         .await?;
-
-    let ids: std::collections::HashMap<String, i32> =
-        rows.iter().map(|row| (row.get(1), row.get(0))).collect();
-    normalized
-        .iter()
-        .map(|name| {
-            ids.get(name)
-                .copied()
-                .ok_or_else(|| db::Error::InvalidData(format!("no player row returned for {name}")))
-        })
-        .collect()
+    Ok(row.get(0))
 }
 
 /// Records a user as a recorder of the challenge.

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -1,16 +1,19 @@
 //! Challenge processing pipeline.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::lifecycle::core::state::Trigger;
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ProcessingError, ProcessingPayload, Stage,
-    StageStatus, Uuid,
+    ChallengeMode, ChallengeStatus, ChallengeType, ProcessingError, ProcessingPayload, Stage, Uuid,
 };
+use crate::store::Store;
 
 pub mod db;
 
 mod challenge;
+mod stage;
 
 /// Challenge state at the time a run is triggered.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,6 +23,7 @@ pub struct ChallengeInfo {
     pub party: Vec<String>,
     pub stage: Stage,
     pub status: ChallengeStatus,
+    pub challenge_ticks: u32,
     pub created_unix_ms: u64,
 }
 
@@ -43,11 +47,12 @@ pub trait StageProcessor: Send + Sync + 'static {
 /// Complete event processing pipeline.
 pub struct Pipeline {
     db: db::Postgres,
+    store: Arc<Store>,
 }
 
 impl Pipeline {
-    pub fn new(db: db::Postgres) -> Pipeline {
-        Pipeline { db }
+    pub fn new(db: db::Postgres, store: Arc<Store>) -> Pipeline {
+        Pipeline { db, store }
     }
 }
 
@@ -93,10 +98,17 @@ impl StageProcessor for Pipeline {
                 challenge::finish(&txn, &request.challenge).await?;
                 ProcessingPayload::None
             }
-            Trigger::Stage { .. } => ProcessingPayload::Stage {
-                status: StageStatus::Completed,
-                ticks: 0,
-            },
+            Trigger::Stage { stage, attempt, .. } => {
+                stage::process(
+                    &self.store,
+                    &txn,
+                    &request.challenge,
+                    request.uuid,
+                    stage,
+                    attempt,
+                )
+                .await?
+            }
         };
         txn.commit(&payload).await?;
 

--- a/challenge-harder/src/processing/stage.rs
+++ b/challenge-harder/src/processing/stage.rs
@@ -1,0 +1,273 @@
+//! Stage event processing.
+//!
+//! The run follows a three-phase pipeline:
+//!
+//! 1. `gather` reads the stage's recorded streams and stored challenge state.
+//! 2. `interpret` runs the synchronous processing step to convert the raw
+//!    streams into a canonical record of stage events.
+//! 3. `persist` receives the results and writes them to the database and
+//!    blob store.
+
+use std::collections::BTreeMap;
+
+use super::ChallengeInfo;
+use super::db;
+use crate::lifecycle::challenge::StoreError;
+use crate::lifecycle::core::types::{
+    ClientId, ClientStageStream, ProcessingError, ProcessingPayload, Stage, StageStatus, Uuid,
+};
+use crate::store::Store;
+
+/// A single client's events for a stage, structured from its stream records.
+// TODO(frolv): move to merging
+#[derive(Debug)]
+pub struct ClientEvents {
+    status: StageStatus,
+    recorded_ticks: u32,
+}
+
+impl ClientEvents {
+    /// Initializes challenge events for a client from its stage event stream.
+    fn from_client_stream(
+        uuid: Uuid,
+        stage: Stage,
+        client_id: ClientId,
+        records: &[ClientStageStream],
+    ) -> ClientEvents {
+        let mut client = ClientEvents {
+            status: StageStatus::Started,
+            recorded_ticks: 0,
+        };
+
+        let mut saw_stage_end = false;
+        for record in records {
+            if let ClientStageStream::End { update, .. } = record {
+                client.status = update.status;
+                client.recorded_ticks = update.recorded_ticks;
+                saw_stage_end = true;
+            }
+        }
+        if !saw_stage_end {
+            tracing::warn!(%uuid, %client_id, ?stage, "client_missing_stage_metadata");
+        }
+
+        client
+    }
+
+    /// The status reported by the client.
+    pub fn status(&self) -> StageStatus {
+        self.status
+    }
+
+    /// The highest recorded tick in the client's events.
+    pub fn final_tick(&self) -> u32 {
+        self.recorded_ticks
+    }
+}
+
+/// Processes a stage's events from its recorded streams.
+pub async fn process(
+    store: &Store,
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    uuid: Uuid,
+    stage: Stage,
+    attempt: Option<u32>,
+) -> Result<ProcessingPayload, ProcessingError> {
+    let stream = gather(store, uuid, stage, attempt).await?;
+
+    // TODO(frolv): Move processing into a synchronous background thread.
+    let clients = build_client_events(uuid, stage, stream);
+    let result = interpret(&clients);
+
+    persist(txn, challenge, result).await
+}
+
+/// Reads a stage's recorded streams from the store.
+// TODO(frolv): This should also collect other data required by the processing
+// thread.
+async fn gather(
+    store: &Store,
+    uuid: Uuid,
+    stage: Stage,
+    attempt: Option<u32>,
+) -> Result<Vec<ClientStageStream>, ProcessingError> {
+    store
+        .read_stage_stream(uuid, stage, attempt)
+        .await
+        .map_err(|error| ProcessingError {
+            retriable: matches!(error, StoreError::Unavailable(_)),
+            message: error.to_string(),
+        })
+}
+
+/// Partitions a stream's records into per-client event streams and metadata.
+fn build_client_events(
+    uuid: Uuid,
+    stage: Stage,
+    records: Vec<ClientStageStream>,
+) -> Vec<ClientEvents> {
+    let mut partitions: BTreeMap<ClientId, Vec<ClientStageStream>> = BTreeMap::new();
+    for record in records {
+        partitions
+            .entry(record.client_id())
+            .or_default()
+            .push(record);
+    }
+
+    partitions
+        .into_iter()
+        .map(|(client_id, records)| {
+            ClientEvents::from_client_stream(uuid, stage, client_id, &records)
+        })
+        .collect()
+}
+
+/// A failure to interpret a stage's recorded data.
+#[derive(Debug)]
+enum InterpretError {
+    /// The stage has no recorded data to process.
+    NoData,
+}
+
+#[derive(Debug)]
+struct ProcessingOutput {
+    status: StageStatus,
+    ticks: u32,
+}
+
+/// Processes a stage's raw events into a canonical record.
+fn interpret(clients: &[ClientEvents]) -> Result<ProcessingOutput, InterpretError> {
+    match clients.first() {
+        Some(first) => Ok(ProcessingOutput {
+            status: first.status(),
+            ticks: first.final_tick(),
+        }),
+        None => Err(InterpretError::NoData),
+    }
+}
+
+/// Writes a stage's processed results to the database and blob store.
+/// Returns the payload to be sent back to the challenge.
+async fn persist(
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    result: Result<ProcessingOutput, InterpretError>,
+) -> Result<ProcessingPayload, ProcessingError> {
+    let payload = payload_from(&result);
+
+    if let Ok(output) = result {
+        let total = (challenge.challenge_ticks + output.ticks).cast_signed();
+        txn.execute(
+            "UPDATE challenges SET challenge_ticks = $1 WHERE id = $2",
+            &[&total, &txn.challenge_id()],
+        )
+        .await
+        .map_err(db::Error::from)?;
+    }
+
+    Ok(payload)
+}
+
+fn payload_from(result: &Result<ProcessingOutput, InterpretError>) -> ProcessingPayload {
+    match result {
+        Ok(output) => ProcessingPayload::Stage {
+            status: output.status,
+            ticks: output.ticks,
+        },
+        // TODO(frolv): Handle errors.
+        Err(InterpretError::NoData) => ProcessingPayload::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::*;
+    use crate::lifecycle::core::types::{ServerTicks, StageUpdate, UserId};
+
+    fn test_uuid() -> Uuid {
+        "a8cb035f-410a-45de-a4d3-2b0a5d8b464d".parse().unwrap()
+    }
+
+    fn metadata(client: i64) -> ClientStageStream {
+        ClientStageStream::Metadata {
+            client_id: ClientId(client),
+            user_id: UserId(client * 10),
+            plugin_version: "0.9.14".into(),
+            runelite_version: "1.12.33".into(),
+        }
+    }
+
+    fn events(client: i64) -> ClientStageStream {
+        ClientStageStream::Events {
+            client_id: ClientId(client),
+            events: Bytes::from_static(b"batch"),
+        }
+    }
+
+    fn end(client: i64, status: StageStatus, ticks: u32) -> ClientStageStream {
+        ClientStageStream::End {
+            client_id: ClientId(client),
+            update: StageUpdate {
+                stage: Stage::TobMaiden,
+                status,
+                accurate: true,
+                recorded_ticks: ticks,
+                server_ticks: Some(ServerTicks {
+                    count: ticks,
+                    precise: true,
+                }),
+            },
+        }
+    }
+
+    fn clients_of(records: Vec<ClientStageStream>) -> Vec<ClientEvents> {
+        build_client_events(test_uuid(), Stage::TobMaiden, records)
+    }
+
+    #[test]
+    fn clients_partition_in_id_order() {
+        let clients = clients_of(vec![
+            metadata(2),
+            metadata(1),
+            events(1),
+            end(1, StageStatus::Completed, 200),
+            events(2),
+            end(2, StageStatus::Wiped, 185),
+        ]);
+        let reports: Vec<(StageStatus, u32)> = clients
+            .iter()
+            .map(|client| (client.status(), client.final_tick()))
+            .collect();
+        assert_eq!(
+            reports,
+            vec![(StageStatus::Completed, 200), (StageStatus::Wiped, 185)],
+        );
+    }
+
+    #[test]
+    fn later_report_supersedes_an_earlier_one() {
+        let clients = clients_of(vec![
+            end(1, StageStatus::Wiped, 100),
+            end(1, StageStatus::Completed, 190),
+        ]);
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].status(), StageStatus::Completed);
+        assert_eq!(clients[0].final_tick(), 190);
+    }
+
+    #[test]
+    fn client_without_a_report_returns_status_started() {
+        let clients = clients_of(vec![metadata(1), events(1)]);
+        assert_eq!(clients.len(), 1);
+        assert_eq!(clients[0].status(), StageStatus::Started);
+        assert_eq!(clients[0].final_tick(), 0);
+    }
+
+    #[test]
+    fn empty_stream_yields_no_payload() {
+        assert_eq!(payload_from(&interpret(&[])), ProcessingPayload::None);
+    }
+}

--- a/challenge-harder/src/store/mod.rs
+++ b/challenge-harder/src/store/mod.rs
@@ -4,8 +4,9 @@ use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
+use bytes::Bytes;
+use deadpool_redis::{Manager, Pool};
 use futures_util::StreamExt;
-use redis::aio::ConnectionManager;
 use redis::streams::{StreamReadOptions, StreamReadReply};
 use serde::Serialize;
 use tokio::sync::mpsc;
@@ -20,14 +21,16 @@ use crate::lifecycle::core::command::{
 use crate::lifecycle::core::event::JournalEntry;
 use crate::lifecycle::core::state::{ChallengePhase, ChallengeState, PublishedClient, Snapshot};
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, Epoch, MsgId, Stage, StageExt, Uuid,
+    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, ClientStageStream, Epoch, MsgId,
+    Stage, StageExt, UserId, Uuid,
 };
 use crate::players::normalize_rsn;
 
 mod scripts;
 use scripts::{
     ANNOUNCE_SCRIPT, APPEND_SCRIPT, CLAIM_SCRIPT, CLIENT_SEND_SCRIPT, DELETE_SCRIPT,
-    PROJECT_SCRIPT, REJOIN_SCRIPT, RELEASE_SCRIPT, RENEW_SCRIPT, SEND_SCRIPT, START_SCRIPT,
+    PROJECT_SCRIPT, REJOIN_SCRIPT, RELEASE_SCRIPT, RENEW_SCRIPT, SEAL_SCRIPT, SEND_SCRIPT,
+    START_SCRIPT,
 };
 
 #[cfg(test)]
@@ -114,6 +117,30 @@ fn streams_set_key(uuid: Uuid) -> String {
     format!("challenge-streams:{uuid}")
 }
 
+/// Stream storing a stage's recorded events.
+/// Matches `challengeStageStreamKey` in `//common/db/redis.ts`.
+fn stage_stream_key(uuid: Uuid, stage: Stage, attempt: Option<u32>) -> String {
+    match attempt {
+        Some(attempt) => format!("challenge-events:{uuid}:{}:{attempt}", stage as i32),
+        None => format!("challenge-events:{uuid}:{}", stage as i32),
+    }
+}
+
+/// Set of a challenge's stage attempts whose streams are closed to writes.
+/// Matches `challengeProcessedStagesKey` in `//common/db/redis.ts`.
+fn processed_stages_key(uuid: Uuid) -> String {
+    format!("{CHALLENGE_KEY_PREFIX}{uuid}:processed-stages")
+}
+
+/// A stage attempt's identity within the processed stages set.
+/// Matches `stageAttemptKey` in `//common/db/redis.ts`.
+fn stage_attempt_member(stage: Stage, attempt: Option<u32>) -> String {
+    match attempt {
+        Some(attempt) => format!("{}:{attempt}", stage as i32),
+        None => (stage as i32).to_string(),
+    }
+}
+
 /// How long a deleted challenge's journal and inbox are retained for
 /// inspection before expiring.
 const DELETED_STREAM_RETENTION: Duration = Duration::from_hours(24);
@@ -170,21 +197,68 @@ enum UpdateMessage {
 pub struct Store {
     /// Name under which this instance claims challenges.
     identity: String,
+    /// Source of the dedicated connections held by blocking consumers.
     client: redis::Client,
-    connection: ConnectionManager,
+    pool: Pool,
+}
+
+/// Checks a connection out of `pool`.
+async fn checkout(pool: &Pool) -> Result<deadpool_redis::Connection, StoreError> {
+    pool.get()
+        .await
+        .map_err(|e| StoreError::Unavailable(e.to_string()))
 }
 
 impl Store {
     /// Connects to the Redis instance at `uri`. `identity` uniquely represents
     /// this instance and must be stable across restarts.
-    pub async fn connect(uri: &str, identity: String) -> redis::RedisResult<Self> {
-        let client = redis::Client::open(uri)?;
-        let connection = client.get_connection_manager().await?;
+    pub async fn connect(
+        uri: &str,
+        identity: String,
+        pool_size: usize,
+    ) -> Result<Self, StoreError> {
+        let client =
+            redis::Client::open(uri).map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        let manager = Manager::new(uri).map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        let pool = Pool::builder(manager)
+            .max_size(pool_size)
+            .build()
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        drop(checkout(&pool).await?);
         Ok(Store {
             identity,
             client,
-            connection,
+            pool,
         })
+    }
+
+    /// Reads and parses the full recorded event stream for a challenge stage,
+    /// in insertion order. Records which fail to parse are skipped.
+    pub async fn read_stage_stream(
+        &self,
+        uuid: Uuid,
+        stage: Stage,
+        attempt: Option<u32>,
+    ) -> Result<Vec<ClientStageStream>, StoreError> {
+        let mut connection = checkout(&self.pool).await?;
+        let entries: Vec<(String, HashMap<String, Vec<u8>>)> = redis::cmd("XRANGE")
+            .arg(stage_stream_key(uuid, stage, attempt))
+            .arg("-")
+            .arg("+")
+            .query_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+
+        Ok(entries
+            .iter()
+            .filter_map(|(id, fields)| match parse_stream_record(fields) {
+                Ok(record) => Some(record),
+                Err(error) => {
+                    tracing::warn!(%uuid, id, error, "invalid_stage_stream_record");
+                    None
+                }
+            })
+            .collect())
     }
 
     /// A write handle to challenge `uuid`'s state under `epoch`.
@@ -197,39 +271,55 @@ impl Store {
             clients_key: clients_key(uuid),
             epoch,
             client: self.client.clone(),
-            connection: self.connection.clone(),
+            pool: self.pool.clone(),
         }
     }
 }
 
+/// Returns the raw value of `name` in a Redis hash.
+fn field<'a, V: AsRef<[u8]>>(hash: &'a HashMap<String, V>, name: &str) -> Result<&'a [u8], String> {
+    hash.get(name)
+        .map(AsRef::as_ref)
+        .ok_or_else(|| format!("missing field {name}"))
+}
+
+/// Returns the value of `name` in a Redis hash as a string.
+fn string_field<'a, V: AsRef<[u8]>>(
+    hash: &'a HashMap<String, V>,
+    name: &str,
+) -> Result<&'a str, String> {
+    std::str::from_utf8(field(hash, name)?).map_err(|_| format!("field {name} is not UTF-8"))
+}
+
+/// Parses the value of `name` in a Redis hash from its decimal form.
+fn int_field<T, V>(hash: &HashMap<String, V>, name: &str) -> Result<T, String>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+    V: AsRef<[u8]>,
+{
+    string_field(hash, name)?
+        .parse()
+        .map_err(|e| format!("invalid {name}: {e}"))
+}
+
 /// Parses a challenge's projected state hash back into a snapshot.
 fn parse_snapshot(uuid: Uuid, hash: &HashMap<String, String>) -> Result<Snapshot, String> {
-    fn field<'a>(hash: &'a HashMap<String, String>, name: &str) -> Result<&'a str, String> {
-        hash.get(name)
-            .map(String::as_str)
-            .ok_or_else(|| format!("missing field {name}"))
-    }
-
-    fn int(hash: &HashMap<String, String>, name: &str) -> Result<i32, String> {
-        field(hash, name)?
-            .parse()
-            .map_err(|e| format!("invalid {name}: {e}"))
-    }
-
     let attempt = hash.get("stageAttempt").map_or("", String::as_str);
-    let party = field(hash, "party")?;
-    let tag = field(hash, "phase")?;
+    let party = string_field(hash, "party")?;
+    let tag = string_field(hash, "phase")?;
     let phase = ChallengePhase::from_tag(tag).ok_or_else(|| format!("invalid phase: {tag}"))?;
-    let status: ChallengeStatus =
-        serde_json::from_str(field(hash, "status")?).map_err(|e| format!("invalid status: {e}"))?;
+    let status: ChallengeStatus = serde_json::from_str(string_field(hash, "status")?)
+        .map_err(|e| format!("invalid status: {e}"))?;
 
     Ok(Snapshot {
         uuid,
-        challenge_type: ChallengeType::try_from(int(hash, "type")?)
+        challenge_type: ChallengeType::try_from(int_field::<i32, _>(hash, "type")?)
             .map_err(|e| format!("invalid type: {e}"))?,
-        mode: ChallengeMode::try_from(int(hash, "mode")?)
+        mode: ChallengeMode::try_from(int_field::<i32, _>(hash, "mode")?)
             .map_err(|e| format!("invalid mode: {e}"))?,
-        stage: Stage::try_from(int(hash, "stage")?).map_err(|e| format!("invalid stage: {e}"))?,
+        stage: Stage::try_from(int_field::<i32, _>(hash, "stage")?)
+            .map_err(|e| format!("invalid stage: {e}"))?,
         stage_attempt: if attempt.is_empty() {
             None
         } else {
@@ -246,10 +336,32 @@ fn parse_snapshot(uuid: Uuid, hash: &HashMap<String, String>) -> Result<Snapshot
         },
         phase,
         status,
-        cursor: field(hash, "cursor")?
-            .parse()
-            .map_err(|e| format!("invalid cursor: {e}"))?,
+        cursor: int_field(hash, "cursor")?,
     })
+}
+
+/// Parses a stage stream entry's fields into a record.
+/// Inverts `stageStreamToRecord` in `//common/db/redis.ts`.
+fn parse_stream_record(fields: &HashMap<String, Vec<u8>>) -> Result<ClientStageStream, String> {
+    let client_id = ClientId(int_field(fields, "clientId")?);
+    match int_field::<u8, _>(fields, "type")? {
+        ClientStageStream::EVENTS_TAG => Ok(ClientStageStream::Events {
+            client_id,
+            events: Bytes::copy_from_slice(field(fields, "events")?),
+        }),
+        ClientStageStream::STAGE_END_TAG => Ok(ClientStageStream::End {
+            client_id,
+            update: serde_json::from_slice(field(fields, "update")?)
+                .map_err(|e| format!("invalid stage update: {e}"))?,
+        }),
+        ClientStageStream::METADATA_TAG => Ok(ClientStageStream::Metadata {
+            client_id,
+            user_id: UserId(int_field(fields, "userId")?),
+            plugin_version: string_field(fields, "pluginVersion")?.into(),
+            runelite_version: string_field(fields, "runeLiteVersion")?.into(),
+        }),
+        other => Err(format!("unknown record type {other}")),
+    }
 }
 
 #[async_trait]
@@ -259,7 +371,7 @@ impl ChallengeStore for Store {
         batch_size: usize,
         exclude: &[Uuid],
     ) -> Result<Vec<Claim>, StoreError> {
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = CLAIM_SCRIPT.prepare_invoke();
         invocation
@@ -294,7 +406,7 @@ impl ChallengeStore for Store {
     async fn start(&self, create: Create) -> Result<Start, StoreError> {
         let uuid = Uuid::new_v4();
         let party = party_key(create.challenge_type, &create.party);
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = START_SCRIPT.prepare_invoke();
         invocation
@@ -351,7 +463,7 @@ impl ChallengeStore for Store {
     async fn rejoin(&self, uuid: Uuid, join: &Join) -> Result<Rejoin, StoreError> {
         let payload =
             serde_json::to_string(&Command::Join(join.clone())).expect("command serializes");
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = REJOIN_SCRIPT.prepare_invoke();
         invocation
@@ -377,7 +489,7 @@ impl ChallengeStore for Store {
 
     async fn send(&self, uuid: Uuid, cmd: &Command) -> Result<Option<MsgId>, StoreError> {
         let payload = serde_json::to_string(cmd).expect("command serializes");
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = SEND_SCRIPT.prepare_invoke();
         invocation
@@ -402,7 +514,7 @@ impl ChallengeStore for Store {
         cmd: &Command,
     ) -> Result<Option<(Uuid, MsgId)>, StoreError> {
         let payload = serde_json::to_string(cmd).expect("command serializes");
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = CLIENT_SEND_SCRIPT.prepare_invoke();
         invocation.key(client_key(client)).arg(payload);
@@ -425,7 +537,7 @@ impl ChallengeStore for Store {
     }
 
     async fn read(&self, uuid: Uuid) -> Result<Option<Snapshot>, StoreError> {
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
         let hash: HashMap<String, String> =
             redis::AsyncCommands::hgetall(&mut connection, challenge_key(uuid))
                 .await
@@ -491,13 +603,13 @@ struct RedisClaim {
     clients_key: String,
     epoch: Epoch,
     client: redis::Client,
-    connection: ConnectionManager,
+    pool: Pool,
 }
 
 #[async_trait]
 impl ChallengeClaim for RedisClaim {
     async fn load(&self) -> Result<Vec<JournalEntry>, StoreError> {
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
         let batches: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
             .arg(&self.journal_key)
             .arg("-")
@@ -527,7 +639,7 @@ impl ChallengeClaim for RedisClaim {
 
     async fn append(&self, batch: &[JournalEntry]) -> Result<(), StoreError> {
         let payload = serde_json::to_string(batch).expect("journal entries serialize");
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = APPEND_SCRIPT.prepare_invoke();
         invocation
@@ -571,7 +683,7 @@ impl ChallengeClaim for RedisClaim {
             state_pairs.push(("stageAttempt", attempt.to_string()));
         }
 
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
         let mut invocation = PROJECT_SCRIPT.prepare_invoke();
         invocation
             .key(&self.challenge_key)
@@ -605,7 +717,7 @@ impl ChallengeClaim for RedisClaim {
             ChallengeServerUpdate::Finish => UpdateMessage::Finish { id: self.uuid },
         };
         let payload = serde_json::to_string(&message).expect("update serializes");
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = ANNOUNCE_SCRIPT.prepare_invoke();
         invocation
@@ -624,8 +736,34 @@ impl ChallengeClaim for RedisClaim {
         }
     }
 
+    async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
+        if stages.is_empty() {
+            return Ok(());
+        }
+        let mut connection = checkout(&self.pool).await?;
+
+        let mut invocation = SEAL_SCRIPT.prepare_invoke();
+        invocation
+            .key(&self.lease_key)
+            .key(processed_stages_key(self.uuid))
+            .arg(self.epoch.0);
+        for (stage, attempt) in stages {
+            invocation.arg(stage_attempt_member(*stage, *attempt));
+        }
+
+        let marked: i64 = invocation
+            .invoke_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        if marked == 1 {
+            Ok(())
+        } else {
+            Err(StoreError::Fenced)
+        }
+    }
+
     async fn renew(&self) -> Result<(), StoreError> {
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = RENEW_SCRIPT.prepare_invoke();
         invocation
@@ -647,7 +785,7 @@ impl ChallengeClaim for RedisClaim {
     }
 
     async fn release(&self) -> Result<(), StoreError> {
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = RELEASE_SCRIPT.prepare_invoke();
         invocation
@@ -670,7 +808,7 @@ impl ChallengeClaim for RedisClaim {
     async fn delete(&self, state: &ChallengeState) -> Result<(), StoreError> {
         let signal = serde_json::to_string(&ChallengeSignal::Deleted { uuid: self.uuid })
             .expect("signal serializes");
-        let mut connection = self.connection.clone();
+        let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = DELETE_SCRIPT.prepare_invoke();
         invocation
@@ -681,6 +819,7 @@ impl ChallengeClaim for RedisClaim {
             .key(inbox_key(self.uuid))
             .key(streams_set_key(self.uuid))
             .key(&self.clients_key)
+            .key(processed_stages_key(self.uuid))
             .key(directory_key(&party_key(
                 state.challenge_type,
                 &state.party,

--- a/challenge-harder/src/store/scripts.rs
+++ b/challenge-harder/src/store/scripts.rs
@@ -210,6 +210,26 @@ pub(super) static ANNOUNCE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
     ))
 });
 
+/// Seals stages' event streams, refusing them further writes.
+///
+/// Returns 1 if the markers were written, or 0 if the claim was fenced off.
+///
+/// - `KEYS[1]` = Challenge's lease hash
+/// - `KEYS[2]` = Challenge's processed stages set
+/// - `ARGV[1]` = Claim's fence epoch
+/// - `ARGV[2..]` = Stage attempt identifiers
+pub(super) static SEAL_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(
+        r"
+        if redis.call('HGET', KEYS[1], 'fence') ~= ARGV[1] then
+            return 0
+        end
+        redis.call('SADD', KEYS[2], unpack(ARGV, 2))
+        return 1
+        ",
+    )
+});
+
 /// Starts a challenge for a client, either creating a new challenge for the
 /// party, or joining the party's existing one if it is live. A live challenge
 /// is either active or does not yet have any state because it is initializing.
@@ -312,7 +332,8 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
 /// - `KEYS[5]` = Challenge's inbox stream
 /// - `KEYS[6]` = Challenge's stage streams set
 /// - `KEYS[7]` = Challenge's clients hash
-/// - `KEYS[8..]` = The challenge's routing keys (directory, client, and player)
+/// - `KEYS[8]` = Challenge's processed stages set
+/// - `KEYS[9..]` = The challenge's routing keys (directory, client, and player)
 ///
 /// - `ARGV[1]` = Lease epoch
 /// - `ARGV[2]` = Challenge uuid
@@ -332,7 +353,8 @@ pub(super) static DELETE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
         end
         redis.call('EXPIRE', KEYS[3], ARGV[5])
         redis.call('EXPIRE', KEYS[7], ARGV[5])
-        for i = 8, #KEYS do
+        redis.call('EXPIRE', KEYS[8], ARGV[4])
+        for i = 9, #KEYS do
             if redis.call('GET', KEYS[i]) == ARGV[2] then
                 redis.call('DEL', KEYS[i])
             end

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -2,7 +2,7 @@
 //! skipped when it is unset. The database it names must be dedicated to
 //! tests, as it is flushed once per run.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
@@ -15,7 +15,7 @@ use crate::lifecycle::core::event::{Cause, LifecycleEvent};
 use crate::lifecycle::core::state::{ChallengePhase, LastCompleted, PhaseState};
 use crate::lifecycle::core::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId, RecordingType,
-    Stage, StageStatus, Timestamp, UserId,
+    ServerTicks, Stage, StageStatus, StageUpdate, Timestamp, UserId,
 };
 
 /// Returns a unique client ID on every call. Tests share a Redis instance and
@@ -83,7 +83,7 @@ async fn test_store() -> Option<Store> {
         eprintln!("BLERT_TEST_REDIS_URI is not set; skipping Redis tests");
         return None;
     };
-    let store = Store::connect(&uri, TEST_IDENTITY.into())
+    let store = Store::connect(&uri, TEST_IDENTITY.into(), 16)
         .await
         .expect("test redis unreachable");
 
@@ -96,7 +96,7 @@ async fn test_store() -> Option<Store> {
 
     TEST_DB_FLUSHED
         .get_or_init(|| async {
-            let mut connection = store.connection.clone();
+            let mut connection = store.pool.get().await.unwrap();
             let _: () = redis::cmd("FLUSHDB")
                 .query_async(&mut connection)
                 .await
@@ -139,7 +139,7 @@ fn as_identity(store: &Store, identity: &str) -> Store {
 /// Establishes a fresh challenge's lease as a start would, returning its
 /// claim at the initial epoch.
 async fn stub_claim(store: &Store, uuid: Uuid) -> RedisClaim {
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
         .hset_multiple(
             lease_key(uuid),
@@ -162,7 +162,7 @@ async fn stub_claim(store: &Store, uuid: Uuid) -> RedisClaim {
 static SWEEP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 async fn clean_up(store: &Store, uuid: Uuid) {
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.zrem(LEASES_KEY, uuid.to_string()).await.unwrap();
     let _: () = connection
         .del(
@@ -180,7 +180,7 @@ async fn clean_up(store: &Store, uuid: Uuid) {
 /// Cleans up keys related to a challenge start. Best effort as anything missed
 /// is isolated by key uniqueness and dies at the next test run's flush.
 async fn clean_up_start(store: &Store, party: &str, clients: &[ClientId], uuids: &[Uuid]) {
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let mut keys = vec![directory_key(party)];
     keys.extend(clients.iter().map(|client| client_key(*client)));
     let _: () = connection.del(keys).await.unwrap();
@@ -192,7 +192,7 @@ async fn clean_up_start(store: &Store, party: &str, clients: &[ClientId], uuids:
 /// Reads a challenge's full journal stream as `(epoch, batch)` pairs, with each
 /// batch parsed back into its entries.
 async fn read_journal(store: &Store, uuid: Uuid) -> Vec<(String, Vec<JournalEntry>)> {
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
         .arg(journal_key(uuid))
         .arg("-")
@@ -216,7 +216,7 @@ async fn read_journal(store: &Store, uuid: Uuid) -> Vec<(String, Vec<JournalEntr
 /// Reads a challenge's full inbox as `(id, fields)` pairs, with command
 /// payloads parsed.
 async fn read_inbox(store: &Store, uuid: Uuid) -> Vec<(MsgId, Vec<(String, Command)>)> {
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
         .arg(inbox_key(uuid))
         .arg("-")
@@ -307,7 +307,7 @@ async fn bumped_fence_rejects_stale_epoch() {
     )];
     claim.append(&first).await.expect("append should succeed");
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
 
     let second = vec![entry(
@@ -345,7 +345,7 @@ async fn expired_leases_are_claimed_and_fenced() {
     claim.append(&journal).await.expect("append should succeed");
 
     // The owning server dies.
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
         .zadd(LEASES_KEY, uuid.to_string(), 500)
         .await
@@ -418,7 +418,7 @@ async fn held_leases_are_reclaimable_only_by_their_owner() {
     };
     assert_eq!(reclaimed.uuid(), uuid);
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let fence: String = connection.hget(lease_key(uuid), "fence").await.unwrap();
     assert_eq!(fence, "2");
 
@@ -448,7 +448,7 @@ async fn running_challenges_are_not_swept() {
         .expect("sweep should succeed");
     assert!(claims.is_empty(), "a running challenge was swept");
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
         .zadd(LEASES_KEY, uuid.to_string(), 500)
         .await
@@ -471,7 +471,7 @@ async fn claim_sweeps_respect_the_batch_size() {
         return;
     };
     let _guard = SWEEP_LOCK.lock().await;
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
 
     // Three lapsed challenges, oldest lease first.
     let mut challenges = Vec::new();
@@ -516,7 +516,7 @@ async fn renewal_extends_a_held_lease() {
     let uuid = Uuid::new_v4();
     let claim = stub_claim(&store, uuid).await;
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
         .zadd(LEASES_KEY, uuid.to_string(), 500)
         .await
@@ -552,7 +552,7 @@ async fn release_makes_a_lease_immediately_claimable() {
     let claim = stub_claim(&store, uuid).await;
 
     claim.release().await.expect("release should succeed");
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let released: Option<u64> = connection
         .zscore(LEASES_KEY, uuid.to_string())
         .await
@@ -598,7 +598,7 @@ async fn projection_writes_hash_and_signals() {
         .expect("project should succeed");
     assert_eq!(store.read(uuid).await, Ok(Some(snapshot(uuid, 4))));
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let hash: BTreeMap<String, String> = connection.hgetall(challenge_key(uuid)).await.unwrap();
     let expected: BTreeMap<String, String> = [
         ("type", "1"),
@@ -737,7 +737,7 @@ async fn bumped_fence_rejects_projection() {
     let uuid = Uuid::new_v4();
     let claim = stub_claim(&store, uuid).await;
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
 
     assert_eq!(
@@ -784,7 +784,7 @@ async fn bumped_fence_rejects_announcements() {
     let uuid = Uuid::new_v4();
     let claim = stub_claim(&store, uuid).await;
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
 
     assert_eq!(
@@ -803,7 +803,7 @@ async fn missing_fence_rejects_appends() {
     let uuid = Uuid::new_v4();
     let claim = stub_claim(&store, uuid).await;
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.del(lease_key(uuid)).await.unwrap();
 
     let batch = vec![entry(
@@ -851,7 +851,7 @@ async fn next_envelope(rx: &mut mpsc::Receiver<Envelope>) -> Envelope {
 /// lease deadline is set in the future so that concurrent claim sweeps from
 /// other tests leave the challenge alone.
 async fn register(store: &Store, uuid: Uuid) {
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
         .zadd(LEASES_KEY, uuid.to_string(), lease_deadline())
         .await
@@ -972,7 +972,7 @@ async fn start_creates_and_claims_a_challenge_for_a_free_party() {
     };
     let uuid = claim.uuid();
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let directory: String = connection.get(directory_key(&party)).await.unwrap();
     assert_eq!(directory, uuid.to_string());
     let routed: String = connection.get(client_key(client)).await.unwrap();
@@ -1059,7 +1059,7 @@ async fn start_joins_a_live_incumbent() {
     };
     assert_eq!(target, uuid);
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let directory: String = connection.get(directory_key(&party)).await.unwrap();
     assert_eq!(directory, uuid.to_string());
     let routed: String = connection.get(client_key(joiner_client)).await.unwrap();
@@ -1166,7 +1166,7 @@ async fn start_at_an_earlier_stage_creates_a_new_challenge() {
     let second = successor.uuid();
     assert_ne!(second, first);
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let directory: String = connection.get(directory_key(&party)).await.unwrap();
     assert_eq!(directory, second.to_string());
 
@@ -1300,7 +1300,7 @@ async fn start_supersedes_a_finished_incumbent() {
     let second = successor.uuid();
     assert_ne!(second, first);
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let directory: String = connection.get(directory_key(&party)).await.unwrap();
     assert_eq!(directory, second.to_string());
     // The finished challenge remains indexed until deletion.
@@ -1403,7 +1403,7 @@ async fn start_sends_a_removal_to_an_existing_challenge() {
     };
     let second = second_claim.uuid();
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let routed: String = connection.get(client_key(client)).await.unwrap();
     assert_eq!(routed, second.to_string());
 
@@ -1533,7 +1533,7 @@ async fn send_to_an_unknown_challenge_is_rejected() {
 
     assert_eq!(store.send(uuid, &update_command()).await, Ok(None));
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let exists: bool = connection.exists(inbox_key(uuid)).await.unwrap();
     assert!(!exists);
 }
@@ -1680,7 +1680,7 @@ async fn rejoin_routes_and_enqueues_for_a_live_challenge() {
         panic!("expected a queued rejoin");
     };
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let routed: String = connection.get(client_key(client)).await.unwrap();
     assert_eq!(routed, uuid.to_string());
     let routed: String = connection.get(client_key(late_client)).await.unwrap();
@@ -1715,7 +1715,7 @@ async fn rejoin_of_an_unknown_challenge_is_rejected() {
     );
 
     // Nothing was routed or queued.
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let routed: Option<String> = connection.get(client_key(client)).await.unwrap();
     assert_eq!(routed, None);
     assert_eq!(read_inbox(&store, uuid).await, vec![]);
@@ -1795,7 +1795,7 @@ async fn rejoin_while_routed_elsewhere_is_rejected() {
     );
 
     // The client's routing is untouched and nothing reached the other inbox.
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let routed: String = connection.get(client_key(client)).await.unwrap();
     assert_eq!(routed, current_uuid.to_string());
     assert_eq!(
@@ -1889,7 +1889,7 @@ async fn delete_removes_a_terminated_challenges_state() {
         .expect("project should succeed");
 
     // Fake stage stream keys.
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let streams = [
         format!("test-events:{uuid}:410"),
         format!("test-events:{uuid}:420"),
@@ -1901,6 +1901,10 @@ async fn delete_removes_a_terminated_challenges_state() {
             .await
             .unwrap();
     }
+    claim
+        .mark_processed(&[(Stage::TobMaiden, None)])
+        .await
+        .expect("mark should succeed");
 
     let mut pubsub = test_pubsub(SIGNAL_CHANNEL).await;
     let mut messages = pubsub.on_message();
@@ -1937,6 +1941,7 @@ async fn delete_removes_a_terminated_challenges_state() {
     for (key, retention) in [
         (journal_key(uuid), stream_retention),
         (inbox_key(uuid), stream_retention),
+        (processed_stages_key(uuid), stream_retention),
         (challenge_key(uuid), state_retention),
     ] {
         let ttl: i64 = redis::cmd("PTTL")
@@ -1970,6 +1975,51 @@ async fn delete_removes_a_terminated_challenges_state() {
 }
 
 #[tokio::test]
+async fn mark_processed_closes_stage_streams_under_the_fence() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let claim = stub_claim(&store, uuid).await;
+
+    claim
+        .mark_processed(&[
+            (Stage::MokhaiotlDelve8, None),
+            (Stage::MokhaiotlDelve8plus, Some(9)),
+        ])
+        .await
+        .expect("mark should succeed");
+    claim
+        .mark_processed(&[])
+        .await
+        .expect("marking nothing should succeed");
+
+    let mut connection = store.pool.get().await.unwrap();
+    let members: BTreeSet<String> = connection
+        .smembers(processed_stages_key(uuid))
+        .await
+        .unwrap();
+    assert_eq!(members, BTreeSet::from(["57".to_string(), "58:9".into()]));
+
+    // A fenced-off claim marks nothing.
+    let _: () = connection.hset(lease_key(uuid), "fence", 99).await.unwrap();
+    assert_eq!(
+        claim
+            .mark_processed(&[(Stage::MokhaiotlDelve8plus, Some(10))])
+            .await,
+        Err(StoreError::Fenced),
+    );
+    let count: usize = connection.scard(processed_stages_key(uuid)).await.unwrap();
+    assert_eq!(count, 2);
+
+    let _: () = connection
+        .del(&[processed_stages_key(uuid)][..])
+        .await
+        .unwrap();
+    clean_up(&store, uuid).await;
+}
+
+#[tokio::test]
 async fn delete_leaves_repointed_routing_keys_alone() {
     let Some(store) = test_store().await else {
         return;
@@ -1985,7 +2035,7 @@ async fn delete_leaves_repointed_routing_keys_alone() {
 
     // A new challenge overwrote every routing key, which should be kept.
     let successor = Uuid::new_v4();
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let routing = [
         directory_key(&party),
         client_key(client),
@@ -2034,7 +2084,7 @@ async fn bumped_fence_rejects_deletion() {
         .await
         .expect("project should succeed");
 
-    let mut connection = store.connection.clone();
+    let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
 
     assert_eq!(
@@ -2066,4 +2116,204 @@ async fn bumped_fence_rejects_deletion() {
     assert_eq!(inbox_ttl, -1);
 
     clean_up_start(&store, &party, &[client], &[uuid]).await;
+}
+
+/// Builds a stage stream entry's field map as `stageStreamToRecord` writes it.
+fn stream_fields(pairs: &[(&str, &[u8])]) -> HashMap<String, Vec<u8>> {
+    pairs
+        .iter()
+        .map(|(name, value)| ((*name).to_string(), value.to_vec()))
+        .collect()
+}
+
+#[test]
+fn stage_stream_keys_match_typescript() {
+    let uuid: Uuid = "a8cb035f-410a-45de-a4d3-2b0a5d8b464d".parse().unwrap();
+    assert_eq!(
+        stage_stream_key(uuid, Stage::TobMaiden, None),
+        "challenge-events:a8cb035f-410a-45de-a4d3-2b0a5d8b464d:10",
+    );
+    assert_eq!(
+        stage_stream_key(uuid, Stage::MokhaiotlDelve8plus, Some(142)),
+        "challenge-events:a8cb035f-410a-45de-a4d3-2b0a5d8b464d:58:142",
+    );
+}
+
+#[test]
+fn stream_records_parse_from_typescript_encoding() {
+    let metadata = parse_stream_record(&stream_fields(&[
+        ("type", b"2"),
+        ("clientId", b"380"),
+        ("userId", b"527"),
+        ("pluginVersion", b"0.9.14-RUNELITE"),
+        ("runeLiteVersion", b"runelite-1.12.33"),
+    ]))
+    .unwrap();
+    assert_eq!(
+        metadata,
+        ClientStageStream::Metadata {
+            client_id: ClientId(380),
+            user_id: UserId(527),
+            plugin_version: "0.9.14-RUNELITE".into(),
+            runelite_version: "runelite-1.12.33".into(),
+        },
+    );
+
+    let events = parse_stream_record(&stream_fields(&[
+        ("type", b"0"),
+        ("clientId", b"380"),
+        ("events", b"\x0a\x04\x08\x07\x20\x2e"),
+    ]))
+    .unwrap();
+    assert_eq!(
+        events,
+        ClientStageStream::Events {
+            client_id: ClientId(380),
+            events: Bytes::from_static(b"\x0a\x04\x08\x07\x20\x2e"),
+        },
+    );
+
+    let end = parse_stream_record(&stream_fields(&[
+        ("type", b"1"),
+        ("clientId", b"380"),
+        (
+            "update",
+            br#"{"stage":52,"status":2,"accurate":true,"recordedTicks":105,"serverTicks":{"count":105,"precise":true}}"#,
+        ),
+    ]))
+    .unwrap();
+    assert_eq!(
+        end,
+        ClientStageStream::End {
+            client_id: ClientId(380),
+            update: StageUpdate {
+                stage: Stage::MokhaiotlDelve3,
+                status: StageStatus::Completed,
+                accurate: true,
+                recorded_ticks: 105,
+                server_ticks: Some(ServerTicks {
+                    count: 105,
+                    precise: true,
+                }),
+            },
+        },
+    );
+
+    let no_server_ticks = parse_stream_record(&stream_fields(&[
+        ("type", b"1"),
+        ("clientId", b"7"),
+        (
+            "update",
+            br#"{"stage":50,"status":1,"accurate":false,"recordedTicks":0,"serverTicks":null}"#,
+        ),
+    ]))
+    .unwrap();
+    assert_eq!(
+        no_server_ticks,
+        ClientStageStream::End {
+            client_id: ClientId(7),
+            update: StageUpdate {
+                stage: Stage::MokhaiotlDelve1,
+                status: StageStatus::Started,
+                accurate: false,
+                recorded_ticks: 0,
+                server_ticks: None,
+            },
+        },
+    );
+}
+
+#[test]
+fn malformed_stream_records_are_rejected() {
+    let unknown_type = parse_stream_record(&stream_fields(&[("type", b"9"), ("clientId", b"1")]));
+    assert_eq!(unknown_type, Err("unknown record type 9".into()));
+
+    let missing_field = parse_stream_record(&stream_fields(&[("type", b"0"), ("clientId", b"1")]));
+    assert_eq!(missing_field, Err("missing field events".into()));
+
+    let bad_update = parse_stream_record(&stream_fields(&[
+        ("type", b"1"),
+        ("clientId", b"1"),
+        ("update", b"not json"),
+    ]));
+    assert!(bad_update.is_err());
+}
+
+#[tokio::test]
+async fn stage_streams_read_in_order_skipping_invalid_records() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let key = stage_stream_key(uuid, Stage::TobMaiden, None);
+    let update = br#"{"stage":10,"status":2,"accurate":true,"recordedTicks":46,"serverTicks":{"count":46,"precise":true}}"#;
+
+    let records: [&[(&str, &[u8])]; 4] = [
+        &[
+            ("type", b"2"),
+            ("clientId", b"380"),
+            ("userId", b"527"),
+            ("pluginVersion", b"0.9.14"),
+            ("runeLiteVersion", b"1.12.33"),
+        ],
+        &[
+            ("type", b"0"),
+            ("clientId", b"380"),
+            ("events", b"\x0a\x02\x08\x07"),
+        ],
+        &[("type", b"9"), ("clientId", b"380")],
+        &[("type", b"1"), ("clientId", b"380"), ("update", update)],
+    ];
+    let mut connection = store.pool.get().await.unwrap();
+    for record in records {
+        let mut cmd = redis::cmd("XADD");
+        cmd.arg(&key).arg("*");
+        for (name, value) in record {
+            cmd.arg(*name).arg(*value);
+        }
+        let _: String = cmd.query_async(&mut connection).await.unwrap();
+    }
+    drop(connection);
+
+    let stream = store
+        .read_stage_stream(uuid, Stage::TobMaiden, None)
+        .await
+        .expect("stream should read");
+    assert_eq!(
+        stream,
+        vec![
+            ClientStageStream::Metadata {
+                client_id: ClientId(380),
+                user_id: UserId(527),
+                plugin_version: "0.9.14".into(),
+                runelite_version: "1.12.33".into(),
+            },
+            ClientStageStream::Events {
+                client_id: ClientId(380),
+                events: Bytes::from_static(b"\x0a\x02\x08\x07"),
+            },
+            ClientStageStream::End {
+                client_id: ClientId(380),
+                update: StageUpdate {
+                    stage: Stage::TobMaiden,
+                    status: StageStatus::Completed,
+                    accurate: true,
+                    recorded_ticks: 46,
+                    server_ticks: Some(ServerTicks {
+                        count: 46,
+                        precise: true,
+                    }),
+                },
+            },
+        ],
+    );
+
+    let missing = store
+        .read_stage_stream(Uuid::new_v4(), Stage::TobMaiden, None)
+        .await
+        .expect("missing stream should read");
+    assert!(missing.is_empty());
+
+    let mut connection = store.pool.get().await.unwrap();
+    let _: () = connection.del(&key).await.unwrap();
 }


### PR DESCRIPTION
Adds a stage processing stub which reads client event streams from redis, parses them, then returns the ticks and status reported by the first client to the challenge command queue, which it uses to accumulate tick count in its state.

Switches the store to a redis connection pool.