### PR TITLE
common: Define splits in proto file

### DIFF
--- a/.github/workflows/test-challenge-harder.yml
+++ b/.github/workflows/test-challenge-harder.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'challenge-harder/**'
       - 'common/migrations/**'
-      - 'proto/**'
+      - 'proto'
       - 'web/resources/extended_items.json'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -16,7 +16,7 @@ on:
     paths:
       - 'challenge-harder/**'
       - 'common/migrations/**'
-      - 'proto/**'
+      - 'proto'
       - 'web/resources/extended_items.json'
       - 'Cargo.toml'
       - 'Cargo.lock'

--- a/.github/workflows/test-common.yml
+++ b/.github/workflows/test-common.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'common/**'
+      - 'proto'
       - 'package.json'
       - 'package-lock.json'
       - '.npmrc'
@@ -13,6 +14,7 @@ on:
       - main
     paths:
       - 'common/**'
+      - 'proto'
       - 'package.json'
       - 'package-lock.json'
       - '.npmrc'

--- a/common/__tests__/split-parity.test.ts
+++ b/common/__tests__/split-parity.test.ts
@@ -1,0 +1,39 @@
+import { SplitType } from '../split';
+import { SplitType as SplitTypeProto } from '../generated/challenge_storage_pb';
+
+// `SplitType` in proto/challenge_storage.proto is the source of truth for
+// split values. The `SplitType` enum in split.ts keeps literal values because
+// initializing its members from the generated bindings degrades the enum to
+// computed members, weakening type checking for every consumer. These tests
+// enforce that the two stay identical.
+// TODO(frolv): Move to a different proto library and kill this (#366).
+describe('SplitType proto parity', () => {
+  const protoMembers = Object.entries(SplitTypeProto).filter(
+    (entry): entry is [string, number] => typeof entry[1] === 'number',
+  );
+  const enumMembers = Object.entries(SplitType).filter(
+    (entry): entry is [string, number] => typeof entry[1] === 'number',
+  );
+
+  it('defines every proto split with an identical value', () => {
+    const mismatches: string[] = [];
+    for (const [protoName, protoValue] of protoMembers) {
+      const member = protoName.replace(/^SPLIT_TYPE_/, '');
+      const value = (SplitType as Record<string, unknown>)[member] as number;
+      if (value !== protoValue) {
+        mismatches.push(
+          `proto ${protoName} = ${protoValue}, but SplitType.${member} is ${value}`,
+        );
+      }
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it('has a proto split for every enum value', () => {
+    const protoValues = new Set(protoMembers.map(([, value]) => value));
+    const unmapped = enumMembers
+      .filter(([, value]) => !protoValues.has(value))
+      .map(([name, value]) => `SplitType.${name} = ${value}`);
+    expect(unmapped).toEqual([]);
+  });
+});


### PR DESCRIPTION
Adds split type values as an enum to the challenge storage proto. The typescript enum is kept as-is, since defining it from the proto causes tsc to widen its type to number because of how ts-protoc-gen defines enums, breaking exhaustiveness. Instead, a test is added to ensure the parity of the two.