### PR TITLE
ci: isolate main CI runs from the shared concurrency group

### DIFF
--- a/.github/workflows/test-bcf.yml
+++ b/.github/workflows/test-bcf.yml
@@ -19,7 +19,7 @@ on:
       - '.github/workflows/test-bcf.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-blertbank-client.yml
+++ b/.github/workflows/test-blertbank-client.yml
@@ -19,7 +19,7 @@ on:
       - '.github/workflows/test-blertbank-client.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-blertbank.yml
+++ b/.github/workflows/test-blertbank.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/test-blertbank.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-challenge-harder.yml
+++ b/.github/workflows/test-challenge-harder.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/test-challenge-harder.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-challenge-server.yml
+++ b/.github/workflows/test-challenge-server.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/test-challenge-server.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -19,7 +19,7 @@ on:
       - '.github/workflows/test-common.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-live-server.yml
+++ b/.github/workflows/test-live-server.yml
@@ -19,7 +19,7 @@ on:
       - '.github/workflows/test-live-server.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-socket-server.yml
+++ b/.github/workflows/test-socket-server.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/test-socket-server.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/test-web.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Follow-up to #338. The test workflows keyed their concurrency group on
`github.ref`, so every push to `main` shared one group. Cancelling
superseded runs in that group discards per-commit CI signal on `main`: an
intermediate mainline commit shows "cancelled" instead of pass/fail, so a
later bisect or "was this commit green?" has no answer for it.

## Change

Key the group on `github.event.pull_request.number || github.run_id` across
all 9 test workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true
```

- **Pull requests:** `pull_request.number` is unique per PR, so superseded
  runs on the same PR are cancelled (unchanged PR behaviour) while distinct
  PRs never collide — including across forks that share a branch name, which
  a plain `head_ref` key would not handle.
- **Pushes to `main`:** `pull_request` is null, so the group falls back to
  the unique `run_id`. Every main run lands in its own group and runs to
  completion, never cancelled or queued out. This fully preserves per-commit
  signal, including under burst merges.

`docker-build.yml` keeps its event-gated `cancel-in-progress` — it must not
cancel *or* parallelize image publishes on `main`, so it stays keyed on
`github.ref`.

## Notes

- Two earlier keys were rejected in review: gating `cancel-in-progress` on
  the event still dropped commits via the single pending slot Actions keeps;
  a `head_ref`-based key collided across same-branch-name fork PRs. Keying
  by PR number avoids both.
- GitHub Actions `concurrency` has no native `queue`/queue-depth option (only
  `group` and `cancel-in-progress`), so unique per-run groups are the
  idiomatic way to keep every main run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQRget2Pj5oai5DSeJESdc