### PR TITLE
socket: Forward reported times if only challenge exists

### DIFF
--- a/challenge-server/event-processing/challenge-processor.ts
+++ b/challenge-server/event-processing/challenge-processor.ts
@@ -118,7 +118,8 @@ type SessionFinalizationOptions = {
 
 export type ReportedTimes = {
   challenge: number;
-  overall: number;
+  /** Absent when the challenge has no overall timer. */
+  overall: number | null;
 };
 
 export type ChallengeSplit = {

--- a/challenge-server/event-processing/index.ts
+++ b/challenge-server/event-processing/index.ts
@@ -93,7 +93,7 @@ export function loadChallengeProcessor(
   state: ChallengeState,
 ) {
   const reportedTimes =
-    state.reportedChallengeTicks !== null && state.reportedOverallTicks !== null
+    state.reportedChallengeTicks !== null
       ? {
           challenge: state.reportedChallengeTicks,
           overall: state.reportedOverallTicks,

--- a/socket-server/remote-challenge-manager.ts
+++ b/socket-server/remote-challenge-manager.ts
@@ -144,17 +144,16 @@ export class RemoteChallengeManager extends ChallengeManager {
     inGameTimes: RecordedTimes | null,
     soft: boolean,
   ): Promise<void> {
-    // The plugin uses -1 to indicate that a time was not reported. Also, it is
-    // unlikely that one of of the two times would be captured and not the other
-    // so only send the times if both are present to simplify the server logic.
-    //
-    // TODO(frolv): The behavior of the plugin should be made consistent with
-    // the logic below so that its times can be sent directly.
+    // The plugin uses -1 to indicate that a time was not reported.
+    // Not all challenges report an overall time.
     const ts = Date.now();
 
     let times = null;
-    if (inGameTimes && inGameTimes.challenge > 0 && inGameTimes.overall > 0) {
-      times = inGameTimes;
+    if (inGameTimes && inGameTimes.challenge > 0) {
+      times = {
+        challenge: inGameTimes.challenge,
+        overall: inGameTimes.overall > 0 ? inGameTimes.overall : null,
+      };
     }
 
     const body = {


### PR DESCRIPTION
Reported time forwarding from the socket to the challenge server only occurred if both a challenge and overall time was set. This baked in a ToB-specific assumption which is not relevant to other challenge types. This updates it to send them even if the challenge type only reports a challenge time without an overall.