### PR TITLE
web: Subnet-based rate limiting

### DIFF
--- a/web/__tests__/utils/headers.test.ts
+++ b/web/__tests__/utils/headers.test.ts
@@ -1,4 +1,8 @@
-import { getRequestIp, getTrustedRequestIp } from '@/utils/headers';
+import {
+  getRequestIp,
+  getTrustedRequestIp,
+  ipSubnetBucket,
+} from '@/utils/headers';
 
 describe('headers', () => {
   describe('getRequestIp', () => {
@@ -50,6 +54,61 @@ describe('headers', () => {
 
     it('returns null when no IP can be determined', () => {
       expect(getTrustedRequestIp(new Headers())).toBeNull();
+    });
+  });
+
+  describe('ipSubnetBucket', () => {
+    it('buckets IPv4 addresses into a /24', () => {
+      expect(ipSubnetBucket('203.0.113.45')).toBe('203.0.113.0/24');
+      expect(ipSubnetBucket('43.119.100.151')).toBe('43.119.100.0/24');
+    });
+
+    it('buckets IPv6 addresses into a /64', () => {
+      expect(ipSubnetBucket('2001:db8:85a3:8d3:1319:8a2e:370:7348')).toBe(
+        '2001:db8:85a3:8d3::/64',
+      );
+    });
+
+    it('expands compressed IPv6 addresses', () => {
+      expect(ipSubnetBucket('2001:db8::1')).toBe('2001:db8:0:0::/64');
+      expect(ipSubnetBucket('::1')).toBe('0:0:0:0::/64');
+    });
+
+    it('lowercases IPv6 groups', () => {
+      expect(ipSubnetBucket('2001:DB8:85A3:8D3:1319:8A2E:370:7348')).toBe(
+        '2001:db8:85a3:8d3::/64',
+      );
+    });
+
+    it('ignores zone indices', () => {
+      expect(ipSubnetBucket('fe80::1%eth0')).toBe('fe80:0:0:0::/64');
+    });
+
+    it('buckets IPv4-mapped addresses by their embedded IPv4 /24', () => {
+      expect(ipSubnetBucket('::ffff:192.0.2.128')).toBe('192.0.2.0/24');
+      expect(ipSubnetBucket('0:0:0:0:0:ffff:192.0.2.128')).toBe('192.0.2.0/24');
+      expect(ipSubnetBucket('::FFFF:192.0.2.128')).toBe('192.0.2.0/24');
+      expect(ipSubnetBucket('0000:0000:0000:0000:0000:ffff:192.0.2.128')).toBe(
+        '192.0.2.0/24',
+      );
+    });
+
+    it('keeps the /64 for non-mapped addresses with an IPv4 tail', () => {
+      expect(ipSubnetBucket('2001:db8::192.0.2.1')).toBe('2001:db8:0:0::/64');
+    });
+
+    it('normalizes leading zeros in IPv6 groups', () => {
+      expect(ipSubnetBucket('2001:0db8:85a3:08d3::1')).toBe(
+        '2001:db8:85a3:8d3::/64',
+      );
+    });
+
+    it('returns unparseable inputs unchanged', () => {
+      expect(ipSubnetBucket('not-an-ip')).toBe('not-an-ip');
+      expect(ipSubnetBucket('300.0.113.45')).toBe('300.0.113.45');
+      expect(ipSubnetBucket('203.0.113')).toBe('203.0.113');
+      expect(ipSubnetBucket('2001:db8::1::2')).toBe('2001:db8::1::2');
+      expect(ipSubnetBucket('')).toBe('');
     });
   });
 });

--- a/web/__tests__/utils/rate-limit.test.ts
+++ b/web/__tests__/utils/rate-limit.test.ts
@@ -6,6 +6,7 @@ import {
   getRateLimitStatus,
   RateLimitConfig,
   rateLimit,
+  rateLimitAll,
 } from '@/utils/rate-limit';
 
 jest.mock('@/actions/redis');
@@ -161,6 +162,166 @@ describe('rate-limit utils', () => {
     });
   });
 
+  describe('rateLimitAll', () => {
+    it('checks every key in a single pipeline and reports the most constrained', async () => {
+      const pipeline = createMockPipeline();
+      pipeline.exec.mockResolvedValue([
+        null,
+        null,
+        3,
+        [{ value: 'oldest-ip', score: Date.now() }],
+        'OK',
+        null,
+        null,
+        19,
+        [{ value: 'oldest-subnet', score: Date.now() }],
+        'OK',
+      ]);
+      mockClient.multi.mockReturnValue(pipeline);
+
+      const result = await rateLimitAll(
+        [
+          { key: 'ratelimit:test:ip:203.0.113.45', limit: 5 },
+          { key: 'ratelimit:test:subnet:203.0.113.0/24', limit: 20 },
+        ],
+        60,
+      );
+
+      expect(result).toEqual({
+        success: true,
+        limit: 20,
+        remaining: 1,
+        reset: Math.floor((Date.now() + 60 * 1000) / 1000),
+      });
+      expect(mockClient.multi).toHaveBeenCalledTimes(1);
+      for (const key of [
+        'ratelimit:test:ip:203.0.113.45',
+        'ratelimit:test:subnet:203.0.113.0/24',
+      ]) {
+        expect(pipeline.zRemRangeByScore).toHaveBeenCalledWith(
+          key,
+          0,
+          Date.now() - 60 * 1000,
+        );
+        expect(pipeline.zAdd).toHaveBeenCalledWith(
+          key,
+          expect.arrayContaining([
+            expect.objectContaining({ score: Date.now() }),
+          ]),
+        );
+        expect(pipeline.zCard).toHaveBeenCalledWith(key);
+        expect(pipeline.zRangeWithScores).toHaveBeenCalledWith(key, 0, 0);
+        expect(pipeline.expire).toHaveBeenCalledWith(key, 120);
+      }
+    });
+
+    it('fails when any key exceeds its limit', async () => {
+      const pipeline = createMockPipeline();
+      pipeline.exec.mockResolvedValue([
+        null,
+        null,
+        2,
+        [{ value: 'oldest-ip', score: Date.now() }],
+        'OK',
+        null,
+        null,
+        25,
+        [{ value: 'oldest-subnet', score: Date.now() }],
+        'OK',
+      ]);
+      mockClient.multi.mockReturnValue(pipeline);
+
+      const result = await rateLimitAll(
+        [
+          { key: 'ratelimit:test:ip:203.0.113.45', limit: 5 },
+          { key: 'ratelimit:test:subnet:203.0.113.0/24', limit: 20 },
+        ],
+        60,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        limit: 20,
+        remaining: 0,
+        reset: Math.floor((Date.now() + 60 * 1000) / 1000),
+      });
+    });
+
+    it('breaks remaining ties toward the later reset', async () => {
+      const pipeline = createMockPipeline();
+      const olderScore = Date.now() - 50 * 1000;
+      const newerScore = Date.now() - 10 * 1000;
+      pipeline.exec.mockResolvedValue([
+        null,
+        null,
+        5,
+        [{ value: 'oldest-ip', score: olderScore }],
+        'OK',
+        null,
+        null,
+        4,
+        [{ value: 'oldest-subnet', score: newerScore }],
+        'OK',
+      ]);
+      mockClient.multi.mockReturnValue(pipeline);
+
+      const result = await rateLimitAll(
+        [
+          { key: 'ratelimit:test:ip:203.0.113.45', limit: 5 },
+          { key: 'ratelimit:test:subnet:203.0.113.0/24', limit: 3 },
+        ],
+        60,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        limit: 3,
+        remaining: 0,
+        reset: Math.floor((newerScore + 60 * 1000) / 1000),
+      });
+    });
+
+    it('fails open with the smallest limit when Redis throws an error', async () => {
+      const pipeline = createMockPipeline();
+      pipeline.exec.mockRejectedValue(new Error('redis down'));
+      mockClient.multi.mockReturnValue(pipeline);
+
+      const result = await rateLimitAll(
+        [
+          { key: 'ratelimit:test:ip:203.0.113.45', limit: 5 },
+          { key: 'ratelimit:test:subnet:203.0.113.0/24', limit: 20 },
+        ],
+        60,
+      );
+
+      expect(result).toEqual({
+        success: true,
+        limit: 5,
+        remaining: 5,
+        reset: Math.floor((Date.now() + 60 * 1000) / 1000),
+      });
+    });
+
+    it('fails open when the Redis connection cannot be established', async () => {
+      mockedRedis.mockRejectedValue(new Error('connection refused'));
+
+      const result = await rateLimitAll(
+        [
+          { key: 'ratelimit:test:ip:203.0.113.45', limit: 5 },
+          { key: 'ratelimit:test:subnet:203.0.113.0/24', limit: 20 },
+        ],
+        60,
+      );
+
+      expect(result).toEqual({
+        success: true,
+        limit: 5,
+        remaining: 5,
+        reset: Math.floor((Date.now() + 60 * 1000) / 1000),
+      });
+    });
+  });
+
   describe('getRateLimitStatus', () => {
     it('returns remaining tokens without incrementing usage', async () => {
       mockClient.zRemRangeByScore.mockResolvedValue(undefined);
@@ -199,6 +360,18 @@ describe('rate-limit utils', () => {
       });
       expect(status.reset).toBe(Math.floor((Date.now() + 60 * 1000) / 1000));
       expect(mockClient.zCard).not.toHaveBeenCalled();
+    });
+
+    it('returns a full window when the Redis connection cannot be established', async () => {
+      mockedRedis.mockRejectedValue(new Error('connection refused'));
+
+      const status = await getRateLimitStatus('ratelimit:test', 10, 60);
+
+      expect(status).toEqual({
+        limit: 10,
+        remaining: 10,
+        reset: Math.floor((Date.now() + 60 * 1000) / 1000),
+      });
     });
   });
 

--- a/web/app/utils/headers.ts
+++ b/web/app/utils/headers.ts
@@ -76,3 +76,76 @@ export function getTrustedRequestIp(
 ): string | null {
   return resolveIp(headers, { ...options, fallback: null });
 }
+
+/**
+ * Maps an IP address to its subnet bucket used for rate limiting.
+ * Inputs which are not parseable as either IPv4 or IPv6 are returned unchanged
+ * so they still form a limitable bucket.
+ *
+ * @param ip The IP address to bucket.
+ * @returns The subnet identifier for the IP.
+ */
+export function ipSubnetBucket(ip: string): string {
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}$/.exec(ip);
+  if (ipv4 !== null) {
+    const octets = ipv4.slice(1).map(Number);
+    if (octets.every((o) => o <= 255)) {
+      return `${octets[0]}.${octets[1]}.${octets[2]}.0/24`;
+    }
+    return ip;
+  }
+
+  if (ip.includes(':')) {
+    const expanded = expandIpv6(ip);
+    if (expanded !== null) {
+      const v4Tail = /:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(ip);
+      if (
+        v4Tail !== null &&
+        expanded.slice(0, 5).every((group) => group === '0') &&
+        expanded[5] === 'ffff'
+      ) {
+        return ipSubnetBucket(v4Tail[1]);
+      }
+      return `${expanded.slice(0, 4).join(':')}::/64`;
+    }
+  }
+
+  return ip;
+}
+
+function expandIpv6(ip: string): string[] | null {
+  let address = ip;
+
+  // Strip the zone index and any embedded IPv4 tail.
+  const zoneIndex = address.indexOf('%');
+  if (zoneIndex !== -1) {
+    address = address.slice(0, zoneIndex);
+  }
+  address = address.replace(/:\d{1,3}(\.\d{1,3}){3}$/, ':0:0');
+
+  const doubleColons = address.split('::');
+  if (doubleColons.length > 2) {
+    return null;
+  }
+
+  const isGroup = (g: string) => /^[0-9a-fA-F]{1,4}$/.test(g);
+
+  let groups: string[];
+  if (doubleColons.length === 2) {
+    const head = doubleColons[0] === '' ? [] : doubleColons[0].split(':');
+    const tail = doubleColons[1] === '' ? [] : doubleColons[1].split(':');
+    if (head.length + tail.length > 7) {
+      return null;
+    }
+    const fill = Array<string>(8 - head.length - tail.length).fill('0');
+    groups = [...head, ...fill, ...tail];
+  } else {
+    groups = address.split(':');
+  }
+
+  if (groups.length !== 8 || !groups.every(isGroup)) {
+    return null;
+  }
+
+  return groups.map((g) => g.toLowerCase().replace(/^0+(?=.)/, ''));
+}

--- a/web/app/utils/rate-limit.ts
+++ b/web/app/utils/rate-limit.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { randomUUID } from 'node:crypto';
 
 import redis from '@/actions/redis';
@@ -9,6 +7,12 @@ export type RateLimitConfig = {
   limit: number;
   windowSec: number;
   keyPrefix: string;
+  subnetLimit?: number;
+};
+
+export type RateLimitEntry = {
+  key: string;
+  limit: number;
 };
 
 export type RateLimitResult = {
@@ -41,57 +45,76 @@ function getOldestScore(entries: unknown): number {
 }
 
 /**
- * Rate limit using Redis sorted sets (sliding window algorithm).
+ * Rate limit across multiple keys using a sliding window.
  *
- * @param key Unique identifier for the rate limit bucket.
- * @param limit Maximum requests allowed in the configured window.
+ * @param entries Keys to check, each with its own limit.
  * @param windowSec Time window duration in seconds.
- * @returns Rate limit status for the current attempt. Reset reflects when the
- *   oldest retained request exits the window.
+ * @returns Combined status which succeeds only if every key is within its
+ *   limit. Limit, remaining, and reset report the most constrained key.
  */
-export async function rateLimit(
-  key: string,
-  limit: number,
+export async function rateLimitAll(
+  entries: [RateLimitEntry, ...RateLimitEntry[]],
   windowSec: number,
 ): Promise<RateLimitResult> {
   const now = Date.now();
   const windowStart = now - windowSec * 1000;
-  const client = await redis();
 
   try {
+    const client = await redis();
     const pipeline = client.multi();
 
-    pipeline.zRemRangeByScore(key, 0, windowStart);
-    pipeline.zAdd(key, [{ score: now, value: `${now}-${randomUUID()}` }]);
-    pipeline.zCard(key);
-    pipeline.zRangeWithScores(key, 0, 0);
-    pipeline.expire(key, windowSec * 2);
+    for (const { key } of entries) {
+      pipeline.zRemRangeByScore(key, 0, windowStart);
+      pipeline.zAdd(key, [{ score: now, value: `${now}-${randomUUID()}` }]);
+      pipeline.zCard(key);
+      pipeline.zRangeWithScores(key, 0, 0);
+      pipeline.expire(key, windowSec * 2);
+    }
 
     const results = await pipeline.exec();
-    const countResult = results?.[2];
-    const oldestResult = results?.[3];
-    const count =
-      typeof countResult === 'number'
-        ? countResult
-        : Number.parseInt(String(countResult ?? 0), 10) || 1;
-    const oldestScore = getOldestScore(oldestResult);
 
-    const remaining = Math.max(0, limit - count);
-    const resetBase = Number.isFinite(oldestScore) ? oldestScore : now;
-    const reset = toUnixSeconds(resetBase + windowSec * 1000);
+    const statuses = entries.map(({ limit }, i) => {
+      const countResult = results?.[i * 5 + 2];
+      const oldestResult = results?.[i * 5 + 3];
+      const count =
+        typeof countResult === 'number'
+          ? countResult
+          : Number.parseInt(String(countResult ?? 0), 10) || 1;
+      const oldestScore = getOldestScore(oldestResult);
+
+      const resetBase = Number.isFinite(oldestScore) ? oldestScore : now;
+
+      return {
+        success: count <= limit,
+        limit,
+        remaining: Math.max(0, limit - count),
+        reset: toUnixSeconds(resetBase + windowSec * 1000),
+      };
+    });
+
+    let binding = statuses[0];
+    for (const status of statuses.slice(1)) {
+      if (
+        status.remaining < binding.remaining ||
+        (status.remaining === binding.remaining && status.reset > binding.reset)
+      ) {
+        binding = status;
+      }
+    }
 
     return {
-      success: count <= limit,
-      limit,
-      remaining,
-      reset,
+      success: statuses.every((status) => status.success),
+      limit: binding.limit,
+      remaining: binding.remaining,
+      reset: binding.reset,
     };
   } catch (error) {
     logger.error('rate_limit_error', {
-      key,
+      keys: entries.map((entry) => entry.key),
       error: error instanceof Error ? error.message : String(error),
     });
-    // Fail open: allow request on Redis errors.
+    // Fail open and allow the request on Redis errors.
+    const limit = Math.min(...entries.map((entry) => entry.limit));
     return {
       success: true,
       limit,
@@ -99,6 +122,22 @@ export async function rateLimit(
       reset: toUnixSeconds(now + windowSec * 1000),
     };
   }
+}
+
+/**
+ * Rate limit a single key using a sliding window.
+ *
+ * @param key Unique identifier for the rate limit bucket.
+ * @param limit Maximum requests allowed in the configured window.
+ * @param windowSec Time window duration in seconds.
+ * @returns Rate limit status for the current attempt.
+ */
+export async function rateLimit(
+  key: string,
+  limit: number,
+  windowSec: number,
+): Promise<RateLimitResult> {
+  return rateLimitAll([{ key, limit }], windowSec);
 }
 
 /**
@@ -116,9 +155,9 @@ export async function getRateLimitStatus(
 ): Promise<Omit<RateLimitResult, 'success'>> {
   const now = Date.now();
   const windowStart = now - windowSec * 1000;
-  const client = await redis();
 
   try {
+    const client = await redis();
     await client.zRemRangeByScore(key, 0, windowStart);
     const [count, oldestEntries] = await Promise.all([
       client.zCard(key),

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getRateLimitKey, rateLimit } from '@/utils/rate-limit';
-import { getTrustedRequestIp } from '@/utils/headers';
+import { getRateLimitKey, rateLimitAll } from '@/utils/rate-limit';
+import { getTrustedRequestIp, ipSubnetBucket } from '@/utils/headers';
 
 import logger from '@/utils/log';
 import { RateLimitConfig } from '@/utils/rate-limit';
@@ -12,6 +12,16 @@ type RouteMatcher = {
 };
 
 const RATE_LIMITS: RouteMatcher[] = [
+  {
+    // Session checks fire on every page load, so keep this permissive.
+    // Sensitive auth flows have stricter limits within better-auth itself.
+    test: (path) => path.startsWith('/api/auth/'),
+    config: {
+      limit: 150,
+      windowSec: 60,
+      keyPrefix: 'ratelimit:auth',
+    },
+  },
   {
     test: (path) => path.startsWith('/api/v1/bcf'),
     config: {
@@ -94,6 +104,8 @@ const DISABLED_RATE_LIMIT: RateLimitConfig = {
   keyPrefix: 'ratelimit:disabled',
 };
 
+const SUBNET_LIMIT_MULTIPLIER = 4;
+
 function rateLimitForPath(pathname: string): RateLimitConfig {
   const matcher = RATE_LIMITS.find(({ test }) => test(pathname));
   return matcher?.config ?? DISABLED_RATE_LIMIT;
@@ -103,10 +115,6 @@ export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   if (!pathname.startsWith('/api/')) {
-    return NextResponse.next();
-  }
-
-  if (pathname.startsWith('/api/auth/')) {
     return NextResponse.next();
   }
 
@@ -125,16 +133,21 @@ export async function proxy(request: NextRequest) {
       url: pathname,
       method: request.method,
     });
-    return NextResponse.json(
-      {
-        error: 'internal_server_error',
-      },
-      { status: 500 },
-    );
+    return NextResponse.next();
   }
 
-  const key = getRateLimitKey(config, ip);
-  const result = await rateLimit(key, config.limit, config.windowSec);
+  const subnetLimit =
+    config.subnetLimit ?? config.limit * SUBNET_LIMIT_MULTIPLIER;
+  const result = await rateLimitAll(
+    [
+      { key: getRateLimitKey(config, ip), limit: config.limit },
+      {
+        key: `${config.keyPrefix}:subnet:${ipSubnetBucket(ip)}`,
+        limit: subnetLimit,
+      },
+    ],
+    config.windowSec,
+  );
 
   const response = result.success
     ? NextResponse.next()
@@ -165,6 +178,7 @@ export async function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
+    '/api/auth/:path*',
     '/api/v1/:path*',
     '/api/admin/:path*',
     '/api/activity/:path*',


### PR DESCRIPTION
Extends the rate limiter proxy to also support rate limit a subnet, with a default of 4x a single IP's limit.