### PR TITLE
common: Move queryable event spell target to int

### DIFF
--- a/common/db/queryable-event.ts
+++ b/common/db/queryable-event.ts
@@ -26,7 +26,7 @@ export const QueryableEventField = {
   PLAYER_ATTACK_WEAPON: 'custom_int_1',
   PLAYER_ATTACK_DISTANCE: 'custom_short_1',
 
-  PLAYER_SPELL_TARGET_PLAYER: 'custom_short_1',
+  PLAYER_SPELL_TARGET_PLAYER: 'custom_int_1',
 
   NPC_MAIDEN_CRAB_SPAWN: 'custom_short_1',
   NPC_MAIDEN_CRAB_POSITION: 'custom_short_2',

--- a/common/migrations/20260727050337-move-spell-target-player-to-custom-int-1-on-queryable-events.ts
+++ b/common/migrations/20260727050337-move-spell-target-player-to-custom-int-1-on-queryable-events.ts
@@ -1,0 +1,11 @@
+import { TransactionSql } from 'postgres';
+
+import { EventType } from '../event';
+
+export async function migrate(sql: TransactionSql) {
+  await sql`
+    UPDATE queryable_events
+    SET custom_int_1 = custom_short_1, custom_short_1 = NULL
+    WHERE event_type = ${EventType.PLAYER_SPELL} AND custom_short_1 IS NOT NULL
+  `;
+}


### PR DESCRIPTION
The target player ID belongs in an int, not a short. Redefines its constant and creates a migration.