### PR TITLE
Configure Dependabot grouping for typescript-eslint packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,18 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
+      # The typescript-eslint meta-package pins the plugin and the parser at
+      # exact versions, so all three can only move together, on any update.
+      typescript-eslint:
+        patterns:
+          - typescript-eslint
+          - '@typescript-eslint/*'
+
       npm-minor-patch:
         # Formatting and lint tooling is excluded from the group because a
         # bump usually requires a matching reformat or relint, which does not
         # belong in a PR carrying dozens of unrelated packages. Excluded
-        # packages still receive their own individual update PRs.
+        # packages still receive their own update PRs.
         exclude-patterns:
           - prettier
           - eslint


### PR DESCRIPTION
## Summary
Updated Dependabot configuration to group typescript-eslint related packages together, ensuring the meta-package, plugin, and parser are updated in sync.

## Changes
- Added a new `typescript-eslint` group in Dependabot configuration that pins `typescript-eslint` and all `@typescript-eslint/*` packages together
- Included explanatory comment documenting why these packages must move together (the meta-package pins exact versions)
- Minor grammar fix in existing comment ("their own individual update PRs" → "their own update PRs")

## Details
The typescript-eslint meta-package maintains exact version pins for both the plugin and parser, which means all three components must be updated together to maintain compatibility. This configuration change ensures Dependabot respects this constraint by grouping them into a single pull request rather than creating separate updates that could cause version mismatches.

https://claude.ai/code/session_01Jrv1YqMJfxu7HQHSBDTMyc