### PR TITLE
ci: keep formatting and lint tooling out of the grouped npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,16 @@ updates:
     open-pull-requests-limit: 10
     groups:
       npm-minor-patch:
+        # Formatting and lint tooling is excluded from the group because a
+        # bump usually requires a matching reformat or relint, which does not
+        # belong in a PR carrying dozens of unrelated packages. Excluded
+        # packages still receive their own individual update PRs.
+        exclude-patterns:
+          - prettier
+          - eslint
+          - '@eslint/*'
+          - typescript-eslint
+          - '@typescript-eslint/*'
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Summary

Grouped minor/patch updates are meant to be mergeable on sight. A prettier
or typescript-eslint bump is not — it changes what the format and lint
checks accept, so it needs a matching reformat or relint in the same PR.
Bundled with dozens of unrelated packages, that companion change blocks
everything else in the group.

#343 is the worked example. Three separate problems, only one of which was
about the dependencies themselves:

| Cause | Effect |
|---|---|
| prettier `3.5.3` → `3.9.6` | reformats 25 files; `--check` fails in all 7 Node workspaces |
| typescript-eslint `8.46` → `8.65` | tightens `no-unnecessary-type-assertion`; ~144 sites across 4 workspaces |
| `ajv` bumped in `bcf` only | `ajv-formats`' nested copy stayed at 8.18.0, breaking bcf's build |

The typescript-eslint fallout is the expensive one, and it is **not**
mechanical. `eslint --fix` strips narrowing casts that exhaustiveness
checks depend on, e.g. in `common/db/redis.ts`:

```ts
-  const type = Number.parseInt(event.type.toString()) as StageStreamType;
+  const type = Number.parseInt(event.type.toString());
   switch (type) { /* all StageStreamType members */ }
   const _exhaustive: never = type;   // now `number` — fails to compile
```

The assertion is redundant for *assignment* (TypeScript allows
`number` → numeric enum) but load-bearing for *narrowing*. The fixer
cannot tell the difference, so each of the ~144 sites needs review.

## Change

Exclude the formatter and lint toolchain from the `npm-minor-patch` group:
`prettier`, `eslint`, `@eslint/*`, `typescript-eslint`, `@typescript-eslint/*`
— all 7 such packages in the root manifest.

This does **not** stop these updates. `exclude-patterns` only un-groups
them, so they still arrive as individual PRs on the weekly schedule — where
the reformat or relint belongs alongside the bump that caused it, and where
a failure is legible instead of being one of three tangled causes.

## Follow-ups

- `·@·d·ependabot r·ecreate` on #343 once this lands, so it returns carrying
  only the genuinely-safe updates. The `ajv` dedupe (`npm update ajv`,
  lockfile only) will still be needed — `ajv` stays in the group.
- The typescript-eslint bump then arrives on its own, where the ~144
  assertion sites can be worked through against a full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQRget2Pj5oai5DSeJESdc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQRget2Pj5oai5DSeJESdc)_