### PR TITLE
all: Fix zod and add docker smoke test

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,12 @@ on:
       - 'Dockerfile'
       - '.dockerignore'
       - '.github/workflows/docker-build.yml'
+      # Dependency changes alter how npm lays out node_modules, which affects
+      # what the runtime stages include (see the smoke test below).
+      - 'package.json'
+      - 'package-lock.json'
+      - '*/package.json'
+      - 'patches/**'
   workflow_dispatch:
 
 # Serialize builds per ref. Superseded pull-request validation runs are
@@ -58,16 +64,45 @@ jobs:
             type=raw,value=main
             type=sha,prefix=sha-,format=short
 
-      - name: Build and push
+      - name: Build
         uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ matrix.service }}
-          push: ${{ github.event_name != 'pull_request' }}
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+          build-args: |
+            BLERT_COMMIT_SHA=${{ github.sha }}
+            NEXT_PUBLIC_BASE_URL=${{ vars.NEXT_PUBLIC_BASE_URL }}
+            NEXT_PUBLIC_LIVE_SERVER_URL=${{ vars.NEXT_PUBLIC_LIVE_SERVER_URL }}
+            NEXT_PUBLIC_BLERTCOIN_ENABLED=${{ vars.NEXT_PUBLIC_BLERTCOIN_ENABLED }}
+            NEXT_PUBLIC_UMAMI_WEBSITE_ID=${{ vars.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
+            NEXT_PUBLIC_UMAMI_SCRIPT_URL=${{ vars.NEXT_PUBLIC_UMAMI_SCRIPT_URL }}
+
+      # These images run from the pruned root node_modules assembled in the
+      # deps-prod stage, and a green build says nothing about whether that
+      # tree can actually resolve its modules at runtime.
+      # Resolving `@blert/common` tests the import chain, failing if any deps
+      # are unresolvable.
+      - name: Smoke test image
+        if: contains(fromJSON('["socket-server", "challenge-server", "blertbank"]'), matrix.service)
+        run: |
+          tag="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)"
+          docker run --rm "$tag" node -e "require('/app/common/dist')"
+
+      - name: Push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: ${{ matrix.service }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service }}
           build-args: |
             BLERT_COMMIT_SHA=${{ github.sha }}
             NEXT_PUBLIC_BASE_URL=${{ vars.NEXT_PUBLIC_BASE_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "google-protobuf": "^3.21.2",
         "grpc-tools": "^1.12.4",
         "node-addon-api": "^8.9.0",
-        "ts-protoc-gen": "^0.15.0"
+        "ts-protoc-gen": "^0.15.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -168,15 +169,6 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
-    },
-    "common/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -10342,15 +10334,6 @@
         }
       }
     },
-    "node_modules/better-auth/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -18352,6 +18335,16 @@
         "next-devtools-mcp": "dist/index.js"
       }
     },
+    "node_modules/next-devtools-mcp/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/next-mdx-remote-client": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/next-mdx-remote-client/-/next-mdx-remote-client-2.1.11.tgz",
@@ -24380,10 +24373,9 @@
       "license": "Unlicense"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -24480,15 +24472,6 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.4.12",
         "tsc-watch": "^6.0.4"
-      }
-    },
-    "socket-server/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "web": {
@@ -25672,15 +25655,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "web/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "google-protobuf": "^3.21.2",
     "grpc-tools": "^1.12.4",
     "node-addon-api": "^8.9.0",
-    "ts-protoc-gen": "^0.15.0"
+    "ts-protoc-gen": "^0.15.0",
+    "zod": "^4.4.3"
   }
 }


### PR DESCRIPTION
Following the recent zod update, two versions existed in the package tree and the wrong one made it into prod images. This corrects that, and adds a smoke test step before image pushes which ensures that they can resolve their dependencies.