### PR TITLE
2c2s: Save stage events to data repository

### DIFF
--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -600,18 +600,8 @@ impl ActiveChallenge {
         let run = self.state.processing.active()?;
         let attempt = run.attempts;
         let request = ProcessingRequest {
-            uuid: self.state.uuid,
             trigger: run.trigger,
-            challenge: ChallengeInfo {
-                challenge_type: self.state.challenge_type,
-                mode: self.state.mode,
-                party: self.state.party.clone(),
-                party_changed: self.state.party_changed,
-                stage: self.state.stage,
-                status: self.state.status(),
-                challenge_ticks: self.state.challenge_ticks,
-                created_unix_ms: self.state.created_unix_ms,
-            },
+            challenge: run.info.clone(),
         };
         let trigger = request.trigger.seq();
         Some(ProcessingTask {

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -7,7 +7,8 @@ use super::command::StageProgress;
 use super::event::{Cause, JournalEntry, LifecycleEvent};
 use super::state::{ChallengeState, ClientState, LastCompleted, PhaseState, StageState, Trigger};
 use super::types::{
-    ClientId, ProcessingError, ProcessingPayload, StageExt, StageStatus, StageStatusExt, Timestamp,
+    ChallengeInfo, ClientId, ProcessingError, ProcessingPayload, StageExt, StageStatus,
+    StageStatusExt, Timestamp,
 };
 
 // it's an exhaustive enum folks
@@ -38,9 +39,10 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
             state.stage_attempt = None;
             state.stage_status = StageStatus::Entered;
             state.stage_state = StageState::InProgress;
+            let info = state.challenge_info();
             state
                 .processing
-                .push(Trigger::Create { seq: entry.seq }, entry.at);
+                .push(Trigger::Create { seq: entry.seq }, info, entry.at);
         }
         LifecycleEvent::ClientJoined {
             client_id,
@@ -50,12 +52,14 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         } => {
             // Process each client the first time it joins.
             if state.recorded_by.insert(client_id) {
+                let info = state.challenge_info();
                 state.processing.push(
                     Trigger::Recorder {
                         seq: entry.seq,
                         user_id,
                         recording_type,
                     },
+                    info,
                     entry.at,
                 );
             }
@@ -92,19 +96,22 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         } => stage_reported(state, entry.at, client_id, attempt, update),
         LifecycleEvent::StageStarted { stage } => {
             // Only fire on actual stage changes, not ENTERED -> STARTED.
-            if stage != state.stage {
+            let stage_changed = stage != state.stage;
+            state.stage = stage;
+            state.stage_attempt = stage.is_retriable().then_some(1);
+            state.stage_status = StageStatus::Started;
+            state.stage_state = StageState::InProgress;
+            if stage_changed {
+                let info = state.challenge_info();
                 state.processing.push(
                     Trigger::StageStart {
                         seq: entry.seq,
                         stage,
                     },
+                    info,
                     entry.at,
                 );
             }
-            state.stage = stage;
-            state.stage_attempt = stage.is_retriable().then_some(1);
-            state.stage_status = StageStatus::Started;
-            state.stage_state = StageState::InProgress;
         }
         LifecycleEvent::StageAttemptStarted { attempt, .. } => {
             state.stage_attempt = Some(attempt);
@@ -113,12 +120,18 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         }
         LifecycleEvent::StageSealed { stage, attempt, .. } => {
             state.stage_state = StageState::Complete { since: entry.at };
+            let info = ChallengeInfo {
+                stage,
+                stage_attempt: attempt,
+                ..state.challenge_info()
+            };
             state.processing.push(
                 Trigger::Stage {
                     seq: entry.seq,
                     stage,
                     attempt,
                 },
+                info,
                 entry.at,
             );
         }
@@ -150,17 +163,16 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         }
         LifecycleEvent::ChallengeTerminated { empty: _ } => {
             state.phase = PhaseState::Terminated;
-            state
-                .processing
-                .push(Trigger::Finish { seq: entry.seq }, entry.at);
         }
         LifecycleEvent::ModeChanged { mode } => {
             state.mode = mode;
+            let info = state.challenge_info();
             state.processing.push(
                 Trigger::Mode {
                     seq: entry.seq,
                     mode,
                 },
+                info,
                 entry.at,
             );
         }
@@ -207,6 +219,15 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
                 .processing
                 .finish(challenge_type, entry.at, Err(timed_out));
         }
+    }
+
+    // A terminated challenge's finish processes once the rest of its pipeline
+    // settles, so that the finished state stores the final outcome.
+    if state.terminated() && state.processing.settled() && !state.processing.finish_queued() {
+        let info = state.challenge_info();
+        state
+            .processing
+            .push(Trigger::Finish { seq: entry.seq }, info, entry.at);
     }
 
     // Check whether the challenge's clients have gone inactive.
@@ -1027,7 +1048,7 @@ mod tests {
             },
         );
 
-        // Finish runs is queued after the create run.
+        // The finish run is deferred until the create run completes.
         assert_eq!(
             state.processing.active().expect("exists").trigger,
             Trigger::Create { seq: JournalSeq(0) },
@@ -1053,9 +1074,140 @@ mod tests {
         );
         assert_eq!(
             state.processing.active().expect("exists").trigger,
-            Trigger::Finish { seq: JournalSeq(1) },
+            Trigger::Finish { seq: JournalSeq(9) },
         );
         assert!(!state.processing.settled());
+    }
+
+    #[test]
+    fn queued_runs_snapshot_the_state_at_their_entry() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+        apply(
+            &mut state,
+            entry(
+                5_500,
+                4,
+                LifecycleEvent::PartyChanged {
+                    party: vec!["Skitter".into()],
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            entry(
+                6_000,
+                5,
+                LifecycleEvent::ModeChanged {
+                    mode: ChallengeMode::TobHard,
+                },
+            ),
+        );
+
+        assert_eq!(
+            state.processing.active().expect("exists").info,
+            ChallengeInfo {
+                uuid: Uuid::from_u128(0xb1e47),
+                challenge_type: ChallengeType::Tob,
+                mode: ChallengeMode::TobRegular,
+                party: vec!["Skitter".into()],
+                party_changed: false,
+                stage: Stage::TobMaiden,
+                stage_attempt: None,
+                status: ChallengeStatus::InProgress,
+                created_unix_ms: 0,
+            },
+        );
+
+        // Completing processing activates the mode run with the later state.
+        apply(
+            &mut state,
+            processing_entry(
+                7_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(5),
+                    payload: ProcessingPayload::None,
+                },
+            ),
+        );
+        let run = state.processing.active().expect("exists");
+        assert_eq!(
+            run.trigger,
+            Trigger::Mode {
+                seq: JournalSeq(0),
+                mode: ChallengeMode::TobHard,
+            },
+        );
+        assert_eq!(
+            run.info,
+            ChallengeInfo {
+                uuid: Uuid::from_u128(0xb1e47),
+                challenge_type: ChallengeType::Tob,
+                mode: ChallengeMode::TobHard,
+                party: vec!["Skitter".into()],
+                party_changed: true,
+                stage: Stage::TobMaiden,
+                stage_attempt: None,
+                status: ChallengeStatus::InProgress,
+                created_unix_ms: 0,
+            },
+        );
+    }
+
+    #[test]
+    fn finish_is_deferred_until_the_pipeline_settles() {
+        let mut state = processing_tob_state();
+        apply(&mut state, maiden_seal(5_000));
+        apply(
+            &mut state,
+            entry(
+                6_000,
+                4,
+                LifecycleEvent::ChallengeTerminated { empty: false },
+            ),
+        );
+
+        // No finish is queued until the stage run completes.
+        assert_eq!(state.processing.outstanding().count(), 1);
+
+        apply(
+            &mut state,
+            processing_entry(
+                7_000,
+                LifecycleEvent::ProcessingStarted {
+                    trigger: JournalSeq(5),
+                },
+            ),
+        );
+        apply(
+            &mut state,
+            processing_entry(
+                8_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(5),
+                    payload: ProcessingPayload::Stage {
+                        status: StageStatus::Wiped,
+                        ticks: 190,
+                    },
+                },
+            ),
+        );
+
+        let run = state.processing.active().expect("exists");
+        assert_eq!(run.trigger, Trigger::Finish { seq: JournalSeq(9) });
+        assert_eq!(run.info.status, ChallengeStatus::Wiped);
+
+        apply(
+            &mut state,
+            processing_entry(
+                9_000,
+                LifecycleEvent::ProcessingFinished {
+                    trigger: JournalSeq(9),
+                    payload: ProcessingPayload::None,
+                },
+            ),
+        );
+        assert!(state.processing.settled());
     }
 
     #[test]

--- a/challenge-harder/src/lifecycle/core/deadline.rs
+++ b/challenge-harder/src/lifecycle/core/deadline.rs
@@ -218,6 +218,7 @@ mod tests {
                 stage: Stage::TobMaiden,
                 attempt: None,
             },
+            ChallengeState::default().challenge_info(),
             since,
         );
         processing

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -1700,6 +1700,7 @@ mod tests {
                 stage: Stage::TobMaiden,
                 attempt: None,
             },
+            ChallengeState::default().challenge_info(),
             Timestamp::from_millis(1_000),
         );
         state

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use core::time::Duration;
 
 use super::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, ClientId, JournalSeq, MsgId,
-    ProcessingError, ProcessingPayload, RecordingType, ReportedTimes, SessionToken, Stage,
-    StageStatus, Timestamp, UserId, Uuid,
+    ChallengeInfo, ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, ClientId,
+    JournalSeq, MsgId, ProcessingError, ProcessingPayload, RecordingType, ReportedTimes,
+    SessionToken, Stage, StageStatus, Timestamp, UserId, Uuid,
 };
 
 /// Progress of the challenge's current stage attempt.
@@ -122,10 +122,18 @@ pub enum ProcessingState {
     Running { since: Timestamp },
 }
 
+/// A queued trigger and the state at the time it was queued.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueuedTrigger {
+    pub trigger: Trigger,
+    pub info: ChallengeInfo,
+}
+
 /// An active processing run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProcessingRun {
     pub trigger: Trigger,
+    pub info: ChallengeInfo,
     pub attempts: u32,
     /// False once a run fails with a non-retriable error.
     pub retriable: bool,
@@ -133,9 +141,10 @@ pub struct ProcessingRun {
 }
 
 impl ProcessingRun {
-    fn new(trigger: Trigger, at: Timestamp) -> Self {
+    fn new(queued: QueuedTrigger, at: Timestamp) -> Self {
         ProcessingRun {
-            trigger,
+            trigger: queued.trigger,
+            info: queued.info,
             attempts: 0,
             retriable: true,
             state: ProcessingState::Idle { since: at },
@@ -154,8 +163,10 @@ impl ProcessingRun {
 pub struct Processing {
     config: ProcessingConfig,
     active: Option<ProcessingRun>,
-    pending: VecDeque<Trigger>,
+    pending: VecDeque<QueuedTrigger>,
     failed: Vec<Trigger>,
+    /// Whether the challenge's finish trigger has been queued.
+    finish_queued: bool,
     /// Status derived from the most recently processed outcome.
     status: Option<ChallengeStatus>,
 }
@@ -167,19 +178,24 @@ impl Processing {
             active: None,
             pending: VecDeque::new(),
             failed: Vec::new(),
+            finish_queued: false,
             status: None,
         }
     }
 
     /// Records a new trigger, starting its run if free.
-    pub fn push(&mut self, trigger: Trigger, at: Timestamp) {
+    pub fn push(&mut self, trigger: Trigger, info: ChallengeInfo, at: Timestamp) {
         if self.config.max_attempts == 0 {
             return;
         }
+        if matches!(trigger, Trigger::Finish { .. }) {
+            self.finish_queued = true;
+        }
+        let queued = QueuedTrigger { trigger, info };
         if self.active.is_none() {
-            self.active = Some(ProcessingRun::new(trigger, at));
+            self.active = Some(ProcessingRun::new(queued, at));
         } else {
-            self.pending.push_back(trigger);
+            self.pending.push_back(queued);
         }
     }
 
@@ -231,7 +247,7 @@ impl Processing {
         self.active = self
             .pending
             .pop_front()
-            .map(|trigger| ProcessingRun::new(trigger, at));
+            .map(|queued| ProcessingRun::new(queued, at));
     }
 
     /// The run currently owning the pipeline.
@@ -245,7 +261,7 @@ impl Processing {
         self.active
             .iter()
             .map(|run| run.trigger)
-            .chain(self.pending.iter().copied())
+            .chain(self.pending.iter().map(|queued| queued.trigger))
     }
 
     /// Triggers whose runs were abandoned after exhausting their attempts.
@@ -264,6 +280,12 @@ impl Processing {
     #[must_use]
     pub fn settled(&self) -> bool {
         self.active.is_none() && self.pending.is_empty()
+    }
+
+    /// Whether the challenge's finish trigger has been queued.
+    #[must_use]
+    pub fn finish_queued(&self) -> bool {
+        self.finish_queued
     }
 }
 
@@ -419,6 +441,22 @@ pub struct ChallengeState {
 }
 
 impl ChallengeState {
+    /// Snapshots the challenge's current state.
+    #[must_use]
+    pub fn challenge_info(&self) -> ChallengeInfo {
+        ChallengeInfo {
+            uuid: self.uuid,
+            challenge_type: self.challenge_type,
+            mode: self.mode,
+            party: self.party.clone(),
+            party_changed: self.party_changed,
+            stage: self.stage,
+            stage_attempt: self.stage_attempt,
+            status: self.status(),
+            created_unix_ms: self.created_unix_ms,
+        }
+    }
+
     /// The challenge's published status.
     #[must_use]
     pub fn status(&self) -> ChallengeStatus {
@@ -500,11 +538,16 @@ mod tests {
         let mut processing = Processing::new(config(2));
         assert!(processing.settled());
 
-        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        processing.push(
+            trigger(3, Stage::TobMaiden),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
         assert_eq!(
             processing.active(),
             Some(&ProcessingRun {
                 trigger: trigger(3, Stage::TobMaiden),
+                info: ChallengeState::default().challenge_info(),
                 attempts: 0,
                 retriable: true,
                 state: ProcessingState::Idle {
@@ -514,14 +557,22 @@ mod tests {
         );
         assert!(!processing.settled());
 
-        processing.push(trigger(7, Stage::TobBloat), Timestamp::from_millis(200));
+        processing.push(
+            trigger(7, Stage::TobBloat),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(200),
+        );
         assert_eq!(processing.active().unwrap().trigger.seq(), JournalSeq(3));
     }
 
     #[test]
     fn processing_start_only_responds_to_the_active_trigger() {
         let mut processing = Processing::new(config(2));
-        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        processing.push(
+            trigger(3, Stage::TobMaiden),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
 
         processing.start(JournalSeq(9), Timestamp::from_millis(150));
         assert_eq!(processing.active().unwrap().attempts, 0);
@@ -540,8 +591,16 @@ mod tests {
     #[test]
     fn processing_finish_records_status_and_starts_next() {
         let mut processing = Processing::new(config(2));
-        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
-        processing.push(trigger(7, Stage::TobBloat), Timestamp::from_millis(200));
+        processing.push(
+            trigger(3, Stage::TobMaiden),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
+        processing.push(
+            trigger(7, Stage::TobBloat),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(200),
+        );
         processing.start(JournalSeq(3), Timestamp::from_millis(150));
 
         processing.finish(
@@ -554,6 +613,7 @@ mod tests {
             processing.active(),
             Some(&ProcessingRun {
                 trigger: trigger(7, Stage::TobBloat),
+                info: ChallengeState::default().challenge_info(),
                 attempts: 0,
                 retriable: true,
                 state: ProcessingState::Idle {
@@ -566,8 +626,16 @@ mod tests {
     #[test]
     fn processing_failed_backs_off_until_exhausted() {
         let mut processing = Processing::new(config(2));
-        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
-        processing.push(trigger(7, Stage::TobBloat), Timestamp::from_millis(200));
+        processing.push(
+            trigger(3, Stage::TobMaiden),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
+        processing.push(
+            trigger(7, Stage::TobBloat),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(200),
+        );
 
         processing.start(JournalSeq(3), Timestamp::from_millis(150));
         processing.finish(
@@ -602,7 +670,11 @@ mod tests {
     #[test]
     fn processing_non_retriable_failure_exhausts_immediately() {
         let mut processing = Processing::new(config(5));
-        processing.push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        processing.push(
+            trigger(3, Stage::TobMaiden),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
         processing.start(JournalSeq(3), Timestamp::from_millis(150));
 
         processing.finish(
@@ -645,9 +717,11 @@ mod tests {
             ..ChallengeState::default()
         };
 
-        state
-            .processing
-            .push(trigger(3, Stage::TobMaiden), Timestamp::from_millis(100));
+        state.processing.push(
+            trigger(3, Stage::TobMaiden),
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
         state
             .processing
             .start(JournalSeq(3), Timestamp::from_millis(150));

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -310,6 +310,26 @@ impl ClientStageStream {
     }
 }
 
+/// Challenge state snapshot at the time of a processing run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChallengeInfo {
+    pub uuid: Uuid,
+    pub challenge_type: ChallengeType,
+    pub mode: ChallengeMode,
+    pub party: Vec<String>,
+    pub party_changed: bool,
+    pub stage: Stage,
+    pub stage_attempt: Option<u32>,
+    pub status: ChallengeStatus,
+    pub created_unix_ms: u64,
+}
+
+impl ChallengeInfo {
+    pub fn scale(&self) -> i16 {
+        i16::try_from(self.party.len()).expect("scale fits in a smallint")
+    }
+}
+
 /// Result that a completed processing run feeds back into the challenge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ProcessingPayload {

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -10,7 +10,7 @@
 mod scenarios;
 
 use core::time::Duration;
-use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::ops::Index;
 use std::slice;
 use std::sync::{Arc, Mutex};
@@ -36,7 +36,7 @@ use super::core::state::{
     ChallengePhase, ChallengeState, Processing, PublishedClient, Snapshot, Trigger,
 };
 use super::core::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, MsgId, ProcessingError,
+    ChallengeMode, ChallengeStatus, ChallengeType, ClientId, JournalSeq, MsgId, ProcessingError,
     ProcessingPayload, RecordingType, ReportedTimes, SessionToken, Stage, StageExt, StageStatus,
     UserId, Uuid,
 };
@@ -1143,8 +1143,12 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
             }
         }
 
+        let max_attempts = config.processing.max_attempts;
         let mut seals = Vec::new();
         let mut trigger_seqs = HashSet::new();
+        let mut outstanding = HashSet::new();
+        let mut attempts: HashMap<JournalSeq, u32> = HashMap::new();
+        let mut finish_seq = None;
         let mut joined = HashSet::new();
         let mut stage = None;
         let mut terminated = false;
@@ -1170,14 +1174,17 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
                 } => {
                     stage = Some(*initial_stage);
                     trigger_seqs.insert(entry.seq);
+                    outstanding.insert(entry.seq);
                 }
-                LifecycleEvent::ChallengeTerminated { .. } | LifecycleEvent::ModeChanged { .. } => {
+                LifecycleEvent::ModeChanged { .. } => {
                     trigger_seqs.insert(entry.seq);
+                    outstanding.insert(entry.seq);
                 }
                 // Only a real stage change triggers processing.
                 LifecycleEvent::StageStarted { stage: started } => {
                     if stage != Some(*started) {
                         trigger_seqs.insert(entry.seq);
+                        outstanding.insert(entry.seq);
                     }
                     stage = Some(*started);
                 }
@@ -1185,6 +1192,7 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
                 LifecycleEvent::ClientJoined { client_id, .. } => {
                     if joined.insert(*client_id) {
                         trigger_seqs.insert(entry.seq);
+                        outstanding.insert(entry.seq);
                     }
                 }
                 LifecycleEvent::StageSealed { stage, attempt, .. } => {
@@ -1194,17 +1202,51 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
                     );
                     seals.push((*stage, *attempt));
                     trigger_seqs.insert(entry.seq);
+                    outstanding.insert(entry.seq);
                 }
-                LifecycleEvent::ProcessingStarted { trigger }
-                | LifecycleEvent::ProcessingFinished { trigger, .. }
-                | LifecycleEvent::ProcessingFailed { trigger, .. }
-                | LifecycleEvent::ProcessingTimedOut { trigger } => {
+                LifecycleEvent::ProcessingStarted { trigger } => {
                     assert!(
                         trigger_seqs.contains(trigger),
                         "processing entry references no trigger: {uuid}",
                     );
+                    *attempts.entry(*trigger).or_default() += 1;
+                }
+                LifecycleEvent::ProcessingFinished { trigger, .. } => {
+                    assert!(
+                        trigger_seqs.contains(trigger),
+                        "processing entry references no trigger: {uuid}",
+                    );
+                    outstanding.remove(trigger);
+                }
+                LifecycleEvent::ProcessingFailed { trigger, error } => {
+                    assert!(
+                        trigger_seqs.contains(trigger),
+                        "processing entry references no trigger: {uuid}",
+                    );
+                    let exhausted = !error.retriable
+                        || attempts.get(trigger).copied().unwrap_or(0) >= max_attempts;
+                    if exhausted {
+                        outstanding.remove(trigger);
+                    }
+                }
+                LifecycleEvent::ProcessingTimedOut { trigger } => {
+                    assert!(
+                        trigger_seqs.contains(trigger),
+                        "processing entry references no trigger: {uuid}",
+                    );
+                    if attempts.get(trigger).copied().unwrap_or(0) >= max_attempts {
+                        outstanding.remove(trigger);
+                    }
                 }
                 _ => {}
+            }
+
+            // The first entry to leave a terminated, settled pipeline queues
+            // the finish under its seq.
+            if terminated && outstanding.is_empty() && finish_seq.is_none() {
+                finish_seq = Some(entry.seq);
+                trigger_seqs.insert(entry.seq);
+                outstanding.insert(entry.seq);
             }
         }
     }

--- a/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
@@ -355,13 +355,13 @@ async fn finalization_waits_for_processing_to_finish_after_termination() {
                 14,
                 6_000,
                 Cause::Deadline(DeadlineKind::ProcessingDue),
-                started(12)
+                started(13)
             ),
             entry(
                 15,
                 6_000,
-                processing(12),
-                finished(12, ProcessingPayload::None),
+                processing(13),
+                finished(13, ProcessingPayload::None),
             ),
         ],
     );
@@ -525,13 +525,13 @@ async fn late_commands_post_termination_while_processing() {
                 14,
                 6_000,
                 Cause::Deadline(DeadlineKind::ProcessingDue),
-                started(12)
+                started(13)
             ),
             entry(
                 15,
                 6_000,
-                processing(12),
-                finished(12, ProcessingPayload::None),
+                processing(13),
+                finished(13, ProcessingPayload::None),
             ),
         ],
     );
@@ -768,7 +768,7 @@ fn final_processing_concludes_exactly_once_on_resume() {
     assert!(collector.is_deleted(uuid));
     assert_eq!(
         collector.journal(uuid).last().unwrap().event,
-        finished(10, ProcessingPayload::None),
+        finished(11, ProcessingPayload::None),
     );
     assert_eq!(second.requests().len(), 2);
 }

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -115,7 +115,13 @@ async fn serve(config: LifecycleConfig) {
             .await
             .expect("failed to connect to Postgres");
         tracing::info!("postgres_connected");
-        coordinator = coordinator.with_processor(Arc::new(processing::Pipeline::new(db, store)));
+        let repository_uri =
+            std::env::var("BLERT_DATA_REPOSITORY").expect("BLERT_DATA_REPOSITORY must be set");
+        let repository = repository::DataRepository::from_uri(&repository_uri)
+            .await
+            .expect("failed to open the data repository");
+        coordinator =
+            coordinator.with_processor(Arc::new(processing::Pipeline::new(db, store, repository)));
     }
     let coordinator = Arc::new(coordinator);
     coordinator.start_scan(CLAIM_SCAN_INTERVAL);

--- a/challenge-harder/src/merging/mod.rs
+++ b/challenge-harder/src/merging/mod.rs
@@ -158,6 +158,11 @@ impl MergedEvents {
         self.metadata.last_tick < self.metadata.queryable_until
     }
 
+    /// Consumes the timeline, returning its events in tick order.
+    pub fn into_events(self) -> Vec<Event> {
+        self.events
+    }
+
     /// Limits the accuracy and queryability of the event stream to `tick`, exclusive.
     pub fn restrict_accuracy_to(&mut self, tick: u32) {
         self.metadata.accurate_until = self.metadata.accurate_until.min(tick);

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -3,18 +3,14 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, PlayerId, PrimaryMeleeGear, RecordingType, Stage, UserId, Uuid,
+    ChallengeMode, ChallengeStatus, PlayerId, PrimaryMeleeGear, RecordingType, Stage, UserId,
 };
 use crate::players::normalize_rsn;
 
 use super::{ChallengeInfo, db};
 
 /// Initializes a new challenge.
-pub async fn create(
-    txn: &mut db::Transaction,
-    uuid: Uuid,
-    info: &ChallengeInfo,
-) -> Result<(), db::Error> {
+pub async fn create(txn: &mut db::Transaction, info: &ChallengeInfo) -> Result<(), db::Error> {
     let start_time = UNIX_EPOCH + Duration::from_millis(info.created_unix_ms);
     let row = txn
         .query_one(
@@ -22,7 +18,7 @@ pub async fn create(
              VALUES ($1, $2, $3, $4, $5, $6, $7)
              RETURNING id",
             &[
-                &uuid,
+                &info.uuid,
                 &(info.challenge_type as i16),
                 &(info.mode as i16),
                 &info.scale(),

--- a/challenge-harder/src/processing/interpret.rs
+++ b/challenge-harder/src/processing/interpret.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 
 use crate::item::{self, ItemDelta};
-use crate::lifecycle::core::types::{ClientStageStream, PrimaryMeleeGear, Stage, Uuid};
+use crate::lifecycle::core::types::{ClientStageStream, PrimaryMeleeGear, Uuid};
 use crate::merging::{self, MergedEvents};
 use crate::proto::{Event, event};
 
@@ -161,6 +161,26 @@ pub struct InterpretOutput {
     pub(super) ctx: StageContext,
 }
 
+impl InterpretOutput {
+    /// Consumes the output, returning the kept events in tick order.
+    pub(super) fn into_kept_events(self) -> Vec<Event> {
+        let mut kept = self.kept.into_iter().peekable();
+        self.events
+            .into_events()
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, event)| {
+                if kept.peek() == Some(&index) {
+                    kept.next();
+                    Some(event)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
 /// A failure to interpret a stage's recorded data.
 #[derive(Debug)]
 pub enum InterpretError {
@@ -170,19 +190,19 @@ pub enum InterpretError {
 
 /// Processes a stage's raw events into a canonical timeline.
 pub fn interpret(
-    uuid: Uuid,
     challenge: ChallengeInfo,
-    stage: Stage,
     records: Vec<ClientStageStream>,
     processor: &mut dyn ChallengeProcessor,
 ) -> Result<InterpretOutput, InterpretError> {
-    let mut events = merging::merge(uuid, stage, records).ok_or(InterpretError::NoData)?;
-
     let ChallengeInfo {
+        uuid,
+        stage,
         party,
         party_changed,
         ..
     } = challenge;
+
+    let mut events = merging::merge(uuid, stage, records).ok_or(InterpretError::NoData)?;
 
     resolve_party_indices(uuid, &party, &mut events);
 
@@ -316,7 +336,15 @@ fn try_determine_gear(player: &event::Player) -> Option<PrimaryMeleeGear> {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+    use prost::Message;
+
+    use super::super::db;
     use super::*;
+    use crate::lifecycle::core::types::{
+        ChallengeMode, ChallengeStatus, ChallengeType, ClientId, Stage,
+    };
+    use crate::proto::ChallengeEvents;
     use crate::proto::event::player::EquipmentSlot;
 
     fn context() -> StageContext {
@@ -554,5 +582,95 @@ mod tests {
         );
         let gear: Vec<_> = ctx.players().iter().map(|p| p.gear).collect();
         assert_eq!(gear, [None, None]);
+    }
+
+    #[test]
+    fn into_kept_events_returns_the_processors_kept_subsequence() {
+        struct KeepEvenMarkers;
+
+        #[async_trait::async_trait]
+        impl ChallengeProcessor for KeepEvenMarkers {
+            fn process_challenge_event(
+                &mut self,
+                _ctx: &mut StageContext,
+                events: &mut EventCursor<'_>,
+            ) -> bool {
+                events.current().x_coord % 2 == 0
+            }
+
+            async fn on_create(&mut self, _txn: &db::Transaction) -> Result<(), db::Error> {
+                Ok(())
+            }
+
+            async fn on_stage_finished(
+                &mut self,
+                _txn: &db::Transaction,
+                _ctx: &mut StageContext,
+                _stage: Stage,
+                _events: &MergedEvents,
+            ) -> Result<(), db::Error> {
+                Ok(())
+            }
+
+            async fn on_finish(
+                &mut self,
+                _txn: &db::Transaction,
+                _final_ticks: u32,
+            ) -> Result<(), db::Error> {
+                Ok(())
+            }
+
+            fn custom_data(&self) -> Option<serde_json::Value> {
+                None
+            }
+
+            fn has_fully_recorded_up_to(&self, _stage: Stage) -> bool {
+                false
+            }
+        }
+
+        let marker = |tick: u32, x_coord: i32| Event {
+            tick,
+            x_coord,
+            ..Default::default()
+        };
+        let message = ChallengeEvents {
+            events: vec![
+                marker(0, 4),
+                marker(0, 7),
+                marker(1, 2),
+                marker(2, 9),
+                marker(2, 6),
+                marker(3, 1),
+            ],
+            ..Default::default()
+        };
+        let info = ChallengeInfo {
+            uuid: "a8cb035f-410a-45de-a4d3-2b0a5d8b464d".parse().unwrap(),
+            challenge_type: ChallengeType::Mokhaiotl,
+            mode: ChallengeMode::NoMode,
+            party: vec!["1Ogp".to_string()],
+            party_changed: false,
+            stage: Stage::MokhaiotlDelve1,
+            stage_attempt: None,
+            status: ChallengeStatus::InProgress,
+            created_unix_ms: 0,
+        };
+
+        let output = interpret(
+            info,
+            vec![ClientStageStream::Events {
+                client_id: ClientId(1),
+                events: Bytes::from(message.encode_to_vec()),
+            }],
+            &mut KeepEvenMarkers,
+        )
+        .unwrap();
+
+        assert_eq!(output.kept, vec![0, 2, 4]);
+        assert_eq!(
+            output.into_kept_events(),
+            vec![marker(0, 4), marker(1, 2), marker(2, 6)],
+        );
     }
 }

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -6,10 +6,12 @@ use async_trait::async_trait;
 
 use crate::lifecycle::core::state::Trigger;
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, ChallengeType, PlayerId, PrimaryMeleeGear, ProcessingError,
-    ProcessingPayload, Stage, Uuid,
+    PlayerId, PrimaryMeleeGear, ProcessingError, ProcessingPayload,
 };
+use crate::repository::DataRepository;
 use crate::store::Store;
+
+pub use crate::lifecycle::core::types::ChallengeInfo;
 
 pub mod db;
 
@@ -21,25 +23,6 @@ mod persist;
 mod split;
 mod stage;
 mod stats;
-
-/// Challenge state at the time a run is triggered.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChallengeInfo {
-    pub challenge_type: ChallengeType,
-    pub mode: ChallengeMode,
-    pub party: Vec<String>,
-    pub party_changed: bool,
-    pub stage: Stage,
-    pub status: ChallengeStatus,
-    pub challenge_ticks: u32,
-    pub created_unix_ms: u64,
-}
-
-impl ChallengeInfo {
-    pub fn scale(&self) -> i16 {
-        i16::try_from(self.party.len()).expect("scale fits in a smallint")
-    }
-}
 
 /// A challenge party member.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -61,7 +44,6 @@ pub struct StoredState {
 /// A request to process the data demanded by a run trigger.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcessingRequest {
-    pub uuid: Uuid,
     pub trigger: Trigger,
     pub challenge: ChallengeInfo,
 }
@@ -79,11 +61,16 @@ pub trait StageProcessor: Send + Sync + 'static {
 pub struct Pipeline {
     db: db::Postgres,
     store: Arc<Store>,
+    repository: DataRepository,
 }
 
 impl Pipeline {
-    pub fn new(db: db::Postgres, store: Arc<Store>) -> Pipeline {
-        Pipeline { db, store }
+    pub fn new(db: db::Postgres, store: Arc<Store>, repository: DataRepository) -> Pipeline {
+        Pipeline {
+            db,
+            store,
+            repository,
+        }
     }
 }
 
@@ -93,20 +80,17 @@ impl StageProcessor for Pipeline {
         &self,
         request: ProcessingRequest,
     ) -> Result<ProcessingPayload, ProcessingError> {
+        let uuid = request.challenge.uuid;
         tracing::info!(
-            uuid = %request.uuid,
+            %uuid,
             trigger = ?request.trigger,
             "processing_started",
         );
 
-        let mut txn = match self
-            .db
-            .start_transaction(request.uuid, request.trigger.seq())
-            .await
-        {
+        let mut txn = match self.db.start_transaction(uuid, request.trigger.seq()).await {
             Ok(txn) => txn,
             Err(db::Error::AlreadyApplied(payload)) => {
-                tracing::debug!(uuid = %request.uuid, seq = ?request.trigger.seq(), "processing_step_already_applied");
+                tracing::debug!(%uuid, seq = ?request.trigger.seq(), "processing_step_already_applied");
                 return Ok(payload);
             }
             Err(error) => return Err(error.into()),
@@ -114,7 +98,7 @@ impl StageProcessor for Pipeline {
 
         let (payload, custom_data) = match request.trigger {
             Trigger::Create { .. } => {
-                challenge::create(&mut txn, request.uuid, &request.challenge).await?;
+                challenge::create(&mut txn, &request.challenge).await?;
                 (ProcessingPayload::None, None)
             }
             Trigger::Recorder {
@@ -137,16 +121,8 @@ impl StageProcessor for Pipeline {
                 challenge::finish(&txn, &request.challenge).await?;
                 (ProcessingPayload::None, None)
             }
-            Trigger::Stage { stage, attempt, .. } => {
-                stage::process(
-                    &self.store,
-                    &txn,
-                    &request.challenge,
-                    request.uuid,
-                    stage,
-                    attempt,
-                )
-                .await?
+            Trigger::Stage { .. } => {
+                stage::process(&self.store, &self.repository, &txn, &request.challenge).await?
             }
         };
         txn.commit(&payload, custom_data.as_ref()).await?;

--- a/challenge-harder/src/processing/persist.rs
+++ b/challenge-harder/src/processing/persist.rs
@@ -6,6 +6,7 @@ use crate::lifecycle::core::types::{
     PrimaryMeleeGear, ProcessingError, ProcessingPayload, Stage, StageStatus,
 };
 use crate::proto::{Event, event};
+use crate::repository::DataRepository;
 use crate::skill::SkillLevel;
 
 use super::challenge_processor::ChallengeProcessor;
@@ -19,9 +20,8 @@ use super::{ChallengeInfo, StoredPlayerInfo, StoredState};
 /// Returns the payload to be sent back to the challenge.
 pub(super) async fn persist(
     txn: &db::Transaction,
+    repository: &DataRepository,
     challenge: &ChallengeInfo,
-    stage: Stage,
-    _attempt: Option<u32>,
     stored: &StoredState,
     result: Result<InterpretOutput, InterpretError>,
     processor: &mut dyn ChallengeProcessor,
@@ -30,7 +30,7 @@ pub(super) async fn persist(
 
     if let Ok(mut output) = result {
         processor
-            .on_stage_finished(txn, &mut output.ctx, stage, &output.events)
+            .on_stage_finished(txn, &mut output.ctx, challenge.stage, &output.events)
             .await?;
 
         let splits = write_splits(
@@ -43,16 +43,33 @@ pub(super) async fn persist(
         .await?;
         update_personal_bests(txn, challenge, &stored.players, &splits).await?;
 
-        tokio::try_join!(
-            update_players(txn, stage, &output.ctx, &stored.players),
+        let ((), (), queryable_events, ()) = tokio::try_join!(
+            update_players(txn, challenge.stage, &output.ctx, &stored.players),
             update_player_stats(txn, &output.ctx, &stored.players),
-            write_queryable_events(txn, challenge, stage, &output, &stored.players),
-            update_challenge_row(
-                txn,
-                challenge.challenge_ticks + output.events.last_tick(),
-                output.ctx.deaths().len(),
-            )
+            write_queryable_events(txn, challenge, &output, &stored.players),
+            update_challenge_row(txn, output.events.last_tick(), output.ctx.deaths().len())
         )?;
+
+        let queryable_until = output.events.queryable_until();
+        let events = output.into_kept_events();
+        let total_events = events.len();
+        repository
+            .save_stage_events(
+                challenge.uuid,
+                challenge.stage,
+                challenge.stage_attempt,
+                &challenge.party,
+                events,
+            )
+            .await?;
+        tracing::info!(
+            uuid = %challenge.uuid,
+            stage = ?challenge.stage,
+            total_events,
+            queryable_events,
+            queryable_until,
+            "challenge_stage_events_saved",
+        );
     }
 
     Ok(payload)
@@ -360,15 +377,15 @@ async fn update_personal_bests(
 
 async fn update_challenge_row(
     txn: &db::Transaction,
-    challenge_ticks: u32,
+    stage_ticks: u32,
     new_deaths: usize,
 ) -> Result<(), db::Error> {
     txn.execute(
         "UPDATE challenges
-         SET challenge_ticks = $1, total_deaths = total_deaths + $2
+         SET challenge_ticks = challenge_ticks + $1, total_deaths = total_deaths + $2
          WHERE id = $3",
         &[
-            &challenge_ticks.cast_signed(),
+            &stage_ticks.cast_signed(),
             &i32::try_from(new_deaths).expect("death count fits in an integer"),
             &txn.challenge_id(),
         ],
@@ -398,7 +415,6 @@ struct QueryableEvent {
 async fn write_queryable_events(
     txn: &db::Transaction,
     challenge: &ChallengeInfo,
-    stage: Stage,
     output: &InterpretOutput,
     players: &[StoredPlayerInfo],
 ) -> Result<usize, db::Error> {
@@ -459,7 +475,7 @@ async fn write_queryable_events(
                        custom_int_1, custom_int_2, custom_short_1, custom_short_2)",
         &[
             &txn.challenge_id(),
-            &(stage as i16),
+            &(challenge.stage as i16),
             &(challenge.mode as i16),
             &event_types,
             &ticks,

--- a/challenge-harder/src/processing/stage.rs
+++ b/challenge-harder/src/processing/stage.rs
@@ -11,8 +11,9 @@
 use crate::lifecycle::challenge::StoreError;
 use crate::lifecycle::core::types::{
     ChallengeType, ClientStageStream, PlayerId, PrimaryMeleeGear, ProcessingError,
-    ProcessingPayload, Stage, Uuid,
+    ProcessingPayload,
 };
+use crate::repository::DataRepository;
 use crate::store::Store;
 
 use super::challenge_processor::ChallengeProcessor;
@@ -25,11 +26,9 @@ use super::{ChallengeInfo, StoredPlayerInfo, StoredState};
 /// Processes a stage's events from its recorded streams.
 pub async fn process(
     store: &Store,
+    repository: &DataRepository,
     txn: &db::Transaction,
     challenge: &ChallengeInfo,
-    uuid: Uuid,
-    stage: Stage,
-    attempt: Option<u32>,
 ) -> Result<(ProcessingPayload, Option<serde_json::Value>), ProcessingError> {
     let mut processor = match challenge.challenge_type {
         ChallengeType::Mokhaiotl => MokhaiotlProcessor,
@@ -41,20 +40,20 @@ pub async fn process(
         | ChallengeType::Inferno
         | ChallengeType::UnknownChallenge => {
             tracing::info!(
-                %uuid,
+                uuid = %challenge.uuid,
                 challenge_type = ?challenge.challenge_type,
-                ?stage,
+                stage = ?challenge.stage,
                 "stage_processing_skipped",
             );
             return Ok((ProcessingPayload::None, None));
         }
     };
 
-    let (stream, stored) = gather(store, txn, challenge, uuid, stage, attempt).await?;
+    let (stream, stored) = gather(store, txn, challenge).await?;
     let info = challenge.clone();
 
     let (result, mut processor) = tokio::task::spawn_blocking(move || {
-        let result = interpret(uuid, info, stage, stream, &mut processor);
+        let result = interpret(info, stream, &mut processor);
         (result, processor)
     })
     .await
@@ -63,16 +62,7 @@ pub async fn process(
         message: format!("interpret task failed: {error}"),
     })?;
 
-    let payload = persist(
-        txn,
-        challenge,
-        stage,
-        attempt,
-        &stored,
-        result,
-        &mut processor,
-    )
-    .await?;
+    let payload = persist(txn, repository, challenge, &stored, result, &mut processor).await?;
     Ok((payload, processor.custom_data()))
 }
 
@@ -81,13 +71,10 @@ async fn gather(
     store: &Store,
     txn: &db::Transaction,
     challenge: &ChallengeInfo,
-    uuid: Uuid,
-    stage: Stage,
-    attempt: Option<u32>,
 ) -> Result<(Vec<ClientStageStream>, StoredState), ProcessingError> {
     let stream = async {
         store
-            .read_stage_stream(uuid, stage, attempt)
+            .read_stage_stream(challenge.uuid, challenge.stage, challenge.stage_attempt)
             .await
             .map_err(|error| ProcessingError {
                 retriable: matches!(error, StoreError::Unavailable(_)),
@@ -147,7 +134,8 @@ mod tests {
     use super::super::interpret::{InterpretError, InterpretOutput};
     use super::*;
     use crate::lifecycle::core::types::{
-        ChallengeMode, ChallengeStatus, ClientId, ServerTicks, StageStatus, StageUpdate,
+        ChallengeMode, ChallengeStatus, ClientId, ServerTicks, Stage, StageStatus, StageUpdate,
+        Uuid,
     };
     use crate::proto::{ChallengeEvents, Event};
 
@@ -190,23 +178,18 @@ mod tests {
 
     fn run_interpret(records: Vec<ClientStageStream>) -> Result<InterpretOutput, InterpretError> {
         let info = ChallengeInfo {
+            uuid: test_uuid(),
             challenge_type: ChallengeType::Mokhaiotl,
             mode: ChallengeMode::NoMode,
             party: vec!["1Ogp".to_string()],
             party_changed: false,
             stage: Stage::MokhaiotlDelve1,
+            stage_attempt: None,
             status: ChallengeStatus::InProgress,
-            challenge_ticks: 0,
             created_unix_ms: 0,
         };
         let mut processor = MokhaiotlProcessor;
-        interpret(
-            test_uuid(),
-            info,
-            Stage::MokhaiotlDelve1,
-            records,
-            &mut processor,
-        )
+        interpret(info, records, &mut processor)
     }
 
     #[test]

--- a/challenge-harder/src/repository/mod.rs
+++ b/challenge-harder/src/repository/mod.rs
@@ -8,7 +8,7 @@
 use futures_util::stream::BoxStream;
 use prost::Message;
 
-use crate::lifecycle::core::types::{Stage, Uuid};
+use crate::lifecycle::core::types::{ProcessingError, Stage, Uuid};
 use crate::proto::{ChallengeData, ChallengeEvents, Event, event};
 
 mod fs;
@@ -27,6 +27,15 @@ pub enum Error {
     Backend(String),
     #[error("stored data failed to decode: {0}")]
     Decode(#[from] prost::DecodeError),
+}
+
+impl From<Error> for ProcessingError {
+    fn from(error: Error) -> Self {
+        ProcessingError {
+            retriable: matches!(error, Error::Backend(_)),
+            message: error.to_string(),
+        }
+    }
 }
 
 /// Raw storage backing the repository. Addressed by paths relative to its root.


### PR DESCRIPTION
Updates stage processing to save all retained events to the configured challenge data repository at the end of its run.

Additionally, rewrites processing triggers to snapshot the state of the challenge at the time of the run to make retries deterministic, and defers triggering the finish processing run until all stage runs have completed to give it the final state.