### PR TITLE
2c2s: Add stage start and mode change processing

### DIFF
--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -91,6 +91,16 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             update,
         } => stage_reported(state, entry.at, client_id, attempt, update),
         LifecycleEvent::StageStarted { stage } => {
+            // Only fire on actual stage changes, not ENTERED -> STARTED.
+            if stage != state.stage {
+                state.processing.push(
+                    Trigger::StageStart {
+                        seq: entry.seq,
+                        stage,
+                    },
+                    entry.at,
+                );
+            }
             state.stage = stage;
             state.stage_attempt = stage.is_retriable().then_some(1);
             state.stage_status = StageStatus::Started;
@@ -146,6 +156,13 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         }
         LifecycleEvent::ModeChanged { mode } => {
             state.mode = mode;
+            state.processing.push(
+                Trigger::Mode {
+                    seq: entry.seq,
+                    mode,
+                },
+                entry.at,
+            );
         }
         LifecycleEvent::PartyChanged { .. } => {
             state.party_changed = true;
@@ -252,6 +269,7 @@ fn stage_reported(
 }
 
 #[cfg(test)]
+#[expect(clippy::too_many_lines)]
 mod tests {
     use core::time::Duration;
 
@@ -948,6 +966,29 @@ mod tests {
     }
 
     #[test]
+    fn mode_change_queues_a_processing_run() {
+        let mut state = processing_tob_state();
+        apply(
+            &mut state,
+            entry(
+                2_000,
+                2,
+                LifecycleEvent::ModeChanged {
+                    mode: ChallengeMode::TobHard,
+                },
+            ),
+        );
+        assert_eq!(state.mode, ChallengeMode::TobHard);
+        assert_eq!(
+            state.processing.active().expect("exists").trigger,
+            Trigger::Mode {
+                seq: JournalSeq(0),
+                mode: ChallengeMode::TobHard,
+            },
+        );
+    }
+
+    #[test]
     fn creation_and_termination_queue_boundary_runs() {
         let mut state = ChallengeState {
             processing: Processing::new(ProcessingConfig {
@@ -1133,6 +1174,21 @@ mod tests {
     #[test]
     fn stage_outcomes_accumulate_ticks() {
         let mut state = processing_tob_state();
+
+        // The first stage's STARTED report updated its status without
+        // triggering a stage update.
+        apply(
+            &mut state,
+            entry(
+                1_000,
+                2,
+                LifecycleEvent::StageStarted {
+                    stage: Stage::TobMaiden,
+                },
+            ),
+        );
+        assert_eq!(state.processing.outstanding().count(), 0);
+
         apply(&mut state, maiden_seal(5_000));
         apply(
             &mut state,
@@ -1156,6 +1212,21 @@ mod tests {
                 },
             ),
         );
+        let outstanding: Vec<Trigger> = state.processing.outstanding().collect();
+        assert_eq!(
+            outstanding,
+            vec![
+                Trigger::Stage {
+                    seq: JournalSeq(5),
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+                Trigger::StageStart {
+                    seq: JournalSeq(0),
+                    stage: Stage::TobBloat,
+                },
+            ],
+        );
         apply(
             &mut state,
             processing_entry(
@@ -1171,6 +1242,27 @@ mod tests {
         );
         assert_eq!(state.challenge_ticks, 190);
         assert_eq!(state.stage_status, StageStatus::Started);
+
+        // Complete the stage update's processing run.
+        apply(
+            &mut state,
+            processing_entry(
+                7_500,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(0),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                7_500,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(0),
+                    payload: ProcessingPayload::None,
+                },
+            ),
+        );
 
         // The current stage's processing returns the definitive status.
         apply(
@@ -1246,6 +1338,26 @@ mod tests {
                 4,
                 LifecycleEvent::StageStarted {
                     stage: Stage::TobBloat,
+                },
+            ),
+        );
+        // Complete the stage update's processing run.
+        apply(
+            &mut state,
+            processing_entry(
+                7_500,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(0),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                7_500,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(0),
+                    payload: ProcessingPayload::None,
                 },
             ),
         );

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -83,6 +83,13 @@ pub enum Trigger {
         user_id: UserId,
         recording_type: RecordingType,
     },
+    /// The challenge began a new stage.
+    StageStart { seq: JournalSeq, stage: Stage },
+    /// The challenge's mode changed.
+    Mode {
+        seq: JournalSeq,
+        mode: ChallengeMode,
+    },
     /// A stage completed.
     Stage {
         seq: JournalSeq,
@@ -100,6 +107,8 @@ impl Trigger {
         match self {
             Trigger::Create { seq }
             | Trigger::Recorder { seq, .. }
+            | Trigger::StageStart { seq, .. }
+            | Trigger::Mode { seq, .. }
             | Trigger::Stage { seq, .. }
             | Trigger::Finish { seq } => seq,
         }

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -772,9 +772,11 @@ impl StageProcessor for ScriptedProcessor {
                     status: StageStatus::Completed,
                     ticks: 0,
                 },
-                Trigger::Create { .. } | Trigger::Recorder { .. } | Trigger::Finish { .. } => {
-                    ProcessingPayload::None
-                }
+                Trigger::Create { .. }
+                | Trigger::Recorder { .. }
+                | Trigger::StageStart { .. }
+                | Trigger::Mode { .. }
+                | Trigger::Finish { .. } => ProcessingPayload::None,
             }),
         }
     }
@@ -1144,6 +1146,7 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
         let mut seals = Vec::new();
         let mut trigger_seqs = HashSet::new();
         let mut joined = HashSet::new();
+        let mut stage = None;
         let mut terminated = false;
 
         for entry in journal {
@@ -1161,9 +1164,22 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
             terminated |= matches!(entry.event, LifecycleEvent::ChallengeTerminated { .. });
 
             match &entry.event {
-                LifecycleEvent::ChallengeCreated { .. }
-                | LifecycleEvent::ChallengeTerminated { .. } => {
+                LifecycleEvent::ChallengeCreated {
+                    stage: initial_stage,
+                    ..
+                } => {
+                    stage = Some(*initial_stage);
                     trigger_seqs.insert(entry.seq);
+                }
+                LifecycleEvent::ChallengeTerminated { .. } | LifecycleEvent::ModeChanged { .. } => {
+                    trigger_seqs.insert(entry.seq);
+                }
+                // Only a real stage change triggers processing.
+                LifecycleEvent::StageStarted { stage: started } => {
+                    if stage != Some(*started) {
+                        trigger_seqs.insert(entry.seq);
+                    }
+                    stage = Some(*started);
                 }
                 // Only a client's first join triggers processing.
                 LifecycleEvent::ClientJoined { client_id, .. } => {

--- a/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
@@ -377,6 +377,7 @@ async fn queued_trigger_processes_after_the_active_run() {
         no_payload(),
         no_payload(),
         ProcessingAttempt::Resolve(2_000, Ok(outcome(StageStatus::Completed, 100))),
+        no_payload(),
         ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 50))),
     ]);
     let result = run_with(
@@ -396,7 +397,7 @@ async fn queued_trigger_processes_after_the_active_run() {
     )
     .await;
 
-    // The second stage waits for the first's run to finish before starting.
+    // The second stage's runs wait for the first's to finish before starting.
     let (_, journal) = result.only_challenge();
     let processing_events: Vec<&JournalEntry> = journal
         .iter()
@@ -408,7 +409,7 @@ async fn queued_trigger_processes_after_the_active_run() {
                 )
         })
         .collect();
-    assert_eq!(processing_events.len(), 10);
+    assert_eq!(processing_events.len(), 12);
     assert_eq!(processing_events[0].event, started(0));
     assert_eq!(processing_events[0].at, Timestamp::ZERO);
     assert_eq!(
@@ -427,15 +428,22 @@ async fn queued_trigger_processes_after_the_active_run() {
         finished(9, outcome(StageStatus::Completed, 100)),
     );
     assert_eq!(processing_events[5].at, Timestamp::from_millis(3_000));
+    assert_eq!(processing_events[6].event, started(11));
     assert_eq!(processing_events[6].at, Timestamp::from_millis(3_000));
     assert_eq!(
         processing_events[7].event,
-        finished(14, outcome(StageStatus::Wiped, 50)),
+        finished(11, ProcessingPayload::None)
     );
-    assert_eq!(processing_events[8].event, started(19));
+    assert_eq!(processing_events[8].event, started(14));
+    assert_eq!(processing_events[8].at, Timestamp::from_millis(3_000));
     assert_eq!(
         processing_events[9].event,
-        finished(19, ProcessingPayload::None)
+        finished(14, outcome(StageStatus::Wiped, 50)),
+    );
+    assert_eq!(processing_events[10].event, started(21));
+    assert_eq!(
+        processing_events[11].event,
+        finished(21, ProcessingPayload::None)
     );
 
     let triggers: Vec<Trigger> = processor.requests().iter().map(|r| r.trigger).collect();
@@ -453,13 +461,17 @@ async fn queued_trigger_processes_after_the_active_run() {
                 stage: Stage::TobMaiden,
                 attempt: None,
             },
+            Trigger::StageStart {
+                seq: JournalSeq(11),
+                stage: Stage::TobBloat,
+            },
             Trigger::Stage {
                 seq: JournalSeq(14),
                 stage: Stage::TobBloat,
                 attempt: None,
             },
             Trigger::Finish {
-                seq: JournalSeq(19)
+                seq: JournalSeq(21)
             },
         ],
     );

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -3,7 +3,7 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use crate::lifecycle::core::types::{
-    ChallengeStatus, PrimaryMeleeGear, RecordingType, UserId, Uuid,
+    ChallengeMode, ChallengeStatus, PrimaryMeleeGear, RecordingType, Stage, UserId, Uuid,
 };
 use crate::players::normalize_rsn;
 
@@ -91,6 +91,26 @@ pub async fn add_recorder(
             &i32::try_from(user_id.0).expect("user id fits in an integer"),
             &(recording_type as i16),
         ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Records the challenge starting a new stage.
+pub async fn update_stage(txn: &db::Transaction, stage: Stage) -> Result<(), db::Error> {
+    txn.execute(
+        "UPDATE challenges SET stage = $1 WHERE id = $2",
+        &[&(stage as i16), &txn.challenge_id()],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Records a change to the challenge's mode.
+pub async fn update_mode(txn: &db::Transaction, mode: ChallengeMode) -> Result<(), db::Error> {
+    txn.execute(
+        "UPDATE challenges SET mode = $1 WHERE id = $2",
+        &[&(mode as i16), &txn.challenge_id()],
     )
     .await?;
     Ok(())

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -94,6 +94,14 @@ impl StageProcessor for Pipeline {
                 challenge::add_recorder(&txn, user_id, recording_type).await?;
                 ProcessingPayload::None
             }
+            Trigger::StageStart { stage, .. } => {
+                challenge::update_stage(&txn, stage).await?;
+                ProcessingPayload::None
+            }
+            Trigger::Mode { mode, .. } => {
+                challenge::update_mode(&txn, mode).await?;
+                ProcessingPayload::None
+            }
             Trigger::Finish { .. } => {
                 challenge::finish(&txn, &request.challenge).await?;
                 ProcessingPayload::None


### PR DESCRIPTION
Implements two new processing triggers: stage start and challenge mode change, both of which update a single field in the DB.