### PR TITLE
2c2s: Distinguish leave when starting new challenge

### DIFF
--- a/challenge-harder/src/lifecycle/core/command.rs
+++ b/challenge-harder/src/lifecycle/core/command.rs
@@ -102,6 +102,13 @@ pub struct ClientStatusChange {
     pub status: ClientStatus,
 }
 
+/// A client started another challenge, leaving this one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientMovedOn {
+    pub client_id: ClientId,
+}
+
 /// Terminal report from a processing run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -120,6 +127,7 @@ pub enum Command {
     Update(Update),
     Finish(Finish),
     ClientStatus(ClientStatusChange),
+    ClientMovedOn(ClientMovedOn),
     Processed(Processed),
     DeadlineFired(Deadline),
 }

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -5,7 +5,8 @@
 //! applied.
 
 use super::command::{
-    ClientStatus, ClientStatusChange, Command, Create, Finish, Join, Processed, Update,
+    ClientMovedOn, ClientStatus, ClientStatusChange, Command, Create, Finish, Join, Processed,
+    Update,
 };
 use super::deadline::{Deadline, DeadlineKind, LifecycleConfig, next_deadline};
 use super::event::LifecycleEvent;
@@ -36,6 +37,7 @@ pub fn decide(
         Command::Update(u) => update(state, u),
         Command::Finish(f) => finish(state, f),
         Command::ClientStatus(c) => client_status(state, c),
+        Command::ClientMovedOn(m) => client_moved_on(state, m),
         Command::DeadlineFired(d) => deadline_fired(state, config, *d),
         Command::Processed(p) => processed(state, p),
     }
@@ -239,6 +241,16 @@ fn client_status(state: &ChallengeState, change: &ClientStatusChange) -> Vec<Lif
         ClientStatus::Disconnected => vec![LifecycleEvent::ClientRemoved {
             client_id: change.client_id,
         }],
+    }
+}
+
+fn client_moved_on(state: &ChallengeState, moved: &ClientMovedOn) -> Vec<LifecycleEvent> {
+    if state.clients.contains_key(&moved.client_id) {
+        vec![LifecycleEvent::ClientRemoved {
+            client_id: moved.client_id,
+        }]
+    } else {
+        Vec::new()
     }
 }
 
@@ -1167,6 +1179,44 @@ mod tests {
                 &state,
                 &LifecycleConfig::default(),
                 &status_change(CLIENT_B, ClientStatus::Disconnected),
+            ),
+            vec![],
+        );
+    }
+
+    #[test]
+    fn moved_on_client_is_removed() {
+        let state = tob_state(vec![(
+            CLIENT_A,
+            client(Stage::TobMaiden, StageStatus::Started, None),
+        )]);
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &Command::ClientMovedOn(ClientMovedOn {
+                    client_id: CLIENT_A,
+                }),
+            ),
+            vec![LifecycleEvent::ClientRemoved {
+                client_id: CLIENT_A
+            }],
+        );
+    }
+
+    #[test]
+    fn moved_on_for_unknown_client_is_ignored() {
+        let state = tob_state(vec![(
+            CLIENT_A,
+            client(Stage::TobMaiden, StageStatus::Started, None),
+        )]);
+        assert_eq!(
+            decide(
+                &state,
+                &LifecycleConfig::default(),
+                &Command::ClientMovedOn(ClientMovedOn {
+                    client_id: CLIENT_B,
+                }),
             ),
             vec![],
         );

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -27,8 +27,8 @@ use super::challenge::{
 use super::coordinator::Coordinator;
 use super::core::apply::apply;
 use super::core::command::{
-    ClientStatus, ClientStatusChange, Command, Create, Envelope, Finish, Join, StageProgress,
-    Update,
+    ClientMovedOn, ClientStatus, ClientStatusChange, Command, Create, Envelope, Finish, Join,
+    StageProgress, Update,
 };
 use super::core::deadline::LifecycleConfig;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
@@ -485,12 +485,7 @@ impl ChallengeStore for Collector {
         if let Some(previous) = left {
             self.enqueue(
                 previous,
-                Command::ClientStatus(ClientStatusChange {
-                    user_id: create.user_id,
-                    client_id,
-                    session_token: create.session_token.clone(),
-                    status: ClientStatus::Disconnected,
-                }),
+                Command::ClientMovedOn(ClientMovedOn { client_id }),
             )
             .await;
         }

--- a/challenge-harder/src/store/mod.rs
+++ b/challenge-harder/src/store/mod.rs
@@ -15,9 +15,7 @@ use crate::lifecycle::challenge::{
     ChallengeClaim, ChallengeServerUpdate, ChallengeSignal, ChallengeStore, Claim, Rejoin, Start,
     StoreError,
 };
-use crate::lifecycle::core::command::{
-    ClientStatus, ClientStatusChange, Command, Create, Envelope, Join,
-};
+use crate::lifecycle::core::command::{ClientMovedOn, Command, Create, Envelope, Join};
 use crate::lifecycle::core::event::JournalEntry;
 use crate::lifecycle::core::state::{ChallengePhase, ChallengeState, PublishedClient, Snapshot};
 use crate::lifecycle::core::types::{
@@ -423,11 +421,8 @@ impl ChallengeStore for Store {
 
         let join_payload =
             serde_json::to_string(&Command::Join(Join::from(&create))).expect("command serializes");
-        let removal_payload = serde_json::to_string(&Command::ClientStatus(ClientStatusChange {
-            user_id: create.user_id,
+        let removal_payload = serde_json::to_string(&Command::ClientMovedOn(ClientMovedOn {
             client_id: create.client_id,
-            session_token: create.session_token.clone(),
-            status: ClientStatus::Disconnected,
         }))
         .expect("command serializes");
         let create_payload =

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -1366,11 +1366,8 @@ async fn start_supersedes_a_finishing_incumbent() {
 
 /// The removal command a start queues to a challenge its client left.
 fn removal_command(create: &Create) -> Command {
-    Command::ClientStatus(ClientStatusChange {
-        user_id: create.user_id,
+    Command::ClientMovedOn(ClientMovedOn {
         client_id: create.client_id,
-        session_token: create.session_token.clone(),
-        status: ClientStatus::Disconnected,
     })
 }
 


### PR DESCRIPTION
When a client sends a start for a new challenge while still pointed to an existing one, it sends a leave command to their inbox. Previously, this was a standard disconnected status. The issue with that is that it relies on the client's session token matching, so if the new challenge begins on a newer connection, the leave would be ignored. This makes the leave a distinct command type that applies unconditionally.