### PR TITLE
2c2s: Implement DB finialization

### DIFF
--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -965,7 +965,7 @@ mod tests {
                     seq: JournalSeq(3),
                     at: Timestamp::ZERO,
                     caused_by: Cause::Command(MsgId::sequence(2)),
-                    event: LifecycleEvent::ChallengeTerminated { empty: false },
+                    event: LifecycleEvent::ChallengeTerminated,
                 },
             ],
         );
@@ -977,7 +977,9 @@ mod tests {
             mode: ChallengeMode::TobRegular,
             party: vec!["a".into()],
             party_changed: false,
-            phase: PhaseState::Terminated,
+            phase: PhaseState::Terminated {
+                finished_unix_ms: 0,
+            },
             reported_times: None,
             stage: Stage::TobMaiden,
             stage_attempt: None,
@@ -1086,12 +1088,7 @@ mod tests {
                 times: None,
             },
         ));
-        journal.push(journaled(
-            3,
-            500,
-            2,
-            LifecycleEvent::ChallengeTerminated { empty: false },
-        ));
+        journal.push(journaled(3, 500, 2, LifecycleEvent::ChallengeTerminated));
 
         // The queued command is never processed.
         let outcome = run_scripted(vec![], journal, vec![finish_command()], false).await;
@@ -1111,7 +1108,9 @@ mod tests {
             mode: ChallengeMode::TobRegular,
             party: vec!["a".into()],
             party_changed: false,
-            phase: PhaseState::Terminated,
+            phase: PhaseState::Terminated {
+                finished_unix_ms: 0,
+            },
             reported_times: None,
             stage: Stage::TobMaiden,
             stage_attempt: None,
@@ -1179,12 +1178,7 @@ mod tests {
                         times: None,
                     },
                 ),
-                journaled(
-                    3,
-                    0,
-                    2,
-                    LifecycleEvent::ChallengeTerminated { empty: false },
-                ),
+                journaled(3, 0, 2, LifecycleEvent::ChallengeTerminated,),
             ],
         );
         assert_eq!(outcome.log.deleted.lock().unwrap().len(), 1);
@@ -1222,7 +1216,7 @@ mod tests {
                 seq: JournalSeq(3),
                 at: Timestamp::from_millis(1_000 + window),
                 caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-                event: LifecycleEvent::ChallengeTerminated { empty: false },
+                event: LifecycleEvent::ChallengeTerminated,
             }],
         );
         assert_eq!(outcome.log.deleted.lock().unwrap().len(), 1);
@@ -1254,7 +1248,7 @@ mod tests {
                 seq: JournalSeq(4),
                 at: Timestamp::from_millis(window * 3),
                 caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-                event: LifecycleEvent::ChallengeTerminated { empty: false },
+                event: LifecycleEvent::ChallengeTerminated,
             }],
         );
         assert_eq!(outcome.log.deleted.lock().unwrap().len(), 1);

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -161,8 +161,16 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
         LifecycleEvent::ClientRemoved { client_id } => {
             state.clients.remove(&client_id);
         }
-        LifecycleEvent::ChallengeTerminated { empty: _ } => {
-            state.phase = PhaseState::Terminated;
+        LifecycleEvent::ChallengeTerminated => {
+            // Prefer a real time from a streamed command, falling back to the
+            // relative time since challenge start, which excludes downtime.
+            let finished_unix_ms = match entry.caused_by {
+                Cause::Command(id) => id.unix_millis(),
+                Cause::Deadline(_) | Cause::Processing(_) => {
+                    state.created_unix_ms.saturating_add(entry.at.as_millis())
+                }
+            };
+            state.phase = PhaseState::Terminated { finished_unix_ms };
         }
         LifecycleEvent::ModeChanged { mode } => {
             state.mode = mode;
@@ -334,7 +342,7 @@ mod tests {
                     uuid,
                     challenge_type,
                     mode,
-                    party: vec!["Skitter".into()],
+                    party: vec!["aSaradomin".into()],
                     stage,
                 },
             ),
@@ -376,7 +384,7 @@ mod tests {
         let state = created_tob_state();
         assert_eq!(state.challenge_type, ChallengeType::Tob);
         assert_eq!(state.mode, ChallengeMode::TobRegular);
-        assert_eq!(state.party, vec!["Skitter".to_string()]);
+        assert_eq!(state.party, vec!["aSaradomin".to_string()]);
         assert_eq!(state.stage, Stage::TobMaiden);
         assert_eq!(state.stage_attempt, None);
         assert_eq!(state.stage_status, StageStatus::Entered);
@@ -841,17 +849,58 @@ mod tests {
     }
 
     #[test]
-    fn challenge_terminated_sets_status() {
+    fn challenge_terminated_uses_time_from_the_causing_command() {
         let mut state = created_tob_state();
         apply(
             &mut state,
-            entry(
-                9_000,
-                2,
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            JournalEntry {
+                seq: JournalSeq(2),
+                at: Timestamp::from_millis(9_000),
+                caused_by: Cause::Command("1785693975535-0".parse().unwrap()),
+                event: LifecycleEvent::ChallengeTerminated,
+            },
         );
-        assert_eq!(state.phase, PhaseState::Terminated);
+        assert_eq!(
+            state.phase,
+            PhaseState::Terminated {
+                finished_unix_ms: 1_785_693_975_535,
+            },
+        );
+    }
+
+    #[test]
+    fn deadline_termination_uses_time_relative_to_start() {
+        let mut state = ChallengeState::default();
+        apply(
+            &mut state,
+            JournalEntry {
+                seq: JournalSeq(0),
+                at: Timestamp::from_millis(0),
+                caused_by: Cause::Command("1785693558201-0".parse().unwrap()),
+                event: LifecycleEvent::ChallengeCreated {
+                    uuid: Uuid::from_u128(1),
+                    challenge_type: ChallengeType::Tob,
+                    mode: ChallengeMode::TobRegular,
+                    party: vec!["1Ogp".into()],
+                    stage: Stage::TobMaiden,
+                },
+            },
+        );
+        apply(
+            &mut state,
+            JournalEntry {
+                seq: JournalSeq(1),
+                at: Timestamp::from_millis(417_333),
+                caused_by: Cause::Deadline(DeadlineKind::ChallengeEnd),
+                event: LifecycleEvent::ChallengeTerminated,
+            },
+        );
+        assert_eq!(
+            state.phase,
+            PhaseState::Terminated {
+                finished_unix_ms: 1_785_693_975_534,
+            },
+        );
     }
 
     #[test]
@@ -938,6 +987,8 @@ mod tests {
             max_attempts: 2,
             run_timeout: Duration::from_secs(10),
             retry_backoff: Duration::from_secs(3),
+            finish_max_attempts: 4,
+            finish_retry_backoff: Duration::from_secs(9),
         });
         state
     }
@@ -1016,6 +1067,8 @@ mod tests {
                 max_attempts: 2,
                 run_timeout: Duration::from_secs(10),
                 retry_backoff: Duration::from_secs(3),
+                finish_max_attempts: 4,
+                finish_retry_backoff: Duration::from_secs(9),
             }),
             ..ChallengeState::default()
         };
@@ -1044,7 +1097,7 @@ mod tests {
                 seq: JournalSeq(1),
                 at: Timestamp::from_millis(200),
                 caused_by: Cause::Command(MsgId::sequence(1)),
-                event: LifecycleEvent::ChallengeTerminated { empty: false },
+                event: LifecycleEvent::ChallengeTerminated,
             },
         );
 
@@ -1110,12 +1163,14 @@ mod tests {
                 uuid: Uuid::from_u128(0xb1e47),
                 challenge_type: ChallengeType::Tob,
                 mode: ChallengeMode::TobRegular,
-                party: vec!["Skitter".into()],
+                party: vec!["aSaradomin".into()],
                 party_changed: false,
                 stage: Stage::TobMaiden,
                 stage_attempt: None,
                 status: ChallengeStatus::InProgress,
                 created_unix_ms: 0,
+                reported_times: None,
+                finished_unix_ms: None,
             },
         );
 
@@ -1144,12 +1199,14 @@ mod tests {
                 uuid: Uuid::from_u128(0xb1e47),
                 challenge_type: ChallengeType::Tob,
                 mode: ChallengeMode::TobHard,
-                party: vec!["Skitter".into()],
+                party: vec!["aSaradomin".into()],
                 party_changed: true,
                 stage: Stage::TobMaiden,
                 stage_attempt: None,
                 status: ChallengeStatus::InProgress,
                 created_unix_ms: 0,
+                reported_times: None,
+                finished_unix_ms: None,
             },
         );
     }
@@ -1161,10 +1218,27 @@ mod tests {
         apply(
             &mut state,
             entry(
-                6_000,
+                5_500,
                 4,
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ClientFinished {
+                    client_id: CLIENT,
+                    definitive: true,
+                    soft: false,
+                    times: Some(ReportedTimes {
+                        challenge: 1_437,
+                        overall: 1_500,
+                    }),
+                },
             ),
+        );
+        apply(
+            &mut state,
+            JournalEntry {
+                seq: JournalSeq(6),
+                at: Timestamp::from_millis(6_000),
+                caused_by: Cause::Command("1785693975535-0".parse().unwrap()),
+                event: LifecycleEvent::ChallengeTerminated,
+            },
         );
 
         // No finish is queued until the stage run completes.
@@ -1195,7 +1269,25 @@ mod tests {
 
         let run = state.processing.active().expect("exists");
         assert_eq!(run.trigger, Trigger::Finish { seq: JournalSeq(9) });
-        assert_eq!(run.info.status, ChallengeStatus::Wiped);
+        assert_eq!(
+            run.info,
+            ChallengeInfo {
+                uuid: Uuid::from_u128(0xb1e47),
+                challenge_type: ChallengeType::Tob,
+                mode: ChallengeMode::TobRegular,
+                party: vec!["aSaradomin".into()],
+                party_changed: false,
+                stage: Stage::TobMaiden,
+                stage_attempt: None,
+                status: ChallengeStatus::Wiped,
+                created_unix_ms: 0,
+                reported_times: Some(ReportedTimes {
+                    challenge: 1_437,
+                    overall: 1_500,
+                }),
+                finished_unix_ms: Some(1_785_693_975_535),
+            },
+        );
 
         apply(
             &mut state,
@@ -1314,11 +1406,7 @@ mod tests {
 
         apply(
             &mut state,
-            entry(
-                9_000,
-                4,
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(9_000, 4, LifecycleEvent::ChallengeTerminated),
         );
         assert_eq!(state.status(), ChallengeStatus::Reset);
     }
@@ -1562,11 +1650,7 @@ mod tests {
         );
         apply(
             &mut state,
-            entry(
-                11_000,
-                7,
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(11_000, 7, LifecycleEvent::ChallengeTerminated),
         );
 
         // The final status falls back to the challenge's reported progress

--- a/challenge-harder/src/lifecycle/core/deadline.rs
+++ b/challenge-harder/src/lifecycle/core/deadline.rs
@@ -80,6 +80,8 @@ impl LifecycleConfig {
                 max_attempts: self.processing.max_attempts,
                 run_timeout: self.processing.run_timeout / factor,
                 retry_backoff: self.processing.retry_backoff / factor,
+                finish_max_attempts: self.processing.finish_max_attempts,
+                finish_retry_backoff: self.processing.finish_retry_backoff / factor,
             },
         }
     }
@@ -101,7 +103,7 @@ pub fn next_deadline(state: &ChallengeState, config: &LifecycleConfig) -> Option
 }
 
 fn lifecycle_deadline(state: &ChallengeState, config: &LifecycleConfig) -> Option<Deadline> {
-    if let PhaseState::Terminated = state.phase {
+    if state.terminated() {
         return None;
     }
 
@@ -155,7 +157,7 @@ fn processing_deadline(state: &ChallengeState) -> Option<Deadline> {
             let backoff = if run.attempts == 0 {
                 Duration::ZERO
             } else {
-                config.retry_backoff
+                config.backoff_for(run.trigger)
             };
             Some(Deadline {
                 kind: DeadlineKind::ProcessingDue,
@@ -211,6 +213,8 @@ mod tests {
             max_attempts: 3,
             run_timeout: Duration::from_secs(10),
             retry_backoff: Duration::from_secs(3),
+            finish_max_attempts: 4,
+            finish_retry_backoff: Duration::from_secs(12),
         });
         processing.push(
             Trigger::Stage {
@@ -256,6 +260,11 @@ mod tests {
         assert_eq!(config.processing.run_timeout, Duration::from_secs(3));
         assert_eq!(config.processing.retry_backoff, Duration::from_millis(500));
         assert_eq!(config.processing.max_attempts, 0);
+        assert_eq!(
+            config.processing.finish_retry_backoff,
+            Duration::from_secs(3)
+        );
+        assert_eq!(config.processing.finish_max_attempts, 10);
     }
 
     #[test]
@@ -419,7 +428,9 @@ mod tests {
     #[test]
     fn terminated_challenge_without_processing_has_no_deadlines() {
         let state = ChallengeState {
-            phase: PhaseState::Terminated,
+            phase: PhaseState::Terminated {
+                finished_unix_ms: 1_785_693_975_535,
+            },
             stage_state: StageState::Complete {
                 since: Timestamp::from_millis(7_000),
             },
@@ -459,6 +470,46 @@ mod tests {
     }
 
     #[test]
+    fn failed_finish_run_retries_after_configured_backoff() {
+        let mut processing = Processing::new(ProcessingConfig {
+            max_attempts: 3,
+            run_timeout: Duration::from_secs(10),
+            retry_backoff: Duration::from_secs(3),
+            finish_max_attempts: 4,
+            finish_retry_backoff: Duration::from_secs(12),
+        });
+        processing.push(
+            Trigger::Finish { seq: JournalSeq(7) },
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(5_000),
+        );
+        processing.start(JournalSeq(7), Timestamp::from_millis(5_000));
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(5_000),
+            Err(ProcessingError {
+                message: "scripted".into(),
+                retriable: true,
+            }),
+        );
+
+        let state = ChallengeState {
+            phase: PhaseState::Terminated {
+                finished_unix_ms: 1_785_693_975_535,
+            },
+            processing,
+            ..mid_stage_state()
+        };
+        assert_eq!(
+            next_deadline(&state, &test_config()),
+            Some(Deadline {
+                kind: DeadlineKind::ProcessingDue,
+                at: Timestamp::from_millis(17_000),
+            }),
+        );
+    }
+
+    #[test]
     fn active_processing_run_has_a_timeout() {
         let state = ChallengeState {
             processing: running_processing(Timestamp::from_millis(5_000)),
@@ -476,7 +527,9 @@ mod tests {
     #[test]
     fn terminated_challenge_with_active_processing_has_a_timeout() {
         let state = ChallengeState {
-            phase: PhaseState::Terminated,
+            phase: PhaseState::Terminated {
+                finished_unix_ms: 1_785_693_975_535,
+            },
             processing: running_processing(Timestamp::from_millis(5_000)),
             ..mid_stage_state()
         };

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -286,26 +286,23 @@ fn deadline_fired(
                 .keys()
                 .map(|&client_id| LifecycleEvent::ClientRemoved { client_id })
                 .collect();
-            events.push(LifecycleEvent::ChallengeTerminated {
-                // TODO(frolv): Set based on recorded data once stage processing exists.
-                empty: false,
-            });
+            events.extend(seal_open_stage(state));
+            events.push(LifecycleEvent::ChallengeTerminated);
             events
         }
-        DeadlineKind::CleanupDisconnect => vec![LifecycleEvent::ChallengeTerminated {
-            // TODO(frolv): Set based on recorded data once stage processing exists.
-            empty: false,
-        }],
+        DeadlineKind::CleanupDisconnect => {
+            let mut events: Vec<LifecycleEvent> = seal_open_stage(state).into_iter().collect();
+            events.push(LifecycleEvent::ChallengeTerminated);
+            events
+        }
         DeadlineKind::CleanupAllIdle => {
             let mut events: Vec<LifecycleEvent> = state
                 .clients
                 .keys()
                 .map(|&client_id| LifecycleEvent::ClientRemoved { client_id })
                 .collect();
-            events.push(LifecycleEvent::ChallengeTerminated {
-                // TODO(frolv): Set based on recorded data once stage processing exists.
-                empty: false,
-            });
+            events.extend(seal_open_stage(state));
+            events.push(LifecycleEvent::ChallengeTerminated);
             events
         }
         DeadlineKind::ProcessingDue => {
@@ -325,6 +322,17 @@ fn deadline_fired(
             }]
         }
     }
+}
+
+/// Seals the current stage if it has not already been.
+fn seal_open_stage(state: &ChallengeState) -> Option<LifecycleEvent> {
+    let open = !matches!(state.stage_state, StageState::Complete { .. })
+        && state.stage_status != StageStatus::Entered;
+    open.then_some(LifecycleEvent::StageSealed {
+        stage: state.stage,
+        attempt: state.stage_attempt,
+        forced: true,
+    })
 }
 
 fn finish(state: &ChallengeState, finish: &Finish) -> Vec<LifecycleEvent> {
@@ -358,20 +366,11 @@ fn finish(state: &ChallengeState, finish: &Finish) -> Vec<LifecycleEvent> {
     }
 
     let mut events = vec![finished];
-    if let StageState::Ending { .. } = state.stage_state {
-        // Once the last client leaves, there is no longer a state end to
-        // receive, so finalize the stage if it is still open.
-        events.push(LifecycleEvent::StageSealed {
-            stage: state.stage,
-            attempt: state.stage_attempt,
-            forced: true,
-        });
-    }
+    // Once the last client leaves, there are no more stage events to receive,
+    // so finalize the stage if it is still open.
+    events.extend(seal_open_stage(state));
 
-    events.push(LifecycleEvent::ChallengeTerminated {
-        // TODO(frolv): Set based on recorded data once stage processing exists.
-        empty: false,
-    });
+    events.push(LifecycleEvent::ChallengeTerminated);
     events
 }
 
@@ -935,7 +934,12 @@ mod tests {
                     soft: true,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -959,7 +963,12 @@ mod tests {
                     soft: false,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -983,7 +992,12 @@ mod tests {
                     soft: false,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -994,10 +1008,13 @@ mod tests {
             challenge: 1_437,
             overall: 1_500,
         };
-        let state = tob_state(vec![(
-            CLIENT_A,
-            client(Stage::TobVerzik, StageStatus::Completed, None),
-        )]);
+        let state = ChallengeState {
+            stage: Stage::TobVerzik,
+            ..tob_state(vec![(
+                CLIENT_A,
+                client(Stage::TobVerzik, StageStatus::Completed, None),
+            )])
+        };
         assert_eq!(
             decide(
                 &state,
@@ -1011,7 +1028,12 @@ mod tests {
                     soft: false,
                     times: Some(times),
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobVerzik,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -1046,7 +1068,7 @@ mod tests {
                     soft: false,
                     times: None,
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -1239,7 +1261,14 @@ mod tests {
                 &LifecycleConfig::default(),
                 &Command::DeadlineFired(fired),
             ),
-            vec![LifecycleEvent::ChallengeTerminated { empty: false }],
+            vec![
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobBloat,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::ChallengeTerminated,
+            ],
         );
     }
 
@@ -1275,7 +1304,12 @@ mod tests {
                 LifecycleEvent::ClientRemoved {
                     client_id: CLIENT_B
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                    forced: true,
+                },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -1668,7 +1702,7 @@ mod tests {
                     attempt: None,
                     forced: true,
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -1699,7 +1733,7 @@ mod tests {
                 LifecycleEvent::ClientRemoved {
                     client_id: CLIENT_B,
                 },
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ChallengeTerminated,
             ],
         );
     }
@@ -1743,6 +1777,8 @@ mod tests {
             max_attempts: 2,
             run_timeout: Duration::from_secs(10),
             retry_backoff: Duration::from_secs(3),
+            finish_max_attempts: 4,
+            finish_retry_backoff: Duration::from_secs(9),
         });
         state.processing.push(
             Trigger::Stage {
@@ -1981,7 +2017,9 @@ mod tests {
     #[test]
     fn terminated_challenge_only_accepts_processing_reports() {
         let mut state = processing_tob_state();
-        state.phase = PhaseState::Terminated;
+        state.phase = PhaseState::Terminated {
+            finished_unix_ms: 1_785_693_975_535,
+        };
         state.clients.clear();
 
         assert_eq!(

--- a/challenge-harder/src/lifecycle/core/event.rs
+++ b/challenge-harder/src/lifecycle/core/event.rs
@@ -112,10 +112,7 @@ pub enum LifecycleEvent {
         client_id: ClientId,
     },
     /// Terminal challenge event.
-    /// `empty` marks a challenge with no recorded data which should be deleted.
-    ChallengeTerminated {
-        empty: bool,
-    },
+    ChallengeTerminated,
 }
 
 #[cfg(test)]

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -36,7 +36,10 @@ pub enum PhaseState {
         since: Timestamp,
     },
     /// The challenge has ended.
-    Terminated,
+    Terminated {
+        /// Time at which the terminated state was first entered.
+        finished_unix_ms: u64,
+    },
 }
 
 impl PhaseState {
@@ -46,7 +49,7 @@ impl PhaseState {
         match self {
             PhaseState::Active => ChallengePhase::Active,
             PhaseState::Finishing { .. } => ChallengePhase::Finishing,
-            PhaseState::Terminated => ChallengePhase::Terminated,
+            PhaseState::Terminated { .. } => ChallengePhase::Terminated,
         }
     }
 }
@@ -60,6 +63,10 @@ pub struct ProcessingConfig {
     pub run_timeout: Duration,
     /// Delay following a failed attempt before retrying.
     pub retry_backoff: Duration,
+    /// Attempts allowed for the challenge's finish run.
+    pub finish_max_attempts: u32,
+    /// Delay following a failed finish attempt before retrying.
+    pub finish_retry_backoff: Duration,
 }
 
 impl Default for ProcessingConfig {
@@ -68,6 +75,36 @@ impl Default for ProcessingConfig {
             max_attempts: 0,
             run_timeout: Duration::from_secs(30),
             retry_backoff: Duration::from_secs(5),
+            finish_max_attempts: 10,
+            finish_retry_backoff: Duration::from_secs(30),
+        }
+    }
+}
+
+impl ProcessingConfig {
+    /// Attempt limit for a trigger's runs.
+    #[must_use]
+    pub fn attempts_for(&self, trigger: Trigger) -> u32 {
+        match trigger {
+            Trigger::Finish { .. } => self.finish_max_attempts,
+            Trigger::Create { .. }
+            | Trigger::Recorder { .. }
+            | Trigger::StageStart { .. }
+            | Trigger::Mode { .. }
+            | Trigger::Stage { .. } => self.max_attempts,
+        }
+    }
+
+    /// Failure retry delay for a trigger's runs.
+    #[must_use]
+    pub fn backoff_for(&self, trigger: Trigger) -> Duration {
+        match trigger {
+            Trigger::Finish { .. } => self.finish_retry_backoff,
+            Trigger::Create { .. }
+            | Trigger::Recorder { .. }
+            | Trigger::StageStart { .. }
+            | Trigger::Mode { .. }
+            | Trigger::Stage { .. } => self.retry_backoff,
         }
     }
 }
@@ -154,7 +191,7 @@ impl ProcessingRun {
     /// If `true`, the run cannot be retried any further.
     #[must_use]
     pub fn exhausted(&self, config: &ProcessingConfig) -> bool {
-        !self.retriable || self.attempts >= config.max_attempts
+        !self.retriable || self.attempts >= config.attempts_for(self.trigger)
     }
 }
 
@@ -454,6 +491,11 @@ impl ChallengeState {
             stage_attempt: self.stage_attempt,
             status: self.status(),
             created_unix_ms: self.created_unix_ms,
+            reported_times: self.reported_times,
+            finished_unix_ms: match self.phase {
+                PhaseState::Terminated { finished_unix_ms } => Some(finished_unix_ms),
+                PhaseState::Active | PhaseState::Finishing { .. } => None,
+            },
         }
     }
 
@@ -462,7 +504,7 @@ impl ChallengeState {
     pub fn status(&self) -> ChallengeStatus {
         match self.phase {
             PhaseState::Active | PhaseState::Finishing { .. } => ChallengeStatus::InProgress,
-            PhaseState::Terminated => self.processing.status.unwrap_or_else(|| {
+            PhaseState::Terminated { .. } => self.processing.status.unwrap_or_else(|| {
                 status_if_finished_now(self.challenge_type, self.stage, self.stage_status)
             }),
         }
@@ -472,7 +514,7 @@ impl ChallengeState {
     #[inline]
     #[must_use]
     pub fn terminated(&self) -> bool {
-        matches!(self.phase, PhaseState::Terminated)
+        matches!(self.phase, PhaseState::Terminated { .. })
     }
 }
 
@@ -484,12 +526,10 @@ fn status_if_finished_now(
 ) -> ChallengeStatus {
     let last_stage = challenge_type.last_stage();
 
-    if last_stage.is_some_and(|last| stage > last) {
-        return ChallengeStatus::Completed;
-    }
-
     match stage_status {
+        // If we didn't see the actual conclusion of the challenge, abandon it.
         StageStatus::Started => ChallengeStatus::Abandoned,
+        _ if last_stage.is_some_and(|last| stage > last) => ChallengeStatus::Completed,
         StageStatus::Entered => ChallengeStatus::Reset,
         StageStatus::Wiped => ChallengeStatus::Wiped,
         StageStatus::Completed => {
@@ -511,6 +551,8 @@ mod tests {
             max_attempts,
             run_timeout: Duration::from_secs(10),
             retry_backoff: Duration::from_secs(3),
+            finish_max_attempts: max_attempts + 2,
+            finish_retry_backoff: Duration::from_secs(9),
         }
     }
 
@@ -688,6 +730,57 @@ mod tests {
     }
 
     #[test]
+    fn processing_finish_trigger_retries_until_the_configured_limit() {
+        // Stage budget of 1, finish of 3.
+        let mut processing = Processing::new(config(1));
+        processing.push(
+            Trigger::Finish { seq: JournalSeq(4) },
+            ChallengeState::default().challenge_info(),
+            Timestamp::from_millis(100),
+        );
+
+        processing.start(JournalSeq(4), Timestamp::from_millis(150));
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(300),
+            Err(error(true)),
+        );
+        assert_eq!(
+            processing.active(),
+            Some(&ProcessingRun {
+                trigger: Trigger::Finish { seq: JournalSeq(4) },
+                info: ChallengeState::default().challenge_info(),
+                attempts: 1,
+                retriable: true,
+                state: ProcessingState::Idle {
+                    since: Timestamp::from_millis(300)
+                },
+            }),
+        );
+
+        processing.start(JournalSeq(4), Timestamp::from_millis(9_300));
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(9_400),
+            Err(error(true)),
+        );
+        assert_eq!(processing.active().unwrap().attempts, 2);
+
+        processing.start(JournalSeq(4), Timestamp::from_millis(18_400));
+        processing.finish(
+            ChallengeType::Tob,
+            Timestamp::from_millis(18_500),
+            Err(error(true)),
+        );
+        assert_eq!(processing.active(), None);
+        assert_eq!(
+            processing.failed,
+            vec![Trigger::Finish { seq: JournalSeq(4) }]
+        );
+        assert!(processing.settled());
+    }
+
+    #[test]
     fn status_stays_in_progress_until_terminated() {
         let mut state = ChallengeState {
             challenge_type: ChallengeType::Tob,
@@ -702,7 +795,9 @@ mod tests {
         };
         assert_eq!(state.status(), ChallengeStatus::InProgress);
 
-        state.phase = PhaseState::Terminated;
+        state.phase = PhaseState::Terminated {
+            finished_unix_ms: 1_785_693_975_535,
+        };
         assert_eq!(state.status(), ChallengeStatus::Wiped);
     }
 
@@ -712,7 +807,9 @@ mod tests {
             challenge_type: ChallengeType::Tob,
             stage: Stage::TobMaiden,
             stage_status: StageStatus::Wiped,
-            phase: PhaseState::Terminated,
+            phase: PhaseState::Terminated {
+                finished_unix_ms: 1_785_693_975_535,
+            },
             processing: Processing::new(config(2)),
             ..ChallengeState::default()
         };
@@ -776,7 +873,7 @@ mod tests {
                 ChallengeType::Mokhaiotl,
                 Stage::MokhaiotlDelve8plus,
                 StageStatus::Started,
-                ChallengeStatus::Completed,
+                ChallengeStatus::Abandoned,
             ),
             (
                 ChallengeType::Mokhaiotl,

--- a/challenge-harder/src/lifecycle/core/types.rs
+++ b/challenge-harder/src/lifecycle/core/types.rs
@@ -322,6 +322,8 @@ pub struct ChallengeInfo {
     pub stage_attempt: Option<u32>,
     pub status: ChallengeStatus,
     pub created_unix_ms: u64,
+    pub finished_unix_ms: Option<u64>,
+    pub reported_times: Option<ReportedTimes>,
 }
 
 impl ChallengeInfo {

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -1034,7 +1034,7 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
     for (uuid, journal) in &result.journals {
         let terminated = journal
             .iter()
-            .any(|entry| matches!(entry.event, LifecycleEvent::ChallengeTerminated { .. }));
+            .any(|entry| matches!(entry.event, LifecycleEvent::ChallengeTerminated));
         if terminated {
             assert!(
                 !result.snapshots.contains_key(uuid),
@@ -1160,7 +1160,7 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
                 !terminated || processing_event,
                 "non-processing entry recorded after termination: {uuid}",
             );
-            terminated |= matches!(entry.event, LifecycleEvent::ChallengeTerminated { .. });
+            terminated |= matches!(entry.event, LifecycleEvent::ChallengeTerminated);
 
             match &entry.event {
                 LifecycleEvent::ChallengeCreated {

--- a/challenge-harder/src/lifecycle/sim/scenarios/challenge_end.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/challenge_end.rs
@@ -77,12 +77,7 @@ async fn each_finish_extends_the_grace_period() {
                     times: None,
                 },
             ),
-            entry(
-                14,
-                8_500,
-                cmd(10),
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(14, 8_500, cmd(10), LifecycleEvent::ChallengeTerminated,),
         ],
     );
 }
@@ -142,7 +137,7 @@ async fn unfinished_client_cut_off_after_grace_period() {
                 11,
                 8_000,
                 Cause::Deadline(DeadlineKind::ChallengeEnd),
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ChallengeTerminated,
             ),
         ],
     );

--- a/challenge-harder/src/lifecycle/sim/scenarios/client_status.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/client_status.rs
@@ -102,7 +102,7 @@ fn client_finished(client: i64) -> LifecycleEvent {
 }
 
 fn terminated() -> LifecycleEvent {
-    LifecycleEvent::ChallengeTerminated { empty: false }
+    LifecycleEvent::ChallengeTerminated
 }
 
 #[tokio::test(start_paused = true)]
@@ -149,6 +149,12 @@ async fn disconnect_without_finish_cleans_up_after_reconnection_window() {
             entry(8, 900, cmd(5), removed(1)),
             entry(
                 9,
+                300_900,
+                fired(DeadlineKind::CleanupDisconnect),
+                sealed(Stage::TobBloat, None, true)
+            ),
+            entry(
+                10,
                 300_900,
                 fired(DeadlineKind::CleanupDisconnect),
                 terminated()
@@ -291,6 +297,12 @@ async fn logout_without_return_cleans_up_after_inactivity_window() {
                 10,
                 905_000,
                 fired(DeadlineKind::CleanupAllIdle),
+                sealed(Stage::InfernoWave2, None, true)
+            ),
+            entry(
+                11,
+                905_000,
+                fired(DeadlineKind::CleanupAllIdle),
                 terminated()
             ),
         ],
@@ -404,7 +416,7 @@ async fn wipe_then_crash_before_finish_is_wiped() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn deep_delve_disconnect_completes() {
+async fn deep_delve_disconnect_abandons() {
     let result = run(Scenario {
         clients: vec![
             Client::participant("a", 1)
@@ -487,11 +499,17 @@ async fn deep_delve_disconnect_completes() {
                 13,
                 301_200,
                 fired(DeadlineKind::CleanupDisconnect),
+                sealed(Stage::MokhaiotlDelve8plus, Some(2), true)
+            ),
+            entry(
+                14,
+                301_200,
+                fired(DeadlineKind::CleanupDisconnect),
                 terminated()
             ),
         ],
     );
-    assert_eq!(result.only_status(), ChallengeStatus::Completed);
+    assert_eq!(result.only_status(), ChallengeStatus::Abandoned);
 }
 
 #[tokio::test(start_paused = true)]
@@ -673,6 +691,12 @@ async fn rejoin_after_window_starts_fresh() {
             entry(4, 700, cmd(3), removed(1)),
             entry(
                 5,
+                300_700,
+                fired(DeadlineKind::CleanupDisconnect),
+                sealed(Stage::TobMaiden, None, true)
+            ),
+            entry(
+                6,
                 300_700,
                 fired(DeadlineKind::CleanupDisconnect),
                 terminated()

--- a/challenge-harder/src/lifecycle/sim/scenarios/creation.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/creation.rs
@@ -149,7 +149,7 @@ async fn terminated_incumbent_is_superseded() {
     assert!(
         result.journals[&first]
             .iter()
-            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated { .. },))
+            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated))
     );
     assert_eq!(result.projections[&first].status, ChallengeStatus::Reset);
 }
@@ -209,7 +209,7 @@ async fn start_for_another_party_leaves_the_recorded_challenge() {
                 3,
                 301_000,
                 Cause::Deadline(DeadlineKind::CleanupDisconnect),
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ChallengeTerminated,
             ),
         ],
     );
@@ -244,7 +244,7 @@ async fn start_joins_the_left_challenge_within_its_window() {
     assert!(
         result.journals[&duo_watch]
             .iter()
-            .all(|e| !matches!(e.event, LifecycleEvent::ChallengeTerminated { .. }))
+            .all(|e| !matches!(e.event, LifecycleEvent::ChallengeTerminated))
     );
     assert!(!result.deleted.contains(&duo_watch));
     assert!(result.deleted.contains(&solo_watch));
@@ -322,7 +322,7 @@ async fn start_attaching_to_an_incumbent_leaves_the_recorded_challenge() {
     assert!(
         result.journals[&solo]
             .iter()
-            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated { .. }))
+            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated))
     );
     assert!(result.deleted.contains(&solo));
 }
@@ -369,7 +369,7 @@ async fn finishing_challenge_is_not_joined() {
                 6,
                 5_100,
                 Cause::Deadline(DeadlineKind::ChallengeEnd),
-                LifecycleEvent::ChallengeTerminated { empty: false },
+                LifecycleEvent::ChallengeTerminated,
             ),
         ],
     );

--- a/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
@@ -7,7 +7,7 @@ use tokio::sync::watch;
 use super::*;
 use crate::lifecycle::challenge::{ChallengeServerUpdate, ChallengeStore, run_challenge};
 use crate::lifecycle::coordinator::Coordinator;
-use crate::lifecycle::core::command::{Create, Finish, Update};
+use crate::lifecycle::core::command::{ClientStatus, Create, Finish, Update};
 use crate::lifecycle::core::deadline::{DeadlineKind, LifecycleConfig};
 use crate::lifecycle::core::state::{ProcessingConfig, Trigger};
 use crate::lifecycle::core::types::{ChallengeStatus, ProcessingError, ProcessingPayload, Uuid};
@@ -24,6 +24,8 @@ fn config() -> LifecycleConfig {
             max_attempts: 2,
             run_timeout: Duration::from_secs(10),
             retry_backoff: Duration::from_secs(3),
+            finish_max_attempts: 4,
+            finish_retry_backoff: Duration::from_secs(9),
         },
         ..LifecycleConfig::default()
     }
@@ -163,12 +165,7 @@ async fn sealed_stage_processes_and_journals_its_run() {
                     times: None,
                 },
             ),
-            entry(
-                13,
-                2_000,
-                cmd(4),
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(13, 2_000, cmd(4), LifecycleEvent::ChallengeTerminated,),
             entry(
                 14,
                 2_000,
@@ -339,12 +336,7 @@ async fn finalization_waits_for_processing_to_finish_after_termination() {
     assert_eq!(
         journal[12..],
         vec![
-            entry(
-                12,
-                2_000,
-                cmd(4),
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(12, 2_000, cmd(4), LifecycleEvent::ChallengeTerminated,),
             entry(
                 13,
                 6_000,
@@ -509,12 +501,7 @@ async fn late_commands_post_termination_while_processing() {
     assert_eq!(
         journal[12..],
         vec![
-            entry(
-                12,
-                2_000,
-                cmd(4),
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(12, 2_000, cmd(4), LifecycleEvent::ChallengeTerminated,),
             entry(
                 13,
                 6_000,
@@ -548,49 +535,132 @@ async fn failed_finish_run_concludes_afterwards() {
         ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Wiped, 60))),
         ProcessingAttempt::Resolve(0, Err(retriable_failure())),
         ProcessingAttempt::Resolve(0, Err(retriable_failure())),
+        ProcessingAttempt::Resolve(0, Err(retriable_failure())),
+        ProcessingAttempt::Resolve(0, Err(retriable_failure())),
     ]);
     let result = run_with(options(&processor), solo_maiden_wipe(2_000)).await;
 
+    // Finish is configured with 4 retries at a 9s backoff.
     let (uuid, journal) = result.only_challenge();
-    assert_eq!(
-        journal[14..],
-        vec![
-            entry(
-                14,
-                2_000,
-                Cause::Deadline(DeadlineKind::ProcessingDue),
-                started(13)
-            ),
-            entry(
-                15,
-                2_000,
-                processing(13),
-                LifecycleEvent::ProcessingFailed {
-                    trigger: JournalSeq(13),
-                    error: retriable_failure(),
-                },
-            ),
-            entry(
-                16,
-                5_000,
-                Cause::Deadline(DeadlineKind::ProcessingDue),
-                started(13)
-            ),
-            entry(
-                17,
-                5_000,
-                processing(13),
-                LifecycleEvent::ProcessingFailed {
-                    trigger: JournalSeq(13),
-                    error: retriable_failure(),
-                },
-            ),
-        ],
-    );
+    let mut expected = Vec::new();
+    for attempt in 0..4u64 {
+        let at_ms = 2_000 + attempt * 9_000;
+        expected.push(entry(
+            14 + attempt * 2,
+            at_ms,
+            Cause::Deadline(DeadlineKind::ProcessingDue),
+            started(13),
+        ));
+        expected.push(entry(
+            15 + attempt * 2,
+            at_ms,
+            processing(13),
+            LifecycleEvent::ProcessingFailed {
+                trigger: JournalSeq(13),
+                error: retriable_failure(),
+            },
+        ));
+    }
+    assert_eq!(journal[14..], expected);
 
     assert!(result.deleted.contains(&uuid));
     assert_eq!(result.updates, vec![(uuid, ChallengeServerUpdate::Finish)]);
     assert_eq!(result.only_status(), ChallengeStatus::Wiped);
+}
+
+#[tokio::test(start_paused = true)]
+async fn finish_after_mid_stage_disconnect_reports_abandoned() {
+    let processor = ScriptedProcessor::new(vec![
+        no_payload(),
+        no_payload(),
+        ProcessingAttempt::Resolve(0, Ok(outcome(StageStatus::Completed, 237))),
+        no_payload(),
+        no_payload(),
+        no_payload(),
+    ]);
+    let result = run_with(
+        options(&processor),
+        Scenario {
+            clients: vec![
+                Client::participant("a", 1)
+                    .at(0, solo_hmt_start())
+                    .at(10, report(Stage::TobMaiden, StageStatus::Started))
+                    .at(500, report(Stage::TobMaiden, StageStatus::Completed))
+                    .at(600, report(Stage::TobBloat, StageStatus::Started))
+                    .at(900, Action::Status(ClientStatus::Disconnected)),
+            ],
+            run_until: 330_000,
+        },
+    )
+    .await;
+
+    // The cleanup deadline seals Bloat so its outstanding data is processed
+    // before the finish runs.
+    let (_, journal) = result.only_challenge();
+    assert_eq!(
+        journal[16..],
+        vec![
+            entry(
+                16,
+                900,
+                cmd(5),
+                LifecycleEvent::ClientRemoved {
+                    client_id: client_id(1),
+                },
+            ),
+            entry(
+                17,
+                300_900,
+                Cause::Deadline(DeadlineKind::CleanupDisconnect),
+                LifecycleEvent::StageSealed {
+                    stage: Stage::TobBloat,
+                    attempt: None,
+                    forced: true,
+                },
+            ),
+            entry(
+                18,
+                300_900,
+                Cause::Deadline(DeadlineKind::CleanupDisconnect),
+                LifecycleEvent::ChallengeTerminated,
+            ),
+            entry(
+                19,
+                300_900,
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(17)
+            ),
+            entry(
+                20,
+                300_900,
+                processing(17),
+                finished(17, ProcessingPayload::None),
+            ),
+            entry(
+                21,
+                300_900,
+                Cause::Deadline(DeadlineKind::ProcessingDue),
+                started(20)
+            ),
+            entry(
+                22,
+                300_900,
+                processing(20),
+                finished(20, ProcessingPayload::None),
+            ),
+        ],
+    );
+
+    let requests = processor.requests();
+    let finish_request = requests.last().expect("the finish should process");
+    assert_eq!(
+        finish_request.trigger,
+        Trigger::Finish {
+            seq: JournalSeq(20)
+        }
+    );
+    assert_eq!(finish_request.challenge.status, ChallengeStatus::Abandoned);
+    assert_eq!(result.only_status(), ChallengeStatus::Abandoned);
 }
 
 /// A fresh runtime starting with a paused clock. Dropping it kills every
@@ -741,7 +811,7 @@ fn final_processing_concludes_exactly_once_on_resume() {
     assert!(
         journal
             .iter()
-            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated { .. })),
+            .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated)),
     );
     assert_eq!(collector.finish_announcements(uuid), 0);
     assert!(!collector.is_deleted(uuid));

--- a/challenge-harder/src/lifecycle/sim/scenarios/progression.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/progression.rs
@@ -96,12 +96,7 @@ async fn solo_colosseum_wipe_full_trace() {
                     times: None,
                 },
             ),
-            entry(
-                11,
-                1_000,
-                cmd(6),
-                LifecycleEvent::ChallengeTerminated { empty: false },
-            ),
+            entry(11, 1_000, cmd(6), LifecycleEvent::ChallengeTerminated,),
         ],
     );
 }

--- a/challenge-harder/src/lifecycle/sim/scenarios/recovery.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/recovery.rs
@@ -174,7 +174,7 @@ fn killed_server_resumes_windows_with_time_to_run() {
         seq: JournalSeq(3),
         at: Timestamp::from_millis(61_000),
         caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-        event: LifecycleEvent::ChallengeTerminated { empty: false },
+        event: LifecycleEvent::ChallengeTerminated,
     });
     assert_eq!(journal(&collector, uuid), expected);
     assert!(deleted(&collector, uuid));
@@ -209,7 +209,7 @@ fn finished_entries(uuid: Uuid, finish_id: MsgId) -> Vec<JournalEntry> {
         seq: JournalSeq(3),
         at: Timestamp::ZERO,
         caused_by: Cause::Command(finish_id),
-        event: LifecycleEvent::ChallengeTerminated { empty: false },
+        event: LifecycleEvent::ChallengeTerminated,
     });
     entries
 }
@@ -308,7 +308,7 @@ fn shutdown_server_hands_over_resumable_state() {
         seq: JournalSeq(3),
         at: Timestamp::from_millis(61_000),
         caused_by: Cause::Deadline(DeadlineKind::CleanupDisconnect),
-        event: LifecycleEvent::ChallengeTerminated { empty: false },
+        event: LifecycleEvent::ChallengeTerminated,
     });
     assert_eq!(journal(&collector, uuid), expected);
     assert!(deleted(&collector, uuid));

--- a/challenge-harder/src/lifecycle/sim/scenarios/rejoin.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/rejoin.rs
@@ -62,7 +62,7 @@ fn client_finished(client: i64) -> LifecycleEvent {
 }
 
 fn terminated() -> LifecycleEvent {
-    LifecycleEvent::ChallengeTerminated { empty: false }
+    LifecycleEvent::ChallengeTerminated
 }
 
 #[tokio::test(start_paused = true)]

--- a/challenge-harder/src/lifecycle/sim/scenarios/retries.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/retries.rs
@@ -47,12 +47,7 @@ fn client_finished(seq: u64, at_ms: u64, caused_by: Cause) -> JournalEntry {
 }
 
 fn completed(seq: u64, at_ms: u64, caused_by: Cause) -> JournalEntry {
-    entry(
-        seq,
-        at_ms,
-        caused_by,
-        LifecycleEvent::ChallengeTerminated { empty: false },
-    )
+    entry(seq, at_ms, caused_by, LifecycleEvent::ChallengeTerminated)
 }
 
 #[tokio::test(start_paused = true)]

--- a/challenge-harder/src/lifecycle/sim/scenarios/sweep.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/sweep.rs
@@ -29,6 +29,8 @@ const SWEEP_CONFIG: LifecycleConfig = LifecycleConfig {
         max_attempts: 0,
         run_timeout: Duration::from_secs(30),
         retry_backoff: Duration::from_secs(5),
+        finish_max_attempts: 10,
+        finish_retry_backoff: Duration::from_secs(30),
     },
 };
 

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -3,14 +3,38 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use crate::lifecycle::core::types::{
-    ChallengeMode, ChallengeStatus, PlayerId, PrimaryMeleeGear, RecordingType, Stage, UserId,
+    ChallengeMode, ChallengeStatus, ChallengeTypeExt, PlayerId, PrimaryMeleeGear, ProcessingError,
+    RecordingType, Stage, UserId,
 };
 use crate::players::normalize_rsn;
+use crate::repository::DataRepository;
 
-use super::{ChallengeInfo, db};
+use super::challenge_processor::ChallengeContext;
+use super::persist::{save_splits, update_player_stats};
+use super::{ChallengeInfo, StoredPlayerInfo, StoredState, db};
 
-/// Initializes a new challenge.
-pub async fn create(txn: &mut db::Transaction, info: &ChallengeInfo) -> Result<(), db::Error> {
+/// Initializes a new challenge, returning custom processor state to persist.
+pub async fn create(
+    txn: &mut db::Transaction,
+    repository: &DataRepository,
+    info: &ChallengeInfo,
+) -> Result<Option<serde_json::Value>, ProcessingError> {
+    insert_challenge(txn, info).await?;
+
+    let Some(mut processor) = super::processor_for(info, None)? else {
+        return Ok(None);
+    };
+    processor.on_create(txn).await?;
+    if let Some(data) = processor.challenge_data() {
+        repository.save_challenge(info.uuid, &data).await?;
+    }
+    Ok(processor.custom_data())
+}
+
+async fn insert_challenge(
+    txn: &mut db::Transaction,
+    info: &ChallengeInfo,
+) -> Result<(), db::Error> {
     let start_time = UNIX_EPOCH + Duration::from_millis(info.created_unix_ms);
     let row = txn
         .query_one(
@@ -114,15 +138,163 @@ pub async fn update_mode(txn: &db::Transaction, mode: ChallengeMode) -> Result<(
     Ok(())
 }
 
-/// Finalizes a challenge, recording its ending status.
-pub async fn finish(txn: &db::Transaction, info: &ChallengeInfo) -> Result<(), db::Error> {
-    txn.execute(
-        "UPDATE challenges SET status = $1 WHERE id = $2",
-        &[&(info.status as i16), &txn.challenge_id()],
-    )
-    .await?;
+/// Finalizes a challenge, recording its outcome.
+/// A challenge without recorded data is deleted.
+pub async fn finish(
+    txn: &mut db::Transaction,
+    repository: &DataRepository,
+    info: &ChallengeInfo,
+) -> Result<(), ProcessingError> {
+    let stored = load_database_state(txn, info).await?;
+    if stored.challenge_ticks == 0 {
+        tracing::info!(uuid = %info.uuid, "challenge_finished_no_data");
+        return delete_empty_challenge(txn, repository, info, &stored.players).await;
+    }
 
-    // TODO(frolv): The rest of the owl
+    let Some(mut processor) = super::processor_for(info, stored.custom_data.as_ref())? else {
+        finalize_challenge_row(txn, info, stored.challenge_ticks, false).await?;
+        return Ok(());
+    };
+
+    let recorded_ticks = processor.final_challenge_ticks(stored.challenge_ticks);
+    let mut final_ticks = recorded_ticks;
+    if let Some(times) = info.reported_times
+        && times.challenge != recorded_ticks
+    {
+        tracing::warn!(
+            uuid = %info.uuid,
+            recorded_ticks,
+            reported_ticks = times.challenge,
+            "challenge_time_mismatch",
+        );
+        final_ticks = times.challenge;
+    }
+
+    // Correct the challenge ticks based on the server report. Any ticks
+    // recorded in stages beyond the official end accumulate further.
+    let challenge_ticks = stored.challenge_ticks - recorded_ticks + final_ticks;
+
+    let full_recording = processor.has_fully_recorded_up_to(info.stage);
+    let mut ctx = ChallengeContext::new(info.party.clone());
+    tokio::try_join!(
+        finalize_challenge_row(txn, info, challenge_ticks, full_recording),
+        processor.on_finish(txn, &mut ctx, final_ticks),
+    )?;
+
+    let times_accurate = !info.party_changed
+        && info
+            .challenge_type
+            .last_stage()
+            .is_some_and(|last| processor.has_fully_recorded_up_to(last))
+        && info.status == ChallengeStatus::Completed;
+
+    tokio::try_join!(
+        save_splits(txn, info, ctx.splits(times_accurate), &stored.players),
+        update_player_stats(txn, ctx.players(), &stored.players),
+    )?;
 
     Ok(())
+}
+
+async fn delete_empty_challenge(
+    txn: &mut db::Transaction,
+    repository: &DataRepository,
+    info: &ChallengeInfo,
+    players: &[StoredPlayerInfo],
+) -> Result<(), ProcessingError> {
+    let delete_row = async { txn.delete_challenge().await.map_err(ProcessingError::from) };
+    let delete_data = async {
+        repository
+            .delete_challenge(info.uuid)
+            .await
+            .map_err(ProcessingError::from)
+    };
+    tokio::try_join!(delete_row, delete_data)?;
+
+    let ids: Vec<i32> = players.iter().map(|player| player.id.0).collect();
+    txn.execute(
+        "UPDATE players SET total_recordings = total_recordings - 1 WHERE id = ANY($1)",
+        &[&ids],
+    )
+    .await
+    .map_err(db::Error::from)?;
+    Ok(())
+}
+
+async fn finalize_challenge_row(
+    txn: &db::Transaction,
+    info: &ChallengeInfo,
+    final_ticks: u32,
+    full_recording: bool,
+) -> Result<(), db::Error> {
+    let finish_time = info
+        .finished_unix_ms
+        .map(|ms| UNIX_EPOCH + Duration::from_millis(ms));
+    txn.execute(
+        "UPDATE challenges
+         SET status = $1, challenge_ticks = $2, overall_ticks = $3, finish_time = $4,
+             full_recording = $5
+         WHERE id = $6",
+        &[
+            &(info.status as i16),
+            &final_ticks.cast_signed(),
+            &info.reported_times.map(|times| times.overall.cast_signed()),
+            &finish_time,
+            &full_recording,
+            &txn.challenge_id(),
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// Loads the stored database state for a processing run.
+pub(super) async fn load_database_state(
+    txn: &db::Transaction,
+    info: &ChallengeInfo,
+) -> Result<StoredState, db::Error> {
+    let players = async {
+        let rows = txn
+            .query(
+                "SELECT player_id, primary_gear FROM challenge_players
+                 WHERE challenge_id = $1
+                 ORDER BY orb",
+                &[&txn.challenge_id()],
+            )
+            .await?;
+        if rows.len() != info.scale().cast_unsigned() as usize {
+            return Err(db::Error::InvalidData(format!(
+                "challenge has {} players, expected {}",
+                rows.len(),
+                info.scale(),
+            )));
+        }
+
+        rows.iter()
+            .map(|row| {
+                let gear: i16 = row.get(1);
+                Ok(StoredPlayerInfo {
+                    id: PlayerId(row.get(0)),
+                    gear: PrimaryMeleeGear::try_from(gear)
+                        .map_err(|value| db::Error::InvalidData(format!("primary gear {value}")))?,
+                })
+            })
+            .collect::<Result<Vec<_>, db::Error>>()
+    };
+    let challenge_ticks = async {
+        let row = txn
+            .query_one(
+                "SELECT challenge_ticks FROM challenges WHERE id = $1",
+                &[&txn.challenge_id()],
+            )
+            .await?;
+        Ok(row.get::<_, i32>(0).cast_unsigned())
+    };
+    let (players, challenge_ticks) = tokio::try_join!(players, challenge_ticks)?;
+
+    Ok(StoredState {
+        players,
+        challenge_ticks,
+        custom_data: txn.custom_data().cloned(),
+    })
 }

--- a/challenge-harder/src/processing/challenge_processor.rs
+++ b/challenge-harder/src/processing/challenge_processor.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::StoredState;
 use super::db;
-use super::split::{ChallengeSplit, SplitType, StageSplit};
+use super::split::{ChallengeSplit, SavedSplit, SplitType, StageSplit};
 use super::stats::PlayerStatsDelta;
 use crate::lifecycle::core::types::{PrimaryMeleeGear, Stage};
 use crate::merging::MergedEvents;
@@ -140,6 +140,18 @@ impl ChallengeContext {
             .iter()
             .map(|(&split, &entry)| (split, entry))
     }
+
+    /// Resolves the recorded challenge splits to their final accuracy.
+    pub(super) fn splits(&self, default_accuracy: bool) -> Vec<SavedSplit> {
+        self.challenge_splits
+            .iter()
+            .map(|(&split, entry)| SavedSplit {
+                split,
+                ticks: entry.ticks,
+                accurate: entry.accurate.unwrap_or(default_accuracy),
+            })
+            .collect()
+    }
 }
 
 /// Stage-scoped state accumulated by the event loop.
@@ -216,13 +228,6 @@ impl StageContext {
         self.challenge.set_challenge_split(split, ticks, accurate);
     }
 
-    /// Iterates over recorded challenge splits in split order.
-    pub(super) fn challenge_splits(
-        &self,
-    ) -> impl Iterator<Item = (SplitType, ChallengeSplit)> + '_ {
-        self.challenge.challenge_splits()
-    }
-
     /// Records a split whose timer is local to the current stage.
     ///
     /// `tick` is the tick on which the split occurred, counted as elapsed from
@@ -260,10 +265,27 @@ impl StageContext {
             .iter()
             .map(|(&split, &entry)| (split, entry))
     }
+
+    /// Resolves every split recorded during the stage to its final accuracy.
+    /// Stage splits are accurate when they fall within the timeline's accurate
+    /// prefix. Challenge splits recorded following a stage are inaccurate
+    /// unless overridden.
+    pub(super) fn splits(&self, accurate_until: u32, completed: bool) -> Vec<SavedSplit> {
+        let mut splits: Vec<SavedSplit> = self
+            .stage_splits
+            .iter()
+            .map(|(&split, entry)| SavedSplit {
+                split,
+                ticks: entry.tick - entry.start,
+                accurate: entry.tick < accurate_until && (!entry.requires_completion || completed),
+            })
+            .collect();
+        splits.extend(self.challenge.splits(false));
+        splits
+    }
 }
 
 /// Type-specific challenge processing behavior.
-#[cfg_attr(not(test), expect(dead_code))]
 #[async_trait]
 pub trait ChallengeProcessor: Send {
     /// Handles one event during the stage processing loop, returning whether

--- a/challenge-harder/src/processing/db.rs
+++ b/challenge-harder/src/processing/db.rs
@@ -5,9 +5,8 @@ use std::ops::Deref;
 use deadpool_postgres::{Manager, ManagerConfig, Object, Pool, RecyclingMethod};
 use tokio_postgres::NoTls;
 
-use crate::lifecycle::core::types::{
-    JournalSeq, ProcessingError, ProcessingPayload, StageStatus, Uuid,
-};
+use crate::lifecycle::core::state::Trigger;
+use crate::lifecycle::core::types::{ProcessingError, ProcessingPayload, StageStatus, Uuid};
 
 /// A database operation failure.
 #[derive(Debug, thiserror::Error)]
@@ -76,21 +75,23 @@ impl Postgres {
         Ok(Postgres { pool })
     }
 
-    /// Opens a guarded transaction for the processing stage triggered by `seq`,
+    /// Opens a guarded transaction for the processing run of `trigger`,
     /// failing with [`Error::AlreadyApplied`] if the processing step has
     /// previously been applied to the database.
     pub async fn start_transaction(
         &self,
         uuid: Uuid,
-        seq: JournalSeq,
+        trigger: Trigger,
     ) -> Result<Transaction, Error> {
+        let seq = trigger.seq();
         let client = self.pool.get().await?;
         client.batch_execute("BEGIN").await?;
         let mut txn = Transaction {
             client: Some(client),
-            seq,
+            trigger,
             challenge_id: 0,
             custom_data: None,
+            deleted: false,
         };
 
         let guard = txn
@@ -102,14 +103,23 @@ impl Postgres {
                 &[&uuid],
             )
             .await?;
-        if let Some(row) = guard {
-            if let Some(processed_seq) = row.get::<_, Option<i64>>(1)
-                && processed_seq >= seq.0.cast_signed()
-            {
-                return Err(Error::AlreadyApplied(stored_payload(&row)?));
+        match guard {
+            Some(row) => {
+                if let Some(processed_seq) = row.get::<_, Option<i64>>(1)
+                    && processed_seq >= seq.0.cast_signed()
+                {
+                    return Err(Error::AlreadyApplied(stored_payload(&row)?));
+                }
+                txn.challenge_id = row.get(0);
+                txn.custom_data = row.get(4);
             }
-            txn.challenge_id = row.get(0);
-            txn.custom_data = row.get(4);
+            None => {
+                // Nothing runs after a finish, so no row existing means a
+                // prior attempt deleted the challenge.
+                if matches!(trigger, Trigger::Finish { .. }) {
+                    return Err(Error::AlreadyApplied(ProcessingPayload::None));
+                }
+            }
         }
 
         Ok(txn)
@@ -136,11 +146,13 @@ fn stored_payload(row: &tokio_postgres::Row) -> Result<ProcessingPayload, Error>
 /// advances the challenge's processing cursor.
 pub struct Transaction {
     client: Option<Object>,
-    seq: JournalSeq,
+    trigger: Trigger,
     /// Database ID of the challenge row.
     challenge_id: i32,
     /// The processor continuation state stored by the last committed run.
     custom_data: Option<serde_json::Value>,
+    /// Whether the challenge's rows were removed within the transaction.
+    deleted: bool,
 }
 
 impl Transaction {
@@ -161,22 +173,61 @@ impl Transaction {
         self.custom_data.as_ref()
     }
 
+    /// Removes the challenge's rows, if they exist.
+    pub async fn delete_challenge(&mut self) -> Result<(), Error> {
+        self.execute(
+            "DELETE FROM challenges WHERE id = $1",
+            &[&self.challenge_id],
+        )
+        .await?;
+        self.deleted = true;
+        Ok(())
+    }
+
     /// Commits the transaction, advancing the challenge's cursor and storing
     /// the processed payload.
     /// `custom_data` replaces the challenge's custom state when present;
     /// `None` preserves it.
+    /// A transaction marked deleted commits without recording processing
+    /// state, as the rows it would reference no longer exist.
     pub async fn commit(
         mut self,
         payload: &ProcessingPayload,
         custom_data: Option<&serde_json::Value>,
     ) -> Result<(), Error> {
+        let client = self.client.take().expect("transaction is active");
+        let seq = self.trigger.seq().0.cast_signed();
+
+        if self.deleted {
+            client.batch_execute("COMMIT").await?;
+            return Ok(());
+        }
+
+        if matches!(self.trigger, Trigger::Finish { .. }) {
+            client
+                .execute(
+                    "INSERT INTO challenge_processing_state
+                       (challenge_id, processed_seq, finalized_seq)
+                     VALUES ($1, $2, $2)
+                     ON CONFLICT (challenge_id)
+                     DO UPDATE SET processed_seq = EXCLUDED.processed_seq,
+                                   outcome_status = NULL,
+                                   outcome_ticks = NULL,
+                                   custom_data = NULL,
+                                   finalized_seq = EXCLUDED.finalized_seq",
+                    &[&self.challenge_id, &seq],
+                )
+                .await?;
+            client.batch_execute("COMMIT").await?;
+            return Ok(());
+        }
+
         let (status, ticks) = match payload {
             ProcessingPayload::Stage { status, ticks } => {
                 (Some(*status as i16), Some(ticks.cast_signed()))
             }
             ProcessingPayload::None => (None, None),
         };
-        let client = self.client.take().expect("transaction is active");
         client
             .execute(
                 "INSERT INTO challenge_processing_state
@@ -190,13 +241,7 @@ impl Transaction {
                                    EXCLUDED.custom_data,
                                    challenge_processing_state.custom_data
                                )",
-                &[
-                    &self.challenge_id,
-                    &self.seq.0.cast_signed(),
-                    &status,
-                    &ticks,
-                    &custom_data,
-                ],
+                &[&self.challenge_id, &seq, &status, &ticks, &custom_data],
             )
             .await?;
         client.batch_execute("COMMIT").await?;
@@ -222,6 +267,14 @@ impl Drop for Transaction {
     }
 }
 
+#[cfg(test)]
+impl Postgres {
+    /// Gets a raw connection from the pool.
+    pub(crate) async fn client(&self) -> Object {
+        self.pool.get().await.expect("failed to check out a client")
+    }
+}
+
 /// Connects to the migrated Postgres database at `BLERT_TEST_DATABASE_URI`,
 /// or returns `None` when it is unset.
 #[cfg(test)]
@@ -240,7 +293,7 @@ pub(crate) async fn test_database() -> Option<Postgres> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lifecycle::core::types::StageStatus;
+    use crate::lifecycle::core::types::{JournalSeq, Stage, StageStatus};
 
     /// Inserts a bare challenge row to satisfy foreign keys.
     async fn insert_challenge(db: &Postgres, uuid: Uuid) -> i32 {
@@ -271,10 +324,19 @@ mod tests {
         let uuid = Uuid::new_v4();
 
         let txn = db
-            .start_transaction(uuid, JournalSeq(1))
+            .start_transaction(uuid, Trigger::Create { seq: JournalSeq(1) })
             .await
             .expect("guard should pass");
         assert_eq!(txn.challenge_id(), 0);
+        drop(txn);
+
+        let finish = db
+            .start_transaction(uuid, Trigger::Finish { seq: JournalSeq(1) })
+            .await;
+        assert!(matches!(
+            finish,
+            Err(Error::AlreadyApplied(ProcessingPayload::None))
+        ));
     }
 
     #[tokio::test]
@@ -288,7 +350,14 @@ mod tests {
         let custom = serde_json::json!({ "delve": 3, "larvae": [1, 2] });
 
         let txn = db
-            .start_transaction(uuid, JournalSeq(3))
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(3),
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            )
             .await
             .expect("guard should pass");
         assert_eq!(txn.challenge_id(), id);
@@ -325,7 +394,16 @@ mod tests {
         drop(client);
 
         // Reopening the committed step returns its stored payload.
-        let replay = db.start_transaction(uuid, JournalSeq(3)).await;
+        let replay = db
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(3),
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            )
+            .await;
         assert!(matches!(
             replay,
             Err(Error::AlreadyApplied(ProcessingPayload::Stage {
@@ -336,7 +414,14 @@ mod tests {
 
         // Custom state is read back, and committing without new state preserves it.
         let next = db
-            .start_transaction(uuid, JournalSeq(4))
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(4),
+                    stage: Stage::TobBloat,
+                    attempt: None,
+                },
+            )
             .await
             .expect("guard should pass");
         assert_eq!(next.custom_data(), Some(&custom));
@@ -345,7 +430,14 @@ mod tests {
             .expect("commit failed");
 
         let after = db
-            .start_transaction(uuid, JournalSeq(5))
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(5),
+                    stage: Stage::TobNylocas,
+                    attempt: None,
+                },
+            )
             .await
             .expect("guard should pass");
         assert_eq!(after.custom_data(), Some(&custom));
@@ -363,7 +455,14 @@ mod tests {
         let id = insert_challenge(&db, uuid).await;
 
         let txn = db
-            .start_transaction(uuid, JournalSeq(1))
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(1),
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            )
             .await
             .expect("guard should pass");
         txn.commit(&ProcessingPayload::None, None)
@@ -383,13 +482,131 @@ mod tests {
         assert_eq!(row.get::<_, Option<i16>>(1), None);
         assert_eq!(row.get::<_, Option<i32>>(2), None);
 
-        let replay = db.start_transaction(uuid, JournalSeq(1)).await;
+        let replay = db
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(1),
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            )
+            .await;
         assert!(matches!(
             replay,
             Err(Error::AlreadyApplied(ProcessingPayload::None))
         ));
 
         delete_challenge(&db, uuid).await;
+    }
+
+    #[tokio::test]
+    async fn finish_commit_finalizes_processing_state() {
+        let Some(db) = test_database().await else {
+            return;
+        };
+        let uuid = Uuid::new_v4();
+        let id = insert_challenge(&db, uuid).await;
+
+        // A stage run leaves continuation state behind.
+        let custom = serde_json::json!({ "delve": 6 });
+        let txn = db
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(3),
+                    stage: Stage::MokhaiotlDelve6,
+                    attempt: None,
+                },
+            )
+            .await
+            .expect("guard should pass");
+        txn.commit(
+            &ProcessingPayload::Stage {
+                status: StageStatus::Completed,
+                ticks: 154,
+            },
+            Some(&custom),
+        )
+        .await
+        .expect("commit failed");
+
+        let txn = db
+            .start_transaction(uuid, Trigger::Finish { seq: JournalSeq(5) })
+            .await
+            .expect("guard should pass");
+        assert_eq!(txn.custom_data(), Some(&custom));
+        txn.commit(&ProcessingPayload::None, None)
+            .await
+            .expect("commit failed");
+
+        let client = db.pool.get().await.expect("client");
+        let row = client
+            .query_one(
+                "SELECT processed_seq, outcome_status, outcome_ticks, custom_data, finalized_seq
+                 FROM challenge_processing_state WHERE challenge_id = $1",
+                &[&id],
+            )
+            .await
+            .expect("state row missing");
+        assert_eq!(row.get::<_, i64>(0), 5);
+        assert_eq!(row.get::<_, Option<i16>>(1), None);
+        assert_eq!(row.get::<_, Option<i32>>(2), None);
+        assert_eq!(row.get::<_, Option<serde_json::Value>>(3), None);
+        assert_eq!(row.get::<_, Option<i64>>(4), Some(5));
+        drop(client);
+
+        let replay = db
+            .start_transaction(uuid, Trigger::Finish { seq: JournalSeq(5) })
+            .await;
+        assert!(matches!(
+            replay,
+            Err(Error::AlreadyApplied(ProcessingPayload::None))
+        ));
+
+        delete_challenge(&db, uuid).await;
+    }
+
+    #[tokio::test]
+    async fn deleted_transaction_commits_without_any_processing_state() {
+        let Some(db) = test_database().await else {
+            return;
+        };
+        let uuid = Uuid::new_v4();
+        let id = insert_challenge(&db, uuid).await;
+
+        let mut txn = db
+            .start_transaction(uuid, Trigger::Finish { seq: JournalSeq(2) })
+            .await
+            .expect("guard should pass");
+        txn.delete_challenge().await.expect("delete failed");
+        txn.commit(&ProcessingPayload::None, None)
+            .await
+            .expect("commit failed");
+
+        let client = db.pool.get().await.expect("client");
+        let challenges = client
+            .query("SELECT 1 FROM challenges WHERE id = $1", &[&id])
+            .await
+            .expect("challenges query");
+        assert!(challenges.is_empty());
+        let state = client
+            .query(
+                "SELECT 1 FROM challenge_processing_state WHERE challenge_id = $1",
+                &[&id],
+            )
+            .await
+            .expect("state query");
+        assert!(state.is_empty());
+        drop(client);
+
+        let replay = db
+            .start_transaction(uuid, Trigger::Finish { seq: JournalSeq(2) })
+            .await;
+        assert!(matches!(
+            replay,
+            Err(Error::AlreadyApplied(ProcessingPayload::None))
+        ));
     }
 
     #[tokio::test]
@@ -401,7 +618,14 @@ mod tests {
         let id = insert_challenge(&db, uuid).await;
 
         let txn = db
-            .start_transaction(uuid, JournalSeq(1))
+            .start_transaction(
+                uuid,
+                Trigger::Stage {
+                    seq: JournalSeq(1),
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            )
             .await
             .expect("guard should pass");
         txn.execute("UPDATE challenges SET scale = 5 WHERE id = $1", &[&id])

--- a/challenge-harder/src/processing/interpret.rs
+++ b/challenge-harder/src/processing/interpret.rs
@@ -439,6 +439,8 @@ mod tests {
             stage_attempt: None,
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
 
         let output = interpret(

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -111,7 +111,7 @@ impl StageProcessor for Pipeline {
             "processing_started",
         );
 
-        let mut txn = match self.db.start_transaction(uuid, request.trigger.seq()).await {
+        let mut txn = match self.db.start_transaction(uuid, request.trigger).await {
             Ok(txn) => txn,
             Err(db::Error::AlreadyApplied(payload)) => {
                 tracing::debug!(%uuid, seq = ?request.trigger.seq(), "processing_step_already_applied");
@@ -122,19 +122,9 @@ impl StageProcessor for Pipeline {
 
         let (payload, custom_data) = match request.trigger {
             Trigger::Create { .. } => {
-                challenge::create(&mut txn, &request.challenge).await?;
-                match processor_for(&request.challenge, None)? {
-                    Some(mut processor) => {
-                        processor.on_create(&txn).await?;
-                        if let Some(data) = processor.challenge_data() {
-                            self.repository
-                                .save_challenge(request.challenge.uuid, &data)
-                                .await?;
-                        }
-                        (ProcessingPayload::None, processor.custom_data())
-                    }
-                    None => (ProcessingPayload::None, None),
-                }
+                let custom_data =
+                    challenge::create(&mut txn, &self.repository, &request.challenge).await?;
+                (ProcessingPayload::None, custom_data)
             }
             Trigger::Recorder {
                 user_id,
@@ -153,7 +143,7 @@ impl StageProcessor for Pipeline {
                 (ProcessingPayload::None, None)
             }
             Trigger::Finish { .. } => {
-                challenge::finish(&txn, &request.challenge).await?;
+                challenge::finish(&mut txn, &self.repository, &request.challenge).await?;
                 (ProcessingPayload::None, None)
             }
             Trigger::Stage { .. } => {

--- a/challenge-harder/src/processing/mokhaiotl.rs
+++ b/challenge-harder/src/processing/mokhaiotl.rs
@@ -317,6 +317,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::lifecycle::core::state::Trigger;
     use crate::lifecycle::core::types::{
         ChallengeMode, ChallengeStatus, ChallengeType, JournalSeq, StageStatus, Uuid,
     };
@@ -340,6 +341,8 @@ mod tests {
                 stage_attempt: None,
                 status: ChallengeStatus::InProgress,
                 created_unix_ms: 0,
+                reported_times: None,
+                finished_unix_ms: None,
             },
             None,
         )
@@ -363,6 +366,8 @@ mod tests {
                 stage_attempt: None,
                 status: ChallengeStatus::InProgress,
                 created_unix_ms: 0,
+                reported_times: None,
+                finished_unix_ms: None,
             },
             Some(&json!({"delves": 51})),
         )
@@ -416,6 +421,8 @@ mod tests {
             stage_attempt: None,
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
 
         let contiguous = MokhaiotlProcessor {
@@ -477,6 +484,8 @@ mod tests {
             stage_attempt: Some(2),
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
 
         let capped = MokhaiotlProcessor {
@@ -512,6 +521,8 @@ mod tests {
             stage_attempt: None,
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
         for (initial, style, expected) in [
             (
@@ -590,6 +601,8 @@ mod tests {
             stage_attempt: None,
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
         let mut processor = MokhaiotlProcessor::new(challenge, None).unwrap();
         let mut ctx = StageContext::new(vec!["1Ogp".to_string()]);
@@ -638,6 +651,8 @@ mod tests {
             stage_attempt: None,
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
         let mut processor = MokhaiotlProcessor::new(challenge, None).unwrap();
         let mut ctx = StageContext::new(vec!["1Ogp".to_string()]);
@@ -663,7 +678,7 @@ mod tests {
             return;
         };
         let txn = db
-            .start_transaction(Uuid::new_v4(), JournalSeq(1))
+            .start_transaction(Uuid::new_v4(), Trigger::Create { seq: JournalSeq(1) })
             .await
             .expect("guard should pass");
 
@@ -713,6 +728,8 @@ mod tests {
                     stage_attempt,
                     status,
                     created_unix_ms: 0,
+                    reported_times: None,
+                    finished_unix_ms: None,
                 },
                 None,
             )

--- a/challenge-harder/src/processing/persist.rs
+++ b/challenge-harder/src/processing/persist.rs
@@ -1,110 +1,19 @@
-//! Stage result persistence.
+//! Database writers for challenge processing effects.
 
 use std::collections::BTreeMap;
 
-use crate::lifecycle::core::types::{
-    PrimaryMeleeGear, ProcessingError, ProcessingPayload, Stage, StageStatus,
-};
+use crate::lifecycle::core::types::{PrimaryMeleeGear, Stage};
 use crate::proto::{Event, event};
-use crate::repository::DataRepository;
 use crate::skill::SkillLevel;
 
-use super::challenge_processor::{ChallengeProcessor, StageContext};
+use super::challenge_processor::{PlayerData, StageContext};
 use super::db;
-use super::interpret::{InterpretError, InterpretOutput};
-use super::split::{SplitExt, SplitType};
+use super::interpret::InterpretOutput;
+use super::split::{SavedSplit, SplitExt, SplitType};
 use super::stats::PlayerStatsDelta;
-use super::{ChallengeInfo, StoredPlayerInfo, StoredState};
+use super::{ChallengeInfo, StoredPlayerInfo};
 
-/// Writes a stage's processed results to the database and blob store.
-/// Returns the payload to be sent back to the challenge.
-pub(super) async fn persist(
-    txn: &db::Transaction,
-    repository: &DataRepository,
-    challenge: &ChallengeInfo,
-    stored: &StoredState,
-    result: Result<InterpretOutput, InterpretError>,
-    processor: &mut dyn ChallengeProcessor,
-) -> Result<ProcessingPayload, ProcessingError> {
-    let payload = payload_from(&result);
-
-    if let Ok(mut output) = result {
-        processor
-            .on_stage_finished(
-                txn,
-                stored,
-                &mut output.ctx,
-                challenge.stage,
-                &output.events,
-            )
-            .await?;
-
-        let splits = write_splits(
-            txn,
-            challenge,
-            output.events.accurate_until(),
-            output.events.status() == StageStatus::Completed,
-            &output.ctx,
-        )
-        .await?;
-        update_personal_bests(txn, challenge, &stored.players, &splits).await?;
-
-        let ((), (), queryable_events, ()) = tokio::try_join!(
-            update_players(txn, challenge.stage, &output.ctx, &stored.players),
-            update_player_stats(txn, &output.ctx, &stored.players),
-            write_queryable_events(txn, challenge, &output, &stored.players),
-            update_challenge_row(txn, output.events.last_tick(), output.ctx.deaths().len())
-        )?;
-
-        let queryable_until = output.events.queryable_until();
-        let events = output.into_kept_events();
-        let total_events = events.len();
-
-        let challenge_data = processor.challenge_data();
-        let save_events = async {
-            if let Some(data) = challenge_data {
-                repository.save_challenge(challenge.uuid, &data).await
-            } else {
-                Ok(())
-            }
-        };
-
-        tokio::try_join!(
-            save_events,
-            repository.save_stage_events(
-                challenge.uuid,
-                challenge.stage,
-                challenge.stage_attempt,
-                &challenge.party,
-                events,
-            )
-        )?;
-
-        tracing::info!(
-            uuid = %challenge.uuid,
-            stage = ?challenge.stage,
-            total_events,
-            queryable_events,
-            queryable_until,
-            "challenge_stage_events_saved",
-        );
-    }
-
-    Ok(payload)
-}
-
-fn payload_from(result: &Result<InterpretOutput, InterpretError>) -> ProcessingPayload {
-    match result {
-        Ok(output) => ProcessingPayload::Stage {
-            status: output.events.status(),
-            ticks: output.events.last_tick(),
-        },
-        // TODO(frolv): Handle errors.
-        Err(InterpretError::NoData) => ProcessingPayload::None,
-    }
-}
-
-async fn update_players(
+pub(super) async fn update_players(
     txn: &db::Transaction,
     stage: Stage,
     ctx: &StageContext,
@@ -146,14 +55,14 @@ async fn update_players(
 }
 
 /// Applies each player's accumulated stat changes to their `player_stats`.
-async fn update_player_stats(
+pub(super) async fn update_player_stats(
     txn: &db::Transaction,
-    ctx: &StageContext,
+    data: &[PlayerData],
     players: &[StoredPlayerInfo],
 ) -> Result<(), db::Error> {
     let updates: Vec<_> = players
         .iter()
-        .zip(ctx.players())
+        .zip(data)
         .filter(|(_, data)| !data.stats.is_empty())
         .map(|(info, data)| (info.id, data.stats.columns()))
         .collect();
@@ -250,45 +159,42 @@ struct InsertedSplit {
     accurate: bool,
 }
 
-/// Inserts a stage's recorded splits, returning the inserted rows.
-///
-/// Stage splits count their ticks from their recorded start, and are accurate
-/// when they lie within the timeline's accurate prefix.
-/// Challenge splits are inaccurate unless explicitly overridden.
+/// Stores resolved splits, updating players' personal bests from any that are
+/// accurate.
+pub(super) async fn save_splits(
+    txn: &db::Transaction,
+    challenge: &ChallengeInfo,
+    splits: Vec<SavedSplit>,
+    players: &[StoredPlayerInfo],
+) -> Result<(), db::Error> {
+    let inserted = write_splits(txn, challenge, splits).await?;
+    update_personal_bests(txn, challenge, players, &inserted).await
+}
+
 async fn write_splits(
     txn: &db::Transaction,
     challenge: &ChallengeInfo,
-    accurate_until: u32,
-    completed: bool,
-    ctx: &StageContext,
+    splits: Vec<SavedSplit>,
 ) -> Result<Vec<InsertedSplit>, db::Error> {
-    let mut rows = Vec::new();
-    for (split, entry) in ctx.stage_splits() {
-        rows.push((
-            split.adjust_to(challenge.mode),
-            entry.tick - entry.start,
-            entry.tick < accurate_until && (!entry.requires_completion || completed),
-        ));
-    }
-    for (split, entry) in ctx.challenge_splits() {
-        rows.push((
-            split.adjust_to(challenge.mode),
-            entry.ticks,
-            entry.accurate.unwrap_or(false),
-        ));
-    }
-
-    if rows.is_empty() {
+    if splits.is_empty() {
         return Ok(Vec::new());
     }
 
-    let mut types = Vec::with_capacity(rows.len());
-    let mut ticks = Vec::with_capacity(rows.len());
-    let mut accurate = Vec::with_capacity(rows.len());
-    for &(split, t, acc) in &rows {
-        types.push(split as i16);
-        ticks.push(t.cast_signed());
-        accurate.push(acc);
+    let splits: Vec<SavedSplit> = splits
+        .into_iter()
+        .map(|entry| SavedSplit {
+            split: entry.split.adjust_to(challenge.mode),
+            ..entry
+        })
+        .collect();
+
+    let mut types = Vec::with_capacity(splits.len());
+    let mut ticks = Vec::with_capacity(splits.len());
+    let mut accurate = Vec::with_capacity(splits.len());
+    for entry in &splits {
+        types.push(entry.split as i16);
+        ticks.push(entry.ticks.cast_signed());
+        accurate.push(entry.accurate);
     }
 
     let ids = txn
@@ -309,12 +215,12 @@ async fn write_splits(
 
     Ok(ids
         .into_iter()
-        .zip(rows)
-        .map(|(row, (split, ticks, accurate))| InsertedSplit {
+        .zip(splits)
+        .map(|(row, entry)| InsertedSplit {
             id: row.get(0),
-            split,
-            ticks,
-            accurate,
+            split: entry.split,
+            ticks: entry.ticks,
+            accurate: entry.accurate,
         })
         .collect())
 }
@@ -393,7 +299,7 @@ async fn update_personal_bests(
     Ok(())
 }
 
-async fn update_challenge_row(
+pub(super) async fn update_challenge_row(
     txn: &db::Transaction,
     stage_ticks: u32,
     new_deaths: usize,
@@ -430,7 +336,7 @@ struct QueryableEvent {
 
 /// Writes the stage's kept events within the queryable prefix to the
 /// `queryable_events` table. Returns the number of rows written.
-async fn write_queryable_events(
+pub(super) async fn write_queryable_events(
     txn: &db::Transaction,
     challenge: &ChallengeInfo,
     output: &InterpretOutput,
@@ -703,17 +609,4 @@ fn to_queryable_event(
     };
 
     Some(row)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn no_data_yields_no_payload() {
-        assert_eq!(
-            payload_from(&Err(InterpretError::NoData)),
-            ProcessingPayload::None,
-        );
-    }
 }

--- a/challenge-harder/src/processing/split.rs
+++ b/challenge-harder/src/processing/split.rs
@@ -24,6 +24,13 @@ pub struct ChallengeSplit {
     pub accurate: Option<bool>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SavedSplit {
+    pub split: SplitType,
+    pub ticks: u32,
+    pub accurate: bool,
+}
+
 pub trait SplitExt {
     /// Converts a split type to a different mode,
     /// For example, `TobEntryNyloBossSpawn` adjusted to `TobHard` becomes

--- a/challenge-harder/src/processing/stage.rs
+++ b/challenge-harder/src/processing/stage.rs
@@ -10,15 +10,19 @@
 
 use crate::lifecycle::challenge::StoreError;
 use crate::lifecycle::core::types::{
-    ClientStageStream, PlayerId, PrimaryMeleeGear, ProcessingError, ProcessingPayload,
+    ClientStageStream, ProcessingError, ProcessingPayload, StageStatus,
 };
 use crate::repository::DataRepository;
 use crate::store::Store;
 
+use super::challenge::load_database_state;
+use super::challenge_processor::ChallengeProcessor;
 use super::db;
-use super::interpret::interpret;
-use super::persist::persist;
-use super::{ChallengeInfo, StoredPlayerInfo, StoredState};
+use super::interpret::{InterpretError, InterpretOutput, interpret};
+use super::persist::{
+    save_splits, update_challenge_row, update_player_stats, update_players, write_queryable_events,
+};
+use super::{ChallengeInfo, StoredState};
 
 /// Processes a stage's events from its recorded streams.
 pub async fn process(
@@ -71,60 +75,101 @@ async fn gather(
             })
     };
     let stored = async {
-        load_database_state(txn, challenge.scale())
+        load_database_state(txn, challenge)
             .await
             .map_err(ProcessingError::from)
     };
     tokio::try_join!(stream, stored)
 }
 
-pub(super) async fn load_database_state(
+/// Writes a stage's processed results to the database and blob store.
+/// Returns the payload to be sent back to the challenge.
+async fn persist(
     txn: &db::Transaction,
-    expected_scale: i16,
-) -> Result<StoredState, db::Error> {
-    let players = async {
-        let rows = txn
-            .query(
-                "SELECT player_id, primary_gear FROM challenge_players
-                 WHERE challenge_id = $1
-                 ORDER BY orb",
-                &[&txn.challenge_id()],
-            )
-            .await?;
-        if rows.len() != expected_scale.cast_unsigned() as usize {
-            return Err(db::Error::InvalidData(format!(
-                "challenge has {} players, expected {expected_scale}",
-                rows.len(),
-            )));
+    repository: &DataRepository,
+    challenge: &ChallengeInfo,
+    stored: &StoredState,
+    result: Result<InterpretOutput, InterpretError>,
+    processor: &mut dyn ChallengeProcessor,
+) -> Result<ProcessingPayload, ProcessingError> {
+    let payload = payload_from(&result);
+    let Ok(mut output) = result else {
+        return Ok(payload);
+    };
+
+    processor
+        .on_stage_finished(
+            txn,
+            stored,
+            &mut output.ctx,
+            challenge.stage,
+            &output.events,
+        )
+        .await?;
+
+    save_splits(
+        txn,
+        challenge,
+        output.ctx.splits(
+            output.events.accurate_until(),
+            output.events.status() == StageStatus::Completed,
+        ),
+        &stored.players,
+    )
+    .await?;
+
+    let ((), (), queryable_events, ()) = tokio::try_join!(
+        update_players(txn, challenge.stage, &output.ctx, &stored.players),
+        update_player_stats(txn, output.ctx.players(), &stored.players),
+        write_queryable_events(txn, challenge, &output, &stored.players),
+        update_challenge_row(txn, output.events.last_tick(), output.ctx.deaths().len())
+    )?;
+
+    let queryable_until = output.events.queryable_until();
+    let events = output.into_kept_events();
+    let total_events = events.len();
+
+    let challenge_data = processor.challenge_data();
+    let save_challenge_data = async {
+        if let Some(data) = challenge_data {
+            repository.save_challenge(challenge.uuid, &data).await
+        } else {
+            Ok(())
         }
-
-        rows.iter()
-            .map(|row| {
-                let gear: i16 = row.get(1);
-                Ok(StoredPlayerInfo {
-                    id: PlayerId(row.get(0)),
-                    gear: PrimaryMeleeGear::try_from(gear)
-                        .map_err(|value| db::Error::InvalidData(format!("primary gear {value}")))?,
-                })
-            })
-            .collect::<Result<Vec<_>, db::Error>>()
     };
-    let challenge_ticks = async {
-        let row = txn
-            .query_one(
-                "SELECT challenge_ticks FROM challenges WHERE id = $1",
-                &[&txn.challenge_id()],
-            )
-            .await?;
-        Ok(row.get::<_, i32>(0).cast_unsigned())
-    };
-    let (players, challenge_ticks) = tokio::try_join!(players, challenge_ticks)?;
 
-    Ok(StoredState {
-        players,
-        challenge_ticks,
-        custom_data: txn.custom_data().cloned(),
-    })
+    tokio::try_join!(
+        save_challenge_data,
+        repository.save_stage_events(
+            challenge.uuid,
+            challenge.stage,
+            challenge.stage_attempt,
+            &challenge.party,
+            events,
+        )
+    )?;
+
+    tracing::info!(
+        uuid = %challenge.uuid,
+        stage = ?challenge.stage,
+        total_events,
+        queryable_events,
+        queryable_until,
+        "challenge_stage_events_saved",
+    );
+
+    Ok(payload)
+}
+
+fn payload_from(result: &Result<InterpretOutput, InterpretError>) -> ProcessingPayload {
+    match result {
+        Ok(output) => ProcessingPayload::Stage {
+            status: output.events.status(),
+            ticks: output.events.last_tick(),
+        },
+        // TODO(frolv): Handle errors.
+        Err(InterpretError::NoData) => ProcessingPayload::None,
+    }
 }
 
 #[cfg(test)]
@@ -132,7 +177,6 @@ mod tests {
     use bytes::Bytes;
     use prost::Message;
 
-    use super::super::interpret::{InterpretError, InterpretOutput};
     use super::super::mokhaiotl::MokhaiotlProcessor;
     use super::*;
     use crate::lifecycle::core::types::{
@@ -143,6 +187,14 @@ mod tests {
 
     fn test_uuid() -> Uuid {
         "a8cb035f-410a-45de-a4d3-2b0a5d8b464d".parse().unwrap()
+    }
+
+    #[test]
+    fn no_data_yields_no_payload() {
+        assert_eq!(
+            payload_from(&Err(InterpretError::NoData)),
+            ProcessingPayload::None,
+        );
     }
 
     fn events(client: i64, ticks: &[u32]) -> ClientStageStream {
@@ -189,6 +241,8 @@ mod tests {
             stage_attempt: None,
             status: ChallengeStatus::InProgress,
             created_unix_ms: 0,
+            reported_times: None,
+            finished_unix_ms: None,
         };
         let mut processor =
             MokhaiotlProcessor::new(info.clone(), None).expect("empty custom data is valid");

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -1851,7 +1851,9 @@ fn terminated_state(uuid: Uuid, create: &Create) -> ChallengeState {
         challenge_type: create.challenge_type,
         mode: create.mode,
         party: create.party.clone(),
-        phase: PhaseState::Terminated,
+        phase: PhaseState::Terminated {
+            finished_unix_ms: 1_785_693_975_535,
+        },
         recorded_by: [create.client_id].into(),
         ..ChallengeState::default()
     }


### PR DESCRIPTION
Updates the challenge finish processing path to call into the challenge processor's completion hook, save final splits and stat updates, record the completion time, and finalize both the challenge and its processing rows. Challenges finishing without any data recorded are deleted.