### PR TITLE
2c2s: Add processing SQL persistence layer

### DIFF
--- a/challenge-harder/build.rs
+++ b/challenge-harder/build.rs
@@ -10,6 +10,7 @@ fn main() -> Result<()> {
     generate_item_ids()?;
 
     let proto_dir = "../proto";
+    println!("cargo:rerun-if-changed={proto_dir}");
     let mut config = prost_build::Config::new();
 
     for ty in [

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -141,6 +141,16 @@ impl std::fmt::Display for UserId {
     }
 }
 
+/// Identifier for an OSRS player.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct PlayerId(pub i32);
+
+impl std::fmt::Display for PlayerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Token authenticating a client's requests within a challenge.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -197,6 +207,23 @@ pub enum PrimaryMeleeGear {
     Blorva = 4,
     Oathplate = 5,
     RadiantOathplate = 6,
+}
+
+impl TryFrom<i16> for PrimaryMeleeGear {
+    type Error = i16;
+
+    fn try_from(value: i16) -> Result<PrimaryMeleeGear, i16> {
+        match value {
+            0 => Ok(PrimaryMeleeGear::Unknown),
+            1 => Ok(PrimaryMeleeGear::EliteVoid),
+            2 => Ok(PrimaryMeleeGear::Bandos),
+            3 => Ok(PrimaryMeleeGear::Torva),
+            4 => Ok(PrimaryMeleeGear::Blorva),
+            5 => Ok(PrimaryMeleeGear::Oathplate),
+            6 => Ok(PrimaryMeleeGear::RadiantOathplate),
+            _ => Err(value),
+        }
+    }
 }
 
 // Compile-time parity checks against the upstream TS values.

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -15,6 +15,7 @@ mod processing;
 mod proto;
 mod repository;
 mod shadow;
+mod skill;
 mod store;
 
 use std::process::ExitCode;

--- a/challenge-harder/src/merging/mod.rs
+++ b/challenge-harder/src/merging/mod.rs
@@ -95,6 +95,11 @@ impl MergedEvents {
         self.events.iter()
     }
 
+    /// Mutably iterates over every event in tick order.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Event> {
+        self.events.iter_mut()
+    }
+
     /// The number of events in the timeline.
     pub fn len(&self) -> usize {
         self.events.len()

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -3,7 +3,7 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, PrimaryMeleeGear, RecordingType, Stage, UserId, Uuid,
+    ChallengeMode, ChallengeStatus, PlayerId, PrimaryMeleeGear, RecordingType, Stage, UserId, Uuid,
 };
 use crate::players::normalize_rsn;
 
@@ -16,7 +16,6 @@ pub async fn create(
     info: &ChallengeInfo,
 ) -> Result<(), db::Error> {
     let start_time = UNIX_EPOCH + Duration::from_millis(info.created_unix_ms);
-    let scale = i16::try_from(info.party.len()).expect("party fits in a smallint");
     let row = txn
         .query_one(
             "INSERT INTO challenges (uuid, type, mode, scale, stage, status, start_time)
@@ -26,7 +25,7 @@ pub async fn create(
                 &uuid,
                 &(info.challenge_type as i16),
                 &(info.mode as i16),
-                &scale,
+                &info.scale(),
                 &(info.stage as i16),
                 &(ChallengeStatus::InProgress as i16),
                 &start_time,
@@ -42,7 +41,7 @@ pub async fn create(
              VALUES ($1, $2, $3, $4, $5)",
             &[
                 &txn.challenge_id(),
-                &player_id,
+                &player_id.0,
                 &username,
                 &i16::try_from(orb).expect("orb fits in a smallint"),
                 &(PrimaryMeleeGear::Unknown as i16),
@@ -56,7 +55,10 @@ pub async fn create(
 
 /// Records that a player has started a challenge, creating their row if it
 /// does not exist. Returns the player's database ID.
-async fn start_player_challenge(txn: &db::Transaction, username: &str) -> Result<i32, db::Error> {
+async fn start_player_challenge(
+    txn: &db::Transaction,
+    username: &str,
+) -> Result<PlayerId, db::Error> {
     // The unique index on normalized_username is partial, so the conflict
     // target must spell its predicate for Postgres.
     let row = txn
@@ -69,7 +71,7 @@ async fn start_player_challenge(txn: &db::Transaction, username: &str) -> Result
             &[&username, &normalize_rsn(username)],
         )
         .await?;
-    Ok(row.get(0))
+    Ok(PlayerId(row.get(0)))
 }
 
 /// Records a user as a recorder of the challenge.

--- a/challenge-harder/src/processing/db.rs
+++ b/challenge-harder/src/processing/db.rs
@@ -157,7 +157,6 @@ impl Transaction {
 
     /// Returns the processor state stored by the last committed run.
     /// Absent for a fresh challenge.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn custom_data(&self) -> Option<&serde_json::Value> {
         self.custom_data.as_ref()
     }

--- a/challenge-harder/src/processing/interpret.rs
+++ b/challenge-harder/src/processing/interpret.rs
@@ -12,6 +12,8 @@ use crate::proto::{Event, event};
 
 use super::ChallengeInfo;
 use super::challenge_processor::{ChallengeProcessor, EventCursor};
+use super::split::{ChallengeSplit, SplitType, StageSplit};
+use super::stats::PlayerStatsDelta;
 
 /// An NPC tracked through a stage.
 #[derive(Debug, Clone, PartialEq)]
@@ -25,6 +27,13 @@ pub struct RoomNpc {
     pub kind: Option<event::npc::Type>,
 }
 
+/// Data accumulated about a single party member during a stage.
+#[derive(Debug, Clone, Default)]
+pub struct PlayerData {
+    pub gear: Option<PrimaryMeleeGear>,
+    pub stats: PlayerStatsDelta,
+}
+
 /// Generic stage state accumulated by the event loop.
 #[derive(Debug)]
 pub struct StageContext {
@@ -32,8 +41,12 @@ pub struct StageContext {
     npcs: BTreeMap<u64, RoomNpc>,
     /// Party indices of players who died this stage, in death order.
     deaths: Vec<usize>,
-    /// Primary melee gear determined for each player this stage.
-    gear: Vec<Option<PrimaryMeleeGear>>,
+    /// Per-player data, indexed by party position.
+    players: Vec<PlayerData>,
+    /// Local splits recorded within the stage.
+    stage_splits: BTreeMap<SplitType, StageSplit>,
+    /// Challenge-wide splits recorded during the stage.
+    challenge_splits: BTreeMap<SplitType, ChallengeSplit>,
 }
 
 impl StageContext {
@@ -43,16 +56,14 @@ impl StageContext {
             party,
             npcs: BTreeMap::new(),
             deaths: Vec::new(),
-            gear: vec![None; scale],
+            players: vec![PlayerData::default(); scale],
+            stage_splits: BTreeMap::new(),
+            challenge_splits: BTreeMap::new(),
         }
     }
 
     pub fn party(&self) -> &[String] {
         &self.party
-    }
-
-    pub fn scale(&self) -> usize {
-        self.party.len()
     }
 
     /// Returns the tracked NPC with the given room ID.
@@ -70,13 +81,74 @@ impl StageContext {
         &self.deaths
     }
 
-    pub(super) fn gear(&self) -> &[Option<PrimaryMeleeGear>] {
-        &self.gear
+    /// Returns all players' collected data, indexed by party position.
+    pub(super) fn players(&self) -> &[PlayerData] {
+        &self.players
+    }
+
+    /// Returns the accumulated data of the player at `party_index`.
+    pub(super) fn player_mut(&mut self, party_index: usize) -> Option<&mut PlayerData> {
+        self.players.get_mut(party_index)
     }
 
     /// Returns the index of `username` in the party.
-    fn party_index(&self, username: &str) -> Option<usize> {
+    pub(super) fn party_index(&self, username: &str) -> Option<usize> {
         self.party.iter().position(|name| name == username)
+    }
+
+    /// Records a split whose timer is local to the current stage.
+    ///
+    /// `tick` is the tick on which the split occurred, counted as elapsed from
+    /// `start`. `requires_completion` indicates whether the split lasts until
+    /// the end of the stage. When set, accuracy is contingent on completion.
+    ///
+    /// Recording the same split again overwrites it.
+    pub fn set_stage_split(
+        &mut self,
+        split: SplitType,
+        tick: u32,
+        start: u32,
+        requires_completion: bool,
+    ) {
+        if tick > start {
+            self.stage_splits.insert(
+                split,
+                StageSplit {
+                    tick,
+                    start,
+                    requires_completion,
+                },
+            );
+        }
+    }
+
+    /// Returns the recorded stage split of the given type.
+    pub fn stage_split(&self, split: SplitType) -> Option<StageSplit> {
+        self.stage_splits.get(&split).copied()
+    }
+
+    /// Records a split whose timer spans the entire challenge.
+    pub fn set_challenge_split(&mut self, split: SplitType, ticks: u32, accurate: Option<bool>) {
+        if ticks > 0 {
+            self.challenge_splits
+                .insert(split, ChallengeSplit { ticks, accurate });
+        }
+    }
+
+    /// Iterates over recorded stage splits in split order.
+    pub(super) fn stage_splits(&self) -> impl Iterator<Item = (SplitType, StageSplit)> + '_ {
+        self.stage_splits
+            .iter()
+            .map(|(&split, &entry)| (split, entry))
+    }
+
+    /// Iterates over recorded challenge splits in split order.
+    pub(super) fn challenge_splits(
+        &self,
+    ) -> impl Iterator<Item = (SplitType, ChallengeSplit)> + '_ {
+        self.challenge_splits
+            .iter()
+            .map(|(&split, &entry)| (split, entry))
     }
 }
 
@@ -112,18 +184,18 @@ pub fn interpret(
         ..
     } = challenge;
 
+    resolve_party_indices(uuid, &party, &mut events);
+
     let mut ctx = StageContext::new(party);
     let mut kept = Vec::with_capacity(events.len());
-    let mut unknown_players: BTreeMap<String, u32> = BTreeMap::new();
 
-    // TODO(frolv): hoist party index as a preprocessing step
     for index in 0..events.len() {
         {
             let event = &events[index];
             if let Some(player) = &event.player
-                && ctx.party_index(&player.name).is_none()
+                && player.party_index == u32::MAX
             {
-                *unknown_players.entry(player.name.clone()).or_default() += 1;
+                // TODO(frolv): These events should be dropped by the merger.
                 continue;
             }
             track_event(&mut ctx, event);
@@ -135,14 +207,6 @@ pub fn interpret(
         }
     }
 
-    if !unknown_players.is_empty() {
-        tracing::error!(
-            %uuid,
-            players = ?unknown_players,
-            "challenge_event_unknown_players",
-        );
-    }
-
     if party_changed {
         events.restrict_accuracy_to(0);
     }
@@ -150,23 +214,45 @@ pub fn interpret(
     Ok(InterpretOutput { events, kept, ctx })
 }
 
+/// Resolves each player event's username to its party index.
+/// Events from players outside the party are marked with an out-of-range index.
+// TODO(frolv): This should be a postprocessing step in the merger.
+fn resolve_party_indices(uuid: Uuid, party: &[String], events: &mut MergedEvents) {
+    let mut unknown: BTreeMap<String, u32> = BTreeMap::new();
+    for event in events.iter_mut() {
+        let Some(player) = &mut event.player else {
+            continue;
+        };
+        if let Some(index) = party.iter().position(|name| name == &player.name) {
+            player.party_index = u32::try_from(index).expect("party index fits in a u32");
+        } else {
+            *unknown.entry(player.name.clone()).or_default() += 1;
+            player.party_index = u32::MAX;
+        }
+    }
+
+    if !unknown.is_empty() {
+        tracing::error!(%uuid, players = ?unknown, "challenge_event_unknown_players");
+    }
+}
+
 /// Handles a single event, updating state if necessary.
 fn track_event(ctx: &mut StageContext, event: &Event) {
     match event.r#type() {
         event::Type::PlayerUpdate => {
             if let Some(player) = &event.player
-                && let Some(index) = ctx.party_index(&player.name)
-                && ctx.gear[index].is_none()
+                && let Some(data) = ctx.players.get_mut(player.party_index as usize)
+                && data.gear.is_none()
                 && let Some(gear) = try_determine_gear(player)
             {
-                ctx.gear[index] = Some(gear);
+                data.gear = Some(gear);
             }
         }
         event::Type::PlayerDeath => {
             if let Some(player) = &event.player
-                && let Some(index) = ctx.party_index(&player.name)
+                && (player.party_index as usize) < ctx.party.len()
             {
-                ctx.deaths.push(index);
+                ctx.deaths.push(player.party_index as usize);
             }
         }
         event::Type::NpcSpawn => {
@@ -237,7 +323,7 @@ mod tests {
         StageContext::new(vec!["1Ogp".to_string(), "WWWWWWWWWWQQ".to_string()])
     }
 
-    fn event_with_player(kind: event::Type, tick: u32, name: &str) -> Event {
+    fn event_with_player(kind: event::Type, tick: u32, name: &str, index: u32) -> Event {
         let mut event = Event {
             tick,
             ..Default::default()
@@ -245,13 +331,14 @@ mod tests {
         event.set_type(kind);
         event.player = Some(event::Player {
             name: name.to_string(),
+            party_index: index,
             ..Default::default()
         });
         event
     }
 
-    fn update_with_deltas(name: &str, deltas: Vec<u64>) -> Event {
-        let mut event = event_with_player(event::Type::PlayerUpdate, 1, name);
+    fn update_with_deltas(name: &str, index: u32, deltas: Vec<u64>) -> Event {
+        let mut event = event_with_player(event::Type::PlayerUpdate, 1, name, index);
         event.player.as_mut().unwrap().equipment_deltas = deltas;
         event
     }
@@ -334,11 +421,11 @@ mod tests {
         let mut ctx = context();
         track_event(
             &mut ctx,
-            &event_with_player(event::Type::PlayerDeath, 10, "WWWWWWWWWWQQ"),
+            &event_with_player(event::Type::PlayerDeath, 10, "WWWWWWWWWWQQ", 1),
         );
         track_event(
             &mut ctx,
-            &event_with_player(event::Type::PlayerDeath, 25, "1Ogp"),
+            &event_with_player(event::Type::PlayerDeath, 25, "1Ogp", 0),
         );
         assert_eq!(ctx.deaths(), &[1, 0]);
     }
@@ -348,9 +435,85 @@ mod tests {
         let mut ctx = context();
         track_event(
             &mut ctx,
-            &event_with_player(event::Type::PlayerDeath, 5, "TobDataEgirl"),
+            &event_with_player(event::Type::PlayerDeath, 5, "TobDataEgirl", u32::MAX),
         );
         assert!(ctx.deaths().is_empty());
+    }
+
+    #[test]
+    fn stage_splits_must_progress_past_their_start() {
+        let mut ctx = context();
+        ctx.set_stage_split(SplitType::TobEntryMaiden70s50s, 0, 0, false);
+        ctx.set_stage_split(SplitType::TobEntryMaiden70s50s, 32, 52, false);
+        assert_eq!(ctx.stage_split(SplitType::TobEntryMaiden70s50s), None);
+
+        ctx.set_stage_split(SplitType::TobEntryMaiden70s50s, 52, 32, false);
+        assert_eq!(
+            ctx.stage_split(SplitType::TobEntryMaiden70s50s),
+            Some(StageSplit {
+                tick: 52,
+                start: 32,
+                requires_completion: false,
+            }),
+        );
+    }
+
+    #[test]
+    fn stage_splits_overwrite_and_iterate_in_split_order() {
+        let mut ctx = context();
+        ctx.set_stage_split(SplitType::TobEntryMaiden70s, 32, 0, false);
+        ctx.set_stage_split(SplitType::TobEntryMaiden, 150, 0, true);
+        ctx.set_stage_split(SplitType::TobEntryMaiden, 155, 0, true);
+        assert_eq!(
+            ctx.stage_splits().collect::<Vec<_>>(),
+            vec![
+                (
+                    SplitType::TobEntryMaiden,
+                    StageSplit {
+                        tick: 155,
+                        start: 0,
+                        requires_completion: true,
+                    },
+                ),
+                (
+                    SplitType::TobEntryMaiden70s,
+                    StageSplit {
+                        tick: 32,
+                        start: 0,
+                        requires_completion: false,
+                    },
+                ),
+            ],
+        );
+    }
+
+    #[test]
+    fn challenge_splits_need_nonzero_ticks_and_iterate_in_split_order() {
+        let mut ctx = context();
+        ctx.set_challenge_split(SplitType::TobEntryChallenge, 0, None);
+        assert_eq!(ctx.challenge_splits().count(), 0);
+
+        ctx.set_challenge_split(SplitType::TobEntryNyloStart, 280, Some(true));
+        ctx.set_challenge_split(SplitType::TobEntryChallenge, 1534, None);
+        assert_eq!(
+            ctx.challenge_splits().collect::<Vec<_>>(),
+            vec![
+                (
+                    SplitType::TobEntryChallenge,
+                    ChallengeSplit {
+                        ticks: 1534,
+                        accurate: None,
+                    },
+                ),
+                (
+                    SplitType::TobEntryNyloStart,
+                    ChallengeSplit {
+                        ticks: 280,
+                        accurate: Some(true),
+                    },
+                ),
+            ],
+        );
     }
 
     #[test]
@@ -360,6 +523,7 @@ mod tests {
             &mut ctx,
             &update_with_deltas(
                 "1Ogp",
+                0,
                 vec![ItemDelta::Add(EquipmentSlot::Torso, item::id::TORVA_PLATEBODY, 1).to_raw()],
             ),
         );
@@ -367,10 +531,12 @@ mod tests {
             &mut ctx,
             &update_with_deltas(
                 "1Ogp",
+                0,
                 vec![ItemDelta::Add(EquipmentSlot::Torso, item::id::BANDOS_CHESTPLATE, 1).to_raw()],
             ),
         );
-        assert_eq!(ctx.gear(), &[Some(PrimaryMeleeGear::Torva), None]);
+        let gear: Vec<_> = ctx.players().iter().map(|p| p.gear).collect();
+        assert_eq!(gear, [Some(PrimaryMeleeGear::Torva), None]);
     }
 
     #[test]
@@ -380,11 +546,13 @@ mod tests {
             &mut ctx,
             &update_with_deltas(
                 "1Ogp",
+                0,
                 vec![
                     ItemDelta::Remove(EquipmentSlot::Torso, item::id::TORVA_PLATEBODY, 1).to_raw(),
                 ],
             ),
         );
-        assert_eq!(ctx.gear(), &[None, None]);
+        let gear: Vec<_> = ctx.players().iter().map(|p| p.gear).collect();
+        assert_eq!(gear, [None, None]);
     }
 }

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 
 use crate::lifecycle::core::state::Trigger;
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ProcessingError, ProcessingPayload, Stage, Uuid,
+    ChallengeMode, ChallengeStatus, ChallengeType, PlayerId, PrimaryMeleeGear, ProcessingError,
+    ProcessingPayload, Stage, Uuid,
 };
 use crate::store::Store;
 
@@ -16,7 +17,10 @@ mod challenge;
 mod challenge_processor;
 mod interpret;
 mod mokhaiotl;
+mod persist;
+mod split;
 mod stage;
+mod stats;
 
 /// Challenge state at the time a run is triggered.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,6 +33,29 @@ pub struct ChallengeInfo {
     pub status: ChallengeStatus,
     pub challenge_ticks: u32,
     pub created_unix_ms: u64,
+}
+
+impl ChallengeInfo {
+    pub fn scale(&self) -> i16 {
+        i16::try_from(self.party.len()).expect("scale fits in a smallint")
+    }
+}
+
+/// A challenge party member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoredPlayerInfo {
+    pub id: PlayerId,
+    /// The gear recorded for the player.
+    pub gear: PrimaryMeleeGear,
+}
+
+/// Challenge state a processing run retrieves from the database.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StoredState {
+    /// Party members in order.
+    pub players: Vec<StoredPlayerInfo>,
+    /// Type-specific processor state persisted across runs.
+    pub custom_data: Option<serde_json::Value>,
 }
 
 /// A request to process the data demanded by a run trigger.

--- a/challenge-harder/src/processing/persist.rs
+++ b/challenge-harder/src/processing/persist.rs
@@ -1,0 +1,685 @@
+//! Stage result persistence.
+
+use std::collections::BTreeMap;
+
+use crate::lifecycle::core::types::{
+    PrimaryMeleeGear, ProcessingError, ProcessingPayload, Stage, StageStatus,
+};
+use crate::proto::{Event, event};
+use crate::skill::SkillLevel;
+
+use super::challenge_processor::ChallengeProcessor;
+use super::db;
+use super::interpret::{InterpretError, InterpretOutput, StageContext};
+use super::split::{SplitExt, SplitType};
+use super::stats::PlayerStatsDelta;
+use super::{ChallengeInfo, StoredPlayerInfo, StoredState};
+
+/// Writes a stage's processed results to the database and blob store.
+/// Returns the payload to be sent back to the challenge.
+pub(super) async fn persist(
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    stage: Stage,
+    _attempt: Option<u32>,
+    stored: &StoredState,
+    result: Result<InterpretOutput, InterpretError>,
+    processor: &mut dyn ChallengeProcessor,
+) -> Result<ProcessingPayload, ProcessingError> {
+    let payload = payload_from(&result);
+
+    if let Ok(mut output) = result {
+        processor
+            .on_stage_finished(txn, &mut output.ctx, stage, &output.events)
+            .await?;
+
+        let splits = write_splits(
+            txn,
+            challenge,
+            output.events.accurate_until(),
+            output.events.status() == StageStatus::Completed,
+            &output.ctx,
+        )
+        .await?;
+        update_personal_bests(txn, challenge, &stored.players, &splits).await?;
+
+        tokio::try_join!(
+            update_players(txn, stage, &output.ctx, &stored.players),
+            update_player_stats(txn, &output.ctx, &stored.players),
+            write_queryable_events(txn, challenge, stage, &output, &stored.players),
+            update_challenge_row(
+                txn,
+                challenge.challenge_ticks + output.events.last_tick(),
+                output.ctx.deaths().len(),
+            )
+        )?;
+    }
+
+    Ok(payload)
+}
+
+fn payload_from(result: &Result<InterpretOutput, InterpretError>) -> ProcessingPayload {
+    match result {
+        Ok(output) => ProcessingPayload::Stage {
+            status: output.events.status(),
+            ticks: output.events.last_tick(),
+        },
+        // TODO(frolv): Handle errors.
+        Err(InterpretError::NoData) => ProcessingPayload::None,
+    }
+}
+
+async fn update_players(
+    txn: &db::Transaction,
+    stage: Stage,
+    ctx: &StageContext,
+    players: &[StoredPlayerInfo],
+) -> Result<(), db::Error> {
+    let mut updates = Vec::new();
+    for (index, player) in players.iter().enumerate() {
+        let died: Vec<i16> = if ctx.deaths().contains(&index) {
+            vec![stage as i16]
+        } else {
+            Vec::new()
+        };
+        let gear = match player.gear {
+            PrimaryMeleeGear::Unknown => ctx.players()[index]
+                .gear
+                .unwrap_or(PrimaryMeleeGear::Unknown),
+            gear => gear,
+        };
+
+        if died.is_empty() && gear == player.gear {
+            continue;
+        }
+
+        updates.push((died, gear as i16, player.id));
+    }
+
+    futures_util::future::try_join_all(updates.iter().map(|(died, gear, player_id)| async move {
+        txn.execute(
+            "UPDATE challenge_players
+             SET stage_deaths = stage_deaths || $1,
+                 primary_gear = $2
+             WHERE challenge_id = $3 AND player_id = $4",
+            &[died, gear, &txn.challenge_id(), &player_id.0],
+        )
+        .await
+    }))
+    .await?;
+    Ok(())
+}
+
+/// Applies each player's accumulated stat changes to their `player_stats`.
+async fn update_player_stats(
+    txn: &db::Transaction,
+    ctx: &StageContext,
+    players: &[StoredPlayerInfo],
+) -> Result<(), db::Error> {
+    let updates: Vec<_> = players
+        .iter()
+        .zip(ctx.players())
+        .filter(|(_, data)| !data.stats.is_empty())
+        .map(|(info, data)| (info.id, data.stats.columns()))
+        .collect();
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    let sql = player_stats_sql(txn).await?;
+    futures_util::future::try_join_all(updates.iter().map(|(id, deltas)| async move {
+        let mut params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            Vec::with_capacity(deltas.len() + 1);
+        params.push(&id.0);
+        for (_, value) in deltas {
+            params.push(value);
+        }
+        txn.execute(sql, &params).await
+    }))
+    .await?;
+    Ok(())
+}
+
+/// Returns a SQL query for writing player stats.
+async fn player_stats_sql(txn: &db::Transaction) -> Result<&'static str, db::Error> {
+    static SQL: tokio::sync::OnceCell<String> = tokio::sync::OnceCell::const_new();
+    let sql = SQL
+        .get_or_try_init(|| async {
+            let statement = txn.prepare("SELECT * FROM player_stats").await?;
+            Ok::<_, db::Error>(build_player_stats_sql(statement.columns()))
+        })
+        .await?;
+    Ok(sql)
+}
+
+/// Assembles the clone-forward player stats upsert query.
+///
+/// The inserted row starts from the player's latest row (or zeroes) with the
+/// provided deltas added on top, conflicting and updating when a stats row
+/// already exists for today.
+fn build_player_stats_sql(columns: &[tokio_postgres::Column]) -> String {
+    let deltas = PlayerStatsDelta::default().columns();
+
+    let mut names = vec!["player_id".to_string(), "date".to_string()];
+    let mut exprs = vec![
+        "$1".to_string(),
+        "date_trunc('day', now(), 'UTC')".to_string(),
+    ];
+    let mut updates = Vec::new();
+    let mut matched = 0;
+
+    for column in columns {
+        let name = column.name();
+        if matches!(name, "id" | "player_id" | "date") {
+            continue;
+        }
+        let base = format!("COALESCE(prev.{name}, 0)");
+        let expr = if let Some(position) = deltas.iter().position(|(delta, _)| delta == name) {
+            matched += 1;
+            // $1 is the player ID; deltas bind in `columns()` order after it.
+            format!("{base} + ${}", position + 2)
+        } else {
+            base
+        };
+        names.push(name.to_string());
+        exprs.push(expr);
+        updates.push(format!("{name} = EXCLUDED.{name}"));
+    }
+    assert_eq!(
+        matched,
+        deltas.len(),
+        "player_stats lacks stat delta columns"
+    );
+
+    format!(
+        "INSERT INTO player_stats ({})
+         SELECT {}
+         FROM (VALUES (1)) AS seed
+         LEFT JOIN LATERAL (
+             SELECT * FROM player_stats
+             WHERE player_id = $1
+             ORDER BY date DESC
+             LIMIT 1
+         ) prev ON true
+         ON CONFLICT (player_id, date) DO UPDATE SET {}",
+        names.join(", "),
+        exprs.join(", "),
+        updates.join(", "),
+    )
+}
+
+struct InsertedSplit {
+    id: i32,
+    split: SplitType,
+    ticks: u32,
+    accurate: bool,
+}
+
+/// Inserts a stage's recorded splits, returning the inserted rows.
+///
+/// Stage splits count their ticks from their recorded start, and are accurate
+/// when they lie within the timeline's accurate prefix.
+/// Challenge splits are inaccurate unless explicitly overridden.
+async fn write_splits(
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    accurate_until: u32,
+    completed: bool,
+    ctx: &StageContext,
+) -> Result<Vec<InsertedSplit>, db::Error> {
+    let mut rows = Vec::new();
+    for (split, entry) in ctx.stage_splits() {
+        rows.push((
+            split.adjust_to(challenge.mode),
+            entry.tick - entry.start,
+            entry.tick < accurate_until && (!entry.requires_completion || completed),
+        ));
+    }
+    for (split, entry) in ctx.challenge_splits() {
+        rows.push((
+            split.adjust_to(challenge.mode),
+            entry.ticks,
+            entry.accurate.unwrap_or(false),
+        ));
+    }
+
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut types = Vec::with_capacity(rows.len());
+    let mut ticks = Vec::with_capacity(rows.len());
+    let mut accurate = Vec::with_capacity(rows.len());
+    for &(split, t, acc) in &rows {
+        types.push(split as i16);
+        ticks.push(t.cast_signed());
+        accurate.push(acc);
+    }
+
+    let ids = txn
+        .query(
+            "INSERT INTO challenge_splits (challenge_id, type, scale, ticks, accurate)
+             SELECT $1, type, $2, ticks, accurate
+             FROM unnest($3::smallint[], $4::int[], $5::bool[]) AS split(type, ticks, accurate)
+             RETURNING id",
+            &[
+                &txn.challenge_id(),
+                &challenge.scale(),
+                &types,
+                &ticks,
+                &accurate,
+            ],
+        )
+        .await?;
+
+    Ok(ids
+        .into_iter()
+        .zip(rows)
+        .map(|(row, (split, ticks, accurate))| InsertedSplit {
+            id: row.get(0),
+            split,
+            ticks,
+            accurate,
+        })
+        .collect())
+}
+
+/// Compares the accurate inserted splits against each player's current
+/// personal bests, recording any new or improved times.
+async fn update_personal_bests(
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    players: &[StoredPlayerInfo],
+    splits: &[InsertedSplit],
+) -> Result<(), db::Error> {
+    let accurate: Vec<&InsertedSplit> = splits.iter().filter(|split| split.accurate).collect();
+    if accurate.is_empty() {
+        return Ok(());
+    }
+
+    let player_ids: Vec<i32> = players.iter().map(|player| player.id.0).collect();
+    let split_types: Vec<i16> = accurate.iter().map(|split| split.split as i16).collect();
+    let scale = challenge.scale();
+
+    let rows = txn
+        .query(
+            "WITH ranked_pbs AS (
+               SELECT pbh.player_id, cs.type, cs.ticks,
+                      ROW_NUMBER() OVER (
+                          PARTITION BY pbh.player_id, cs.type, cs.scale
+                          ORDER BY pbh.created_at DESC
+                      ) AS rn
+               FROM personal_best_history pbh
+               JOIN challenge_splits cs ON pbh.challenge_split_id = cs.id
+               WHERE pbh.player_id = ANY($1) AND cs.type = ANY($2) AND cs.scale = $3
+             )
+             SELECT player_id, type, ticks FROM ranked_pbs WHERE rn = 1",
+            &[&player_ids, &split_types, &scale],
+        )
+        .await?;
+    let mut current: BTreeMap<(i32, i16), i32> = BTreeMap::new();
+    for row in rows {
+        current.insert((row.get(0), row.get(1)), row.get(2));
+    }
+
+    let mut pb_players = Vec::new();
+    let mut pb_split_ids = Vec::new();
+    let mut pb_splits = Vec::new();
+
+    for split in &accurate {
+        for player in players {
+            let new_best = match current.get(&(player.id.0, split.split as i16)) {
+                None => true,
+                Some(&ticks) => split.ticks.cast_signed() < ticks,
+            };
+            if new_best {
+                pb_players.push(player.id.0);
+                pb_split_ids.push(split.id);
+                pb_splits.push(split.split);
+            }
+        }
+    }
+
+    if !pb_players.is_empty() {
+        tracing::info!(
+            scale,
+            players = ?pb_players,
+            splits = ?pb_splits,
+            "challenge_personal_bests_updated",
+        );
+        txn.execute(
+            "INSERT INTO personal_best_history (player_id, challenge_split_id)
+             SELECT * FROM unnest($1::int[], $2::int[])",
+            &[&pb_players, &pb_split_ids],
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn update_challenge_row(
+    txn: &db::Transaction,
+    challenge_ticks: u32,
+    new_deaths: usize,
+) -> Result<(), db::Error> {
+    txn.execute(
+        "UPDATE challenges
+         SET challenge_ticks = $1, total_deaths = total_deaths + $2
+         WHERE id = $3",
+        &[
+            &challenge_ticks.cast_signed(),
+            &i32::try_from(new_deaths).expect("death count fits in an integer"),
+            &txn.challenge_id(),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// A row of the `queryable_events` table.
+#[derive(Default)]
+struct QueryableEvent {
+    event_type: i16,
+    tick: i32,
+    x_coord: i16,
+    y_coord: i16,
+    subtype: Option<i16>,
+    player_id: Option<i32>,
+    npc_id: Option<i32>,
+    custom_int_1: Option<i32>,
+    custom_int_2: Option<i32>,
+    custom_short_1: Option<i16>,
+    custom_short_2: Option<i16>,
+}
+
+/// Writes the stage's kept events within the queryable prefix to the
+/// `queryable_events` table. Returns the number of rows written.
+async fn write_queryable_events(
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    stage: Stage,
+    output: &InterpretOutput,
+    players: &[StoredPlayerInfo],
+) -> Result<usize, db::Error> {
+    let queryable_until = output.events.queryable_until();
+    if queryable_until == 0 {
+        return Ok(0);
+    }
+
+    let mut rows = Vec::new();
+    for &index in &output.kept {
+        let event = &output.events[index];
+        if event.tick < queryable_until
+            && let Some(row) = to_queryable_event(event, &output.ctx, players)
+        {
+            rows.push(row);
+        }
+    }
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let mut event_types = Vec::with_capacity(rows.len());
+    let mut ticks = Vec::with_capacity(rows.len());
+    let mut x_coords = Vec::with_capacity(rows.len());
+    let mut y_coords = Vec::with_capacity(rows.len());
+    let mut subtypes = Vec::with_capacity(rows.len());
+    let mut player_ids = Vec::with_capacity(rows.len());
+    let mut npc_ids = Vec::with_capacity(rows.len());
+    let mut custom_int_1s = Vec::with_capacity(rows.len());
+    let mut custom_int_2s = Vec::with_capacity(rows.len());
+    let mut custom_short_1s = Vec::with_capacity(rows.len());
+    let mut custom_short_2s = Vec::with_capacity(rows.len());
+    for row in &rows {
+        event_types.push(row.event_type);
+        ticks.push(row.tick);
+        x_coords.push(row.x_coord);
+        y_coords.push(row.y_coord);
+        subtypes.push(row.subtype);
+        player_ids.push(row.player_id);
+        npc_ids.push(row.npc_id);
+        custom_int_1s.push(row.custom_int_1);
+        custom_int_2s.push(row.custom_int_2);
+        custom_short_1s.push(row.custom_short_1);
+        custom_short_2s.push(row.custom_short_2);
+    }
+
+    txn.execute(
+        "INSERT INTO queryable_events
+           (challenge_id, event_type, stage, mode, tick, x_coord, y_coord, subtype,
+            player_id, npc_id, custom_int_1, custom_int_2, custom_short_1, custom_short_2)
+         SELECT $1, event.event_type, $2, $3, event.tick, event.x_coord, event.y_coord,
+                event.subtype, event.player_id, event.npc_id, event.custom_int_1,
+                event.custom_int_2, event.custom_short_1, event.custom_short_2
+         FROM unnest($4::smallint[], $5::int[], $6::smallint[], $7::smallint[],
+                     $8::smallint[], $9::int[], $10::int[], $11::int[], $12::int[],
+                     $13::smallint[], $14::smallint[])
+              AS event(event_type, tick, x_coord, y_coord, subtype, player_id, npc_id,
+                       custom_int_1, custom_int_2, custom_short_1, custom_short_2)",
+        &[
+            &txn.challenge_id(),
+            &(stage as i16),
+            &(challenge.mode as i16),
+            &event_types,
+            &ticks,
+            &x_coords,
+            &y_coords,
+            &subtypes,
+            &player_ids,
+            &npc_ids,
+            &custom_int_1s,
+            &custom_int_2s,
+            &custom_short_1s,
+            &custom_short_2s,
+        ],
+    )
+    .await?;
+    Ok(rows.len())
+}
+
+/// Maps an event to its queryable row, if its type is queryable.
+#[expect(clippy::cast_possible_truncation, clippy::too_many_lines)]
+fn to_queryable_event(
+    event: &Event,
+    ctx: &StageContext,
+    players: &[StoredPlayerInfo],
+) -> Option<QueryableEvent> {
+    let base = || QueryableEvent {
+        event_type: event.r#type as i16,
+        tick: event.tick.cast_signed(),
+        x_coord: event.x_coord as i16,
+        y_coord: event.y_coord as i16,
+        ..QueryableEvent::default()
+    };
+    let id_from_index = |index: u32| {
+        players
+            .get(index as usize)
+            .map(|player: &StoredPlayerInfo| player.id.0)
+    };
+    let id_from_name = |name: &str| {
+        ctx.party_index(name)
+            .and_then(|index| players.get(index))
+            .map(|player| player.id.0)
+    };
+
+    let row = match event.r#type() {
+        event::Type::PlayerAttack => {
+            let attack = event.player_attack.as_ref()?;
+            let mut row = base();
+            row.subtype = Some(attack.r#type as i16);
+            row.player_id = event
+                .player
+                .as_ref()
+                .and_then(|player| id_from_index(player.party_index));
+            row.npc_id = attack.target.as_ref().map(|npc| npc.id.cast_signed());
+            // PLAYER_ATTACK_WEAPON
+            row.custom_int_1 = attack.weapon.as_ref().map(|weapon| weapon.id.cast_signed());
+            // PLAYER_ATTACK_DISTANCE
+            row.custom_short_1 = Some(attack.distance_to_target as i16);
+            row
+        }
+        event::Type::PlayerSpell => {
+            let spell = event.player_spell.as_ref()?;
+            let mut row = base();
+            row.subtype = Some(spell.r#type as i16);
+            row.player_id = event
+                .player
+                .as_ref()
+                .and_then(|player| id_from_index(player.party_index));
+            match &spell.target {
+                Some(event::spell::Target::TargetPlayer(name)) => {
+                    // PLAYER_SPELL_TARGET_PLAYER
+                    row.custom_int_1 = id_from_name(name);
+                }
+                Some(event::spell::Target::TargetNpc(npc)) => {
+                    row.npc_id = Some(npc.id.cast_signed());
+                }
+                Some(event::spell::Target::NoTarget(())) | None => {}
+            }
+            row
+        }
+        event::Type::PlayerDeath => {
+            let player = event.player.as_ref()?;
+            let mut row = base();
+            row.player_id = id_from_index(player.party_index);
+            row
+        }
+        event::Type::NpcSpawn | event::Type::NpcDeath => {
+            let npc = event.npc.as_ref()?;
+            let mut row = base();
+            row.npc_id = Some(npc.id.cast_signed());
+            if let Some(kind) = ctx
+                .npc(npc.room_id)
+                .and_then(|tracked| tracked.kind.as_ref())
+            {
+                match kind {
+                    event::npc::Type::Basic(()) => row.subtype = Some(0),
+                    event::npc::Type::MaidenCrab(crab) => {
+                        row.subtype = Some(1);
+                        // NPC_MAIDEN_CRAB_SPAWN and NPC_MAIDEN_CRAB_POSITION
+                        row.custom_short_1 = Some(crab.spawn as i16);
+                        row.custom_short_2 = Some(crab.position as i16);
+                    }
+                    event::npc::Type::Nylo(nylo) => {
+                        row.subtype = Some(2);
+                        // NPC_NYLO_SPAWN_TYPE and NPC_NYLO_STYLE
+                        row.custom_short_1 = Some(nylo.spawn_type as i16);
+                        row.custom_short_2 = Some(nylo.style as i16);
+                    }
+                    event::npc::Type::VerzikCrab(crab) => {
+                        row.subtype = Some(3);
+                        // NPC_VERZIK_CRAB_PHASE and NPC_VERZIK_CRAB_SPAWN
+                        row.custom_short_1 = Some(crab.phase as i16);
+                        row.custom_short_2 = Some(crab.spawn as i16);
+                    }
+                }
+            }
+            row
+        }
+        event::Type::NpcAttack => {
+            let attack = event.npc_attack.as_ref()?;
+            let mut row = base();
+            row.subtype = Some(attack.attack as i16);
+            row.npc_id = event.npc.as_ref().map(|npc| npc.id.cast_signed());
+            row.player_id = attack.target.as_deref().and_then(id_from_name);
+            row
+        }
+        event::Type::TobMaidenCrabLeak => {
+            let npc = event.npc.as_ref()?;
+            let Some(event::npc::Type::MaidenCrab(crab)) = ctx
+                .npc(npc.room_id)
+                .and_then(|tracked| tracked.kind.as_ref())
+            else {
+                return None;
+            };
+            let mut row = base();
+            row.npc_id = Some(npc.id.cast_signed());
+            // TOB_MAIDEN_CRAB_LEAK_SPAWN and TOB_MAIDEN_CRAB_LEAK_POSITION
+            row.custom_short_1 = Some(crab.spawn as i16);
+            row.custom_short_2 = Some(crab.position as i16);
+            // TOB_MAIDEN_CRAB_LEAK_CURRENT_HP and TOB_MAIDEN_CRAB_LEAK_BASE_HP
+            let hitpoints = SkillLevel::from_raw(npc.hitpoints);
+            row.custom_int_1 = Some(i32::from(hitpoints.current));
+            row.custom_int_2 = Some(i32::from(hitpoints.base));
+            row
+        }
+        event::Type::TobBloatDown => {
+            let down = event.bloat_down.as_ref()?;
+            let mut row = base();
+            // TOB_BLOAT_DOWN_NUMBER
+            row.custom_short_1 = Some(down.down_number as i16);
+            // TOB_BLOAT_DOWN_WALK_TIME
+            row.custom_short_2 = Some((down.up_ticks.cast_signed() - 1) as i16);
+            row
+        }
+        event::Type::TobNyloWaveStall => {
+            let wave = event.nylo_wave.as_ref()?;
+            let mut row = base();
+            // TOB_NYLO_WAVE_NUMBER and TOB_NYLO_WAVE_NYLO_COUNT
+            row.custom_short_1 = Some(wave.wave as i16);
+            row.custom_short_2 = Some(wave.nylos_alive as i16);
+            row
+        }
+        event::Type::TobXarpusExhumed => {
+            let exhumed = event.xarpus_exhumed.as_ref()?;
+            let mut row = base();
+            row.tick = exhumed.spawn_tick.cast_signed();
+            // TOB_XARPUS_EXHUMED_HEAL_COUNT
+            row.custom_short_1 = Some(
+                i16::try_from(exhumed.heal_ticks.len()).expect("heal count fits in a smallint"),
+            );
+            row
+        }
+        event::Type::TobVerzikBounce => {
+            let bounce = event.verzik_bounce.as_ref()?;
+            let mut row = base();
+            row.player_id = bounce.bounced_player.as_deref().and_then(id_from_name);
+            // TOB_VERZIK_BOUNCE_PLAYERS_IN_RANGE and
+            row.custom_short_1 = Some(bounce.players_in_range as i16);
+            // TOB_VERZIK_BOUNCE_PLAYERS_NOT_IN_RANGE
+            row.custom_short_2 = Some(bounce.players_not_in_range as i16);
+            row
+        }
+        event::Type::TobVerzikHeal => {
+            let heal = event.verzik_heal.as_ref()?;
+            let mut row = base();
+            row.player_id = id_from_name(&heal.player);
+            // TOB_VERZIK_HEAL_AMOUNT
+            row.custom_short_1 = Some(heal.heal_amount as i16);
+            row
+        }
+        event::Type::TobVerzikDawnDrop => {
+            let drop = event.verzik_dawn_drop.as_ref()?;
+            let mut row = base();
+            row.subtype = Some(i16::from(drop.dropped));
+            row
+        }
+        event::Type::ColosseumSolGrapple => {
+            let grapple = event.colosseum_sol_grapple.as_ref()?;
+            let mut row = base();
+            row.player_id = players.first().map(|player| player.id.0);
+            // SOL_GRAPPLE_TARGET
+            row.custom_short_1 = Some(grapple.target as i16);
+            // SOL_GRAPPLE_OUTCOME
+            row.custom_short_2 = Some(grapple.outcome as i16);
+            row
+        }
+        _ => return None,
+    };
+
+    Some(row)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_data_yields_no_payload() {
+        assert_eq!(
+            payload_from(&Err(InterpretError::NoData)),
+            ProcessingPayload::None,
+        );
+    }
+}

--- a/challenge-harder/src/processing/split.rs
+++ b/challenge-harder/src/processing/split.rs
@@ -1,0 +1,176 @@
+//! Challenge split processing utilities.
+//!
+//! `SplitType` is generated from `challenge_storage.proto`.
+
+use crate::lifecycle::core::types::ChallengeMode;
+
+pub use crate::proto::SplitType;
+
+/// A recorded split whose timer is local to a single stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StageSplit {
+    pub tick: u32,
+    pub start: u32,
+    /// Marks a split lasting until the end of its stage, making accuracy
+    /// contingent on stage completion.
+    pub requires_completion: bool,
+}
+
+/// A recorded split whose timer spans the entire challenge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChallengeSplit {
+    pub ticks: u32,
+    /// If set, overrides the default challenge accuracy computation.
+    pub accurate: Option<bool>,
+}
+
+pub trait SplitExt {
+    /// Converts a split type to a different mode,
+    /// For example, `TobEntryNyloBossSpawn` adjusted to `TobHard` becomes
+    /// `TobHmNyloBossSpawn`. Splits that lack modes are returned unchanged.
+    fn adjust_to(self, mode: ChallengeMode) -> SplitType;
+
+    /// Returns the generic version of a mode-specific split.
+    /// Splits of challenges without modes are returned unchanged.
+    fn generalize(self) -> SplitType;
+}
+
+impl SplitExt for SplitType {
+    fn adjust_to(self, mode: ChallengeMode) -> SplitType {
+        if !is_tob_split(self) {
+            return self;
+        }
+
+        let value = self.generalize() as i32;
+        let offset = match mode {
+            ChallengeMode::TobRegular => 1,
+            ChallengeMode::TobHard => 2,
+            ChallengeMode::NoMode
+            | ChallengeMode::TobEntry
+            | ChallengeMode::CoxRegular
+            | ChallengeMode::CoxChallenge
+            | ChallengeMode::ToaEntry
+            | ChallengeMode::ToaNormal
+            | ChallengeMode::ToaExpert => 0,
+        };
+
+        SplitType::try_from(value + offset).expect("ToB mode splits are consecutive")
+    }
+
+    fn generalize(self) -> SplitType {
+        if is_tob_split(self) {
+            let value = self as i32;
+            SplitType::try_from(value - value % 3).expect("ToB mode splits are consecutive")
+        } else {
+            self
+        }
+    }
+}
+
+fn is_tob_split(split: SplitType) -> bool {
+    (SplitType::TobEntryChallenge as i32..=SplitType::TobHmVerzikStart as i32)
+        .contains(&(split as i32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adjust_to_selects_the_mode_variant_of_generic_tob_splits() {
+        assert_eq!(
+            SplitType::TobEntryChallenge.adjust_to(ChallengeMode::TobRegular),
+            SplitType::TobRegChallenge,
+        );
+        assert_eq!(
+            SplitType::TobEntryMaiden.adjust_to(ChallengeMode::TobHard),
+            SplitType::TobHmMaiden,
+        );
+        assert_eq!(
+            SplitType::TobEntryVerzikStart.adjust_to(ChallengeMode::TobHard),
+            SplitType::TobHmVerzikStart,
+        );
+        assert_eq!(
+            SplitType::TobEntryMaiden.adjust_to(ChallengeMode::TobEntry),
+            SplitType::TobEntryMaiden,
+        );
+        assert_eq!(
+            SplitType::TobEntryMaiden.adjust_to(ChallengeMode::NoMode),
+            SplitType::TobEntryMaiden,
+        );
+    }
+
+    #[test]
+    fn adjust_to_converts_between_tob_modes() {
+        assert_eq!(
+            SplitType::TobRegMaiden.adjust_to(ChallengeMode::TobHard),
+            SplitType::TobHmMaiden,
+        );
+        assert_eq!(
+            SplitType::TobHmChallenge.adjust_to(ChallengeMode::TobRegular),
+            SplitType::TobRegChallenge,
+        );
+        assert_eq!(
+            SplitType::TobHmMaiden.adjust_to(ChallengeMode::NoMode),
+            SplitType::TobEntryMaiden,
+        );
+    }
+
+    #[test]
+    fn adjust_to_passes_through_other_challenges() {
+        assert_eq!(
+            SplitType::ColosseumWave1.adjust_to(ChallengeMode::TobHard),
+            SplitType::ColosseumWave1,
+        );
+        assert_eq!(
+            SplitType::MokhaiotlDelve8.adjust_to(ChallengeMode::TobRegular),
+            SplitType::MokhaiotlDelve8,
+        );
+    }
+
+    #[test]
+    fn generalize_removes_the_mode_of_tob_splits() {
+        assert_eq!(
+            SplitType::TobRegChallenge.generalize(),
+            SplitType::TobEntryChallenge,
+        );
+        assert_eq!(
+            SplitType::TobHmMaiden.generalize(),
+            SplitType::TobEntryMaiden
+        );
+        assert_eq!(
+            SplitType::TobHmVerzikStart.generalize(),
+            SplitType::TobEntryVerzikStart,
+        );
+        assert_eq!(
+            SplitType::TobEntryMaiden.generalize(),
+            SplitType::TobEntryMaiden,
+        );
+    }
+
+    #[test]
+    fn generalize_passes_through_other_challenges() {
+        assert_eq!(
+            SplitType::ColosseumWave12.generalize(),
+            SplitType::ColosseumWave12,
+        );
+        assert_eq!(
+            SplitType::InfernoWave69Time.generalize(),
+            SplitType::InfernoWave69Time,
+        );
+    }
+
+    #[test]
+    fn split_values_support_stage_arithmetic() {
+        assert_eq!(
+            SplitType::try_from(SplitType::MokhaiotlDelve1 as i32 + 7),
+            Ok(SplitType::MokhaiotlDelve8),
+        );
+        assert_eq!(
+            SplitType::try_from(SplitType::MokhaiotlDelve3Start as i32 + 2),
+            Ok(SplitType::MokhaiotlDelve5Start),
+        );
+        assert!(SplitType::try_from(114).is_err());
+        assert!(SplitType::try_from(304).is_err());
+    }
+}

--- a/challenge-harder/src/processing/stage.rs
+++ b/challenge-harder/src/processing/stage.rs
@@ -10,15 +10,17 @@
 
 use crate::lifecycle::challenge::StoreError;
 use crate::lifecycle::core::types::{
-    ChallengeType, ClientStageStream, ProcessingError, ProcessingPayload, Stage, Uuid,
+    ChallengeType, ClientStageStream, PlayerId, PrimaryMeleeGear, ProcessingError,
+    ProcessingPayload, Stage, Uuid,
 };
 use crate::store::Store;
 
-use super::ChallengeInfo;
 use super::challenge_processor::ChallengeProcessor;
 use super::db;
-use super::interpret::{InterpretError, InterpretOutput, interpret};
+use super::interpret::interpret;
 use super::mokhaiotl::MokhaiotlProcessor;
+use super::persist::persist;
+use super::{ChallengeInfo, StoredPlayerInfo, StoredState};
 
 /// Processes a stage's events from its recorded streams.
 pub async fn process(
@@ -48,7 +50,7 @@ pub async fn process(
         }
     };
 
-    let stream = gather(store, uuid, stage, attempt).await?;
+    let (stream, stored) = gather(store, txn, challenge, uuid, stage, attempt).await?;
     let info = challenge.clone();
 
     let (result, mut processor) = tokio::task::spawn_blocking(move || {
@@ -61,65 +63,80 @@ pub async fn process(
         message: format!("interpret task failed: {error}"),
     })?;
 
-    let payload = persist(txn, challenge, stage, result, &mut processor).await?;
+    let payload = persist(
+        txn,
+        challenge,
+        stage,
+        attempt,
+        &stored,
+        result,
+        &mut processor,
+    )
+    .await?;
     Ok((payload, processor.custom_data()))
 }
 
-/// Reads a stage's recorded streams from the store.
-// TODO(frolv): This should also collect other data required by the processing
-// thread.
+/// Collects the recorded streams and stored challenge state a run requires.
 async fn gather(
     store: &Store,
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
     uuid: Uuid,
     stage: Stage,
     attempt: Option<u32>,
-) -> Result<Vec<ClientStageStream>, ProcessingError> {
-    store
-        .read_stage_stream(uuid, stage, attempt)
-        .await
-        .map_err(|error| ProcessingError {
-            retriable: matches!(error, StoreError::Unavailable(_)),
-            message: error.to_string(),
-        })
+) -> Result<(Vec<ClientStageStream>, StoredState), ProcessingError> {
+    let stream = async {
+        store
+            .read_stage_stream(uuid, stage, attempt)
+            .await
+            .map_err(|error| ProcessingError {
+                retriable: matches!(error, StoreError::Unavailable(_)),
+                message: error.to_string(),
+            })
+    };
+    let stored = async {
+        load_database_state(txn, challenge.scale())
+            .await
+            .map_err(ProcessingError::from)
+    };
+    tokio::try_join!(stream, stored)
 }
 
-/// Writes a stage's processed results to the database and blob store.
-/// Returns the payload to be sent back to the challenge.
-async fn persist(
+pub(super) async fn load_database_state(
     txn: &db::Transaction,
-    challenge: &ChallengeInfo,
-    stage: Stage,
-    result: Result<InterpretOutput, InterpretError>,
-    processor: &mut dyn ChallengeProcessor,
-) -> Result<ProcessingPayload, ProcessingError> {
-    let payload = payload_from(&result);
-
-    if let Ok(mut output) = result {
-        processor
-            .on_stage_finished(txn, &mut output.ctx, stage, &output.events)
-            .await?;
-
-        let total = (challenge.challenge_ticks + output.events.last_tick()).cast_signed();
-        txn.execute(
-            "UPDATE challenges SET challenge_ticks = $1 WHERE id = $2",
-            &[&total, &txn.challenge_id()],
+    expected_scale: i16,
+) -> Result<StoredState, db::Error> {
+    let rows = txn
+        .query(
+            "SELECT player_id, primary_gear FROM challenge_players
+             WHERE challenge_id = $1
+             ORDER BY orb",
+            &[&txn.challenge_id()],
         )
-        .await
-        .map_err(db::Error::from)?;
+        .await?;
+    if rows.len() != expected_scale.cast_unsigned() as usize {
+        return Err(db::Error::InvalidData(format!(
+            "challenge has {} players, expected {expected_scale}",
+            rows.len(),
+        )));
     }
 
-    Ok(payload)
-}
+    let players = rows
+        .iter()
+        .map(|row| {
+            let gear: i16 = row.get(1);
+            Ok(StoredPlayerInfo {
+                id: PlayerId(row.get(0)),
+                gear: PrimaryMeleeGear::try_from(gear)
+                    .map_err(|value| db::Error::InvalidData(format!("primary gear {value}")))?,
+            })
+        })
+        .collect::<Result<Vec<_>, db::Error>>()?;
 
-fn payload_from(result: &Result<InterpretOutput, InterpretError>) -> ProcessingPayload {
-    match result {
-        Ok(output) => ProcessingPayload::Stage {
-            status: output.events.status(),
-            ticks: output.events.last_tick(),
-        },
-        // TODO(frolv): Handle errors.
-        Err(InterpretError::NoData) => ProcessingPayload::None,
-    }
+    Ok(StoredState {
+        players,
+        custom_data: txn.custom_data().cloned(),
+    })
 }
 
 #[cfg(test)]
@@ -127,6 +144,7 @@ mod tests {
     use bytes::Bytes;
     use prost::Message;
 
+    use super::super::interpret::{InterpretError, InterpretOutput};
     use super::*;
     use crate::lifecycle::core::types::{
         ChallengeMode, ChallengeStatus, ClientId, ServerTicks, StageStatus, StageUpdate,
@@ -209,13 +227,5 @@ mod tests {
         let result = run_interpret(vec![events(1, &[0, 1, 4])]).unwrap();
         assert_eq!(result.events.status(), StageStatus::Started);
         assert_eq!(result.events.last_tick(), 4);
-    }
-
-    #[test]
-    fn empty_stream_yields_no_payload() {
-        assert_eq!(
-            payload_from(&run_interpret(vec![])),
-            ProcessingPayload::None,
-        );
     }
 }

--- a/challenge-harder/src/processing/stats.rs
+++ b/challenge-harder/src/processing/stats.rs
@@ -1,0 +1,38 @@
+//! Player statistics accumulation.
+
+use serde::Serialize;
+
+/// Changes to a player's lifetime stats accumulated over a processing run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[expect(clippy::struct_field_names)]
+pub struct PlayerStatsDelta {
+    pub mokhaiotl_completions: i32,
+    pub mokhaiotl_wipes: i32,
+    pub mokhaiotl_resets: i32,
+    pub mokhaiotl_total_delves: i32,
+    pub mokhaiotl_delves_completed: i32,
+    pub mokhaiotl_deep_delves_completed: i32,
+}
+
+impl PlayerStatsDelta {
+    /// Whether no changes occurred.
+    pub fn is_empty(&self) -> bool {
+        *self == PlayerStatsDelta::default()
+    }
+
+    /// Pairs each field's value with its `player_stats` column.
+    pub fn columns(&self) -> Vec<(String, i32)> {
+        let serde_json::Value::Object(fields) =
+            serde_json::to_value(self).expect("stats delta serializes")
+        else {
+            unreachable!("a struct serializes to a JSON object")
+        };
+        fields
+            .into_iter()
+            .map(|(name, value)| {
+                let value = value.as_i64().and_then(|v| i32::try_from(v).ok());
+                (name, value.expect("stat fields are integers"))
+            })
+            .collect()
+    }
+}

--- a/challenge-harder/src/skill.rs
+++ b/challenge-harder/src/skill.rs
@@ -1,0 +1,52 @@
+//! Skill level handling.
+
+/// A skill's current and base levels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillLevel {
+    pub current: u16,
+    pub base: u16,
+}
+
+impl SkillLevel {
+    /// Unpacks a skill level from its raw numeric representation.
+    pub fn from_raw(raw: u32) -> SkillLevel {
+        SkillLevel {
+            current: (raw >> 16) as u16,
+            base: (raw & 0xffff) as u16,
+        }
+    }
+
+    /// Packs the skill level into its numeric representation.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub fn to_raw(self) -> u32 {
+        u32::from(self.current) << 16 | u32::from(self.base)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_raw_unpacks_current_and_base() {
+        assert_eq!(
+            SkillLevel::from_raw(0x001d_0063),
+            SkillLevel {
+                current: 29,
+                base: 99,
+            },
+        );
+    }
+
+    #[test]
+    fn to_raw_packs_the_parsed_representation() {
+        assert_eq!(
+            SkillLevel {
+                current: 85,
+                base: 99,
+            }
+            .to_raw(),
+            0x0055_0063,
+        );
+    }
+}


### PR DESCRIPTION
Defines helpers which consume the result of a processing run and write it to the various tables in the SQL for splits, player stats, and PBs.