### PR TITLE
2c2s: Publish STAGE_END and delete streams

### DIFF
--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -18,7 +18,7 @@ use super::core::state::{
     ChallengeState, LastCompleted, PhaseState, Processing, ProcessingState, PublishedClient,
     Snapshot, Trigger,
 };
-use super::core::types::{ClientId, JournalSeq, MsgId, Stage, Timestamp, Uuid};
+use super::core::types::{ClientId, JournalSeq, MsgId, ProcessingPayload, Stage, Timestamp, Uuid};
 use crate::processing::{ChallengeInfo, ProcessingRequest, StageProcessor};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -85,11 +85,12 @@ pub enum Rejoin {
 
 /// A lifecycle milestone broadcast to external consumers.
 /// Mirrors `ChallengeServerUpdate` in `//common/db/redis.ts`.
-// TODO(frolv): STAGE_END should be added alongside the stage processor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChallengeServerUpdate {
     /// The challenge has ended.
     Finish,
+    /// Processing of a stage has concluded.
+    StageEnd { stage: Stage, attempt: Option<u32> },
 }
 
 /// A change to a challenge's published state, delivered to store subscribers.
@@ -184,6 +185,13 @@ pub trait ChallengeClaim: Send + Sync + 'static {
 
     /// Marks stages' event streams as sealed, blocking further writes.
     async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError>;
+
+    /// Deletes a processed stage's event stream.
+    async fn remove_stage_stream(
+        &self,
+        stage: Stage,
+        attempt: Option<u32>,
+    ) -> Result<(), StoreError>;
 
     /// Extends this claim's hold on the challenge.
     async fn renew(&self) -> Result<(), StoreError>;
@@ -282,6 +290,7 @@ pub struct ActiveChallenge {
     claim: Claim,
     next_seq: u64,
     processor: Option<Arc<dyn StageProcessor>>,
+    processing_task: Option<ProcessingTask>,
 }
 
 /// A challenge data processing task which is aborted when dropped.
@@ -311,6 +320,7 @@ impl ActiveChallenge {
             claim,
             next_seq,
             processor,
+            processing_task: None,
         }
     }
 
@@ -320,7 +330,6 @@ impl ActiveChallenge {
     /// it terminates.
     /// `resumed_at` is the time of the last journal entry in the challenge's
     /// clock, to continue timestamps from it.
-    #[allow(clippy::too_many_lines)]
     pub async fn run(&mut self, resumed_at: Timestamp, mut shutdown: watch::Receiver<bool>) {
         if self.state.terminated() && self.state.processing.settled() {
             // A previous task stopped between its terminal entry and deletion.
@@ -349,7 +358,7 @@ impl ActiveChallenge {
                 _ => None,
             })
             .collect();
-        if !self.mark_processed(&outstanding).await {
+        if self.mark_processed(&outstanding).await.is_err() {
             return;
         }
 
@@ -359,8 +368,7 @@ impl ActiveChallenge {
         let (chanel_tx, mut chanel) = mpsc::channel(CHANEL_BUFFER_LEN);
 
         // Respawn any run the journal shows started but never finished.
-        // The task is held purely for drop semantics.
-        let mut _run_task = match self.state.processing.active() {
+        self.processing_task = match self.state.processing.active() {
             Some(run) if matches!(run.state, ProcessingState::Running { .. }) => {
                 self.spawn_processing_run(chanel_tx.clone())
             }
@@ -417,80 +425,16 @@ impl ActiveChallenge {
                 base.saturating_add(u64::try_from(elapsed).unwrap_or(u64::MAX)),
             );
 
-            let batch: Vec<JournalEntry> = decide(&self.state, &self.config, &cmd)
-                .into_iter()
-                .map(|event| {
-                    let seq = JournalSeq(self.next_seq);
-                    self.next_seq += 1;
-                    JournalEntry {
-                        seq,
-                        at,
-                        caused_by: cause,
-                        event,
-                    }
-                })
-                .collect();
-
-            let decided = !batch.is_empty();
-            if decided {
-                if let Err(error) = self.append(&batch).await {
-                    tracing::error!(uuid = %self.state.uuid, %error, "journal_append_failed");
-                    return;
-                }
-                let mut sealed = Vec::new();
-                for entry in batch {
-                    tracing::info!(
-                        uuid = %self.state.uuid,
-                        seq = entry.seq.0,
-                        caused_by = ?entry.caused_by,
-                        event = ?entry.event,
-                        "journal_entry",
-                    );
-                    let starts_run =
-                        matches!(entry.event, LifecycleEvent::ProcessingStarted { .. });
-                    let ends_run = match entry.event {
-                        LifecycleEvent::ProcessingFinished { .. } => true,
-                        LifecycleEvent::ProcessingFailed { trigger, ref error } => {
-                            tracing::error!(
-                                uuid = %self.state.uuid,
-                                trigger = trigger.0,
-                                error = %error.message,
-                                "processing_failed",
-                            );
-                            true
-                        }
-                        LifecycleEvent::ProcessingTimedOut { trigger } => {
-                            tracing::warn!(
-                                uuid = %self.state.uuid,
-                                trigger = trigger.0,
-                                "processing_timed_out",
-                            );
-                            true
-                        }
-                        _ => false,
-                    };
-                    if let LifecycleEvent::StageSealed { stage, attempt, .. } = entry.event {
-                        sealed.push((stage, attempt));
-                    }
-                    apply(&mut self.state, entry);
-                    if starts_run {
-                        _run_task = self.spawn_processing_run(chanel_tx.clone());
-                    } else if ends_run {
-                        _run_task = None;
-                    }
-                }
-                // Close stage streams immediately after they're sealed.
-                if !self.mark_processed(&sealed).await {
-                    return;
-                }
-            }
+            let Ok(updated) = self.handle_command(&cmd, cause, at, &chanel_tx).await else {
+                return;
+            };
 
             if let Cause::Command(id) = cause {
                 cursor = id;
             }
 
             // Only publish if the state changed.
-            let changed = decided || matches!(cause, Cause::Command(_));
+            let changed = updated || matches!(cause, Cause::Command(_));
             if changed && !self.project(cursor).await {
                 return;
             }
@@ -502,19 +446,118 @@ impl ActiveChallenge {
         }
     }
 
-    /// Closes sealed stages' streams to further writes, returning false if
-    /// the markers could not be written. Marking nothing trivially succeeds.
-    async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> bool {
+    /// Processes a command occurring at time `at`, applying changes and effects.
+    /// Returns whether any of its outcomes modified the challenge state.
+    async fn handle_command(
+        &mut self,
+        cmd: &Command,
+        cause: Cause,
+        at: Timestamp,
+        chanel: &mpsc::Sender<Processed>,
+    ) -> Result<bool, StoreError> {
+        let batch: Vec<JournalEntry> = decide(&self.state, &self.config, cmd)
+            .into_iter()
+            .map(|event| {
+                let seq = JournalSeq(self.next_seq);
+                self.next_seq += 1;
+                JournalEntry {
+                    seq,
+                    at,
+                    caused_by: cause,
+                    event,
+                }
+            })
+            .collect();
+
+        if batch.is_empty() {
+            return Ok(false);
+        }
+
+        if let Err(error) = self.append(&batch).await {
+            tracing::error!(uuid = %self.state.uuid, %error, "journal_append_failed");
+            return Err(error);
+        }
+
+        let mut sealed = Vec::new();
+        let completed_runs_before = self.state.processing.completed().len();
+
+        for entry in batch {
+            tracing::info!(
+                uuid = %self.state.uuid,
+                seq = entry.seq.0,
+                caused_by = ?entry.caused_by,
+                event = ?entry.event,
+                "journal_entry",
+            );
+            let starts_run = matches!(entry.event, LifecycleEvent::ProcessingStarted { .. });
+            let ends_run = match entry.event {
+                LifecycleEvent::ProcessingFinished { .. } => true,
+                LifecycleEvent::ProcessingFailed { trigger, ref error } => {
+                    tracing::error!(
+                        uuid = %self.state.uuid,
+                        trigger = trigger.0,
+                        error = %error.message,
+                        "processing_failed",
+                    );
+                    true
+                }
+                LifecycleEvent::ProcessingTimedOut { trigger } => {
+                    tracing::warn!(
+                        uuid = %self.state.uuid,
+                        trigger = trigger.0,
+                        "processing_timed_out",
+                    );
+                    true
+                }
+                _ => false,
+            };
+            if let LifecycleEvent::StageSealed { stage, attempt, .. } = entry.event {
+                sealed.push((stage, attempt));
+            }
+            apply(&mut self.state, entry);
+            if starts_run {
+                self.processing_task = self.spawn_processing_run(chanel.clone());
+            } else if ends_run {
+                self.processing_task = None;
+            }
+        }
+        // Close stage streams immediately after they're sealed.
+        self.mark_processed(&sealed).await?;
+
+        for &trigger in &self.state.processing.completed()[completed_runs_before..] {
+            if let Trigger::Stage { stage, attempt, .. } = trigger {
+                if let Err(error) = with_retries(self.state.uuid, || {
+                    self.claim.remove_stage_stream(stage, attempt)
+                })
+                .await
+                {
+                    tracing::error!(uuid = %self.state.uuid, %error, "stage_stream_removal_failed");
+                }
+                let update = ChallengeServerUpdate::StageEnd { stage, attempt };
+                if let Err(error) =
+                    with_retries(self.state.uuid, || self.claim.announce(&update)).await
+                {
+                    tracing::error!(uuid = %self.state.uuid, %error, "stage_end_publish_failed");
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Closes sealed stages' streams to further writes. Marking nothing
+    /// trivially succeeds.
+    async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
         if stages.is_empty() {
-            return true;
+            return Ok(());
         }
         if let Err(error) =
             with_retries(self.state.uuid, || self.claim.mark_processed(stages)).await
         {
             tracing::error!(uuid = %self.state.uuid, %error, "mark_processed_failed");
-            return false;
+            return Err(error);
         }
-        true
+        Ok(())
     }
 
     /// Publishes a snapshot of the current state and its clients, returning
@@ -648,6 +691,7 @@ mod tests {
         projected: Mutex<Vec<(Snapshot, Vec<PublishedClient>)>>,
         announced: Mutex<Vec<ChallengeServerUpdate>>,
         marked: Mutex<Vec<(Stage, Option<u32>)>>,
+        removed: Mutex<Vec<(Stage, Option<u32>)>>,
         deleted: Mutex<Vec<ChallengeState>>,
         // Holds the inbox feed's sender when the run is deadline-driven,
         // as dropping it would close the actor's inbox and end the run.
@@ -723,6 +767,16 @@ mod tests {
         async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
             self.log.next_result()?;
             self.log.marked.lock().unwrap().extend_from_slice(stages);
+            Ok(())
+        }
+
+        async fn remove_stage_stream(
+            &self,
+            stage: Stage,
+            attempt: Option<u32>,
+        ) -> Result<(), StoreError> {
+            self.log.next_result()?;
+            self.log.removed.lock().unwrap().push((stage, attempt));
             Ok(())
         }
 
@@ -924,6 +978,8 @@ mod tests {
         assert_eq!(outcome.log.calls.load(Ordering::Relaxed), 2);
         assert!(outcome.log.appended.lock().unwrap().is_empty());
         assert!(outcome.log.projected.lock().unwrap().is_empty());
+        assert!(outcome.log.announced.lock().unwrap().is_empty());
+        assert!(outcome.log.removed.lock().unwrap().is_empty());
     }
 
     #[tokio::test(start_paused = true)]

--- a/challenge-harder/src/lifecycle/coordinator.rs
+++ b/challenge-harder/src/lifecycle/coordinator.rs
@@ -705,6 +705,10 @@ mod tests {
             unreachable!();
         }
 
+        async fn remove_stage_stream(&self, _: Stage, _: Option<u32>) -> Result<(), StoreError> {
+            unreachable!();
+        }
+
         async fn renew(&self) -> Result<(), StoreError> {
             unreachable!();
         }

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -201,7 +201,8 @@ pub struct Processing {
     config: ProcessingConfig,
     active: Option<ProcessingRun>,
     pending: VecDeque<QueuedTrigger>,
-    failed: Vec<Trigger>,
+    /// Triggers whose runs settled, successfully or not, in order.
+    completed: Vec<Trigger>,
     /// Whether the challenge's finish trigger has been queued.
     finish_queued: bool,
     /// Status derived from the most recently processed outcome.
@@ -214,7 +215,7 @@ impl Processing {
             config,
             active: None,
             pending: VecDeque::new(),
-            failed: Vec::new(),
+            completed: Vec::new(),
             finish_queued: false,
             status: None,
         }
@@ -277,10 +278,10 @@ impl Processing {
                     run.state = ProcessingState::Idle { since: at };
                     return;
                 }
-                self.failed.push(run.trigger);
             }
         }
 
+        self.completed.push(run.trigger);
         self.active = self
             .pending
             .pop_front()
@@ -301,10 +302,10 @@ impl Processing {
             .chain(self.pending.iter().map(|queued| queued.trigger))
     }
 
-    /// Triggers whose runs were abandoned after exhausting their attempts.
+    /// Triggers whose runs settled, successfully or not, in order.
     #[must_use]
-    pub fn failed(&self) -> &[Trigger] {
-        &self.failed
+    pub fn completed(&self) -> &[Trigger] {
+        &self.completed
     }
 
     /// Timing parameters of the pipeline's runs.
@@ -705,7 +706,7 @@ mod tests {
             Err(error(true)),
         );
         assert_eq!(processing.status, None);
-        assert_eq!(processing.failed, vec![trigger(3, Stage::TobMaiden)]);
+        assert_eq!(processing.completed, vec![trigger(3, Stage::TobMaiden)]);
         assert_eq!(processing.active().unwrap().trigger.seq(), JournalSeq(7));
     }
 
@@ -725,7 +726,7 @@ mod tests {
             Err(error(false)),
         );
         assert_eq!(processing.active(), None);
-        assert_eq!(processing.failed, vec![trigger(3, Stage::TobMaiden)]);
+        assert_eq!(processing.completed, vec![trigger(3, Stage::TobMaiden)]);
         assert!(processing.settled());
     }
 
@@ -774,7 +775,7 @@ mod tests {
         );
         assert_eq!(processing.active(), None);
         assert_eq!(
-            processing.failed,
+            processing.completed,
             vec![Trigger::Finish { seq: JournalSeq(4) }]
         );
         assert!(processing.settled());

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -143,6 +143,8 @@ pub struct ScenarioResult {
     pub inboxes: BTreeMap<Uuid, Vec<MsgId>>,
     /// Stage attempts whose streams were marked processed, per challenge.
     pub marked: MarkedStages,
+    /// Stage attempts whose streams were removed, per challenge.
+    pub removed: RemovedStreams,
     /// Challenges whose state was deleted from the store.
     pub deleted: BTreeSet<Uuid>,
 }
@@ -256,9 +258,8 @@ pub fn perturb(scenario: &mut Scenario, rng: &mut Rng, jitter_ms: u64) {
 }
 
 type SignalSink = Arc<Mutex<Option<mpsc::Sender<ChallengeSignal>>>>;
-
-/// Stage attempts whose streams were marked processed, per challenge.
 type MarkedStages = BTreeMap<Uuid, BTreeSet<(Stage, Option<u32>)>>;
+type RemovedStreams = BTreeMap<Uuid, BTreeSet<(Stage, Option<u32>)>>;
 
 /// Identity of a party for routing, built from its raw names.
 fn party_identity(challenge_type: ChallengeType, party: &[String]) -> String {
@@ -295,6 +296,7 @@ pub(crate) struct Collector {
     projections: Arc<Mutex<BTreeMap<Uuid, Snapshot>>>,
     updates: Arc<Mutex<Vec<(Uuid, ChallengeServerUpdate)>>>,
     marked: Arc<Mutex<MarkedStages>>,
+    removed: Arc<Mutex<RemovedStreams>>,
     signals: SignalSink,
 }
 
@@ -319,14 +321,25 @@ impl Collector {
             .contains(&uuid)
     }
 
-    /// How many times the finish of challenge `uuid` has been announced.
-    pub fn finish_announcements(&self, uuid: Uuid) -> usize {
+    /// Updates published for challenge `uuid`, in publish order.
+    pub fn challenge_updates(&self, uuid: Uuid) -> Vec<ChallengeServerUpdate> {
         self.updates
             .lock()
             .expect("collector lock poisoned")
             .iter()
-            .filter(|(id, update)| *id == uuid && *update == ChallengeServerUpdate::Finish)
-            .count()
+            .filter(|(id, _)| *id == uuid)
+            .map(|(_, update)| *update)
+            .collect()
+    }
+
+    /// Stage streams removed for challenge `uuid`.
+    pub fn removed_streams(&self, uuid: Uuid) -> BTreeSet<(Stage, Option<u32>)> {
+        self.removed
+            .lock()
+            .expect("collector lock poisoned")
+            .get(&uuid)
+            .cloned()
+            .unwrap_or_default()
     }
 
     fn collector_claim(&self, uuid: Uuid) -> CollectorClaim {
@@ -338,6 +351,7 @@ impl Collector {
             projections: self.projections.clone(),
             updates: self.updates.clone(),
             marked: self.marked.clone(),
+            removed: self.removed.clone(),
             signals: self.signals.clone(),
         }
     }
@@ -372,6 +386,7 @@ struct CollectorClaim {
     projections: Arc<Mutex<BTreeMap<Uuid, Snapshot>>>,
     updates: Arc<Mutex<Vec<(Uuid, ChallengeServerUpdate)>>>,
     marked: Arc<Mutex<MarkedStages>>,
+    removed: Arc<Mutex<RemovedStreams>>,
     signals: SignalSink,
 }
 
@@ -669,6 +684,20 @@ impl ChallengeClaim for CollectorClaim {
         Ok(())
     }
 
+    async fn remove_stage_stream(
+        &self,
+        stage: Stage,
+        attempt: Option<u32>,
+    ) -> Result<(), StoreError> {
+        self.removed
+            .lock()
+            .expect("collector lock poisoned")
+            .entry(self.uuid)
+            .or_default()
+            .insert((stage, attempt));
+        Ok(())
+    }
+
     async fn renew(&self) -> Result<(), StoreError> {
         Ok(())
     }
@@ -876,6 +905,11 @@ pub async fn run_with(options: impl Into<RunOptions>, scenario: Scenario) -> Sce
         .lock()
         .expect("collector lock poisoned")
         .clone();
+    let removed = collector
+        .removed
+        .lock()
+        .expect("collector lock poisoned")
+        .clone();
     let deleted = collector
         .routing
         .lock()
@@ -901,6 +935,7 @@ pub async fn run_with(options: impl Into<RunOptions>, scenario: Scenario) -> Sce
         updates,
         inboxes,
         marked,
+        removed,
         deleted,
     };
     check_invariants(&result, &config);
@@ -1067,6 +1102,35 @@ fn check_invariants(result: &ScenarioResult, config: &LifecycleConfig) {
             .collect();
         let marked = result.marked.get(uuid).cloned().unwrap_or_default();
         assert_eq!(marked, sealed, "seal markers mismatch: {uuid}");
+
+        // Every settled stage run deletes its stream and publishes a stage end.
+        let completed_stages: Vec<(Stage, Option<u32>)> = folded
+            .processing
+            .completed()
+            .iter()
+            .filter_map(|trigger| match trigger {
+                Trigger::Stage { stage, attempt, .. } => Some((*stage, *attempt)),
+                _ => None,
+            })
+            .collect();
+        let stage_ends: Vec<(Stage, Option<u32>)> = result
+            .updates
+            .iter()
+            .filter_map(|(id, update)| match update {
+                ChallengeServerUpdate::StageEnd { stage, attempt } if id == uuid => {
+                    Some((*stage, *attempt))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(stage_ends, completed_stages, "stage ends mismatch: {uuid}");
+        let removed = result.removed.get(uuid).cloned().unwrap_or_default();
+        let expected_removed: BTreeSet<(Stage, Option<u32>)> =
+            completed_stages.iter().copied().collect();
+        assert_eq!(
+            removed, expected_removed,
+            "stream removals mismatch: {uuid}"
+        );
 
         // A challenge whose processing completed after termination is deleted
         // and announces its finish exactly once.

--- a/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
+++ b/challenge-harder/src/lifecycle/sim/scenarios/processing.rs
@@ -1,5 +1,6 @@
 //! Stage processing machinery scenarios, driven by a scripted processor.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use tokio::sync::watch;
@@ -359,7 +360,19 @@ async fn finalization_waits_for_processing_to_finish_after_termination() {
     );
 
     assert!(result.deleted.contains(&uuid));
-    assert_eq!(result.updates, vec![(uuid, ChallengeServerUpdate::Finish)],);
+    assert_eq!(
+        result.updates,
+        vec![
+            (
+                uuid,
+                ChallengeServerUpdate::StageEnd {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            ),
+            (uuid, ChallengeServerUpdate::Finish),
+        ],
+    );
     assert_eq!(result.only_status(), ChallengeStatus::Reset);
 }
 
@@ -564,7 +577,19 @@ async fn failed_finish_run_concludes_afterwards() {
     assert_eq!(journal[14..], expected);
 
     assert!(result.deleted.contains(&uuid));
-    assert_eq!(result.updates, vec![(uuid, ChallengeServerUpdate::Finish)]);
+    assert_eq!(
+        result.updates,
+        vec![
+            (
+                uuid,
+                ChallengeServerUpdate::StageEnd {
+                    stage: Stage::TobMaiden,
+                    attempt: None,
+                },
+            ),
+            (uuid, ChallengeServerUpdate::Finish),
+        ],
+    );
     assert_eq!(result.only_status(), ChallengeStatus::Wiped);
 }
 
@@ -757,6 +782,8 @@ fn killed_run_respawns_on_resume() {
     let journal = collector.journal(uuid);
     assert_eq!(journal.last().unwrap().event, started(7));
     assert_eq!(first.requests().len(), 3);
+    assert!(collector.challenge_updates(uuid).is_empty());
+    assert!(collector.removed_streams(uuid).is_empty());
 
     // A new server resumes and the journal's unfinished run respawns without
     // repeating its `Started` entry.
@@ -781,6 +808,29 @@ fn killed_run_respawns_on_resume() {
         finished(7, outcome(StageStatus::Wiped, 60)),
     );
     assert_eq!(second.requests().len(), 1);
+
+    // The completed processing publishes an update.
+    let expected_updates = vec![ChallengeServerUpdate::StageEnd {
+        stage: Stage::TobMaiden,
+        attempt: None,
+    }];
+    assert_eq!(collector.challenge_updates(uuid), expected_updates);
+    let expected_removed = BTreeSet::from([(Stage::TobMaiden, None)]);
+    assert_eq!(collector.removed_streams(uuid), expected_removed);
+
+    // A later instance resuming does not re-run publishes.
+    let third = ScriptedProcessor::new(vec![]);
+    let store = collector.clone();
+    let processor = Arc::clone(&third) as Arc<dyn StageProcessor>;
+    runtime().block_on(async move {
+        let claim = claim_only(&store, uuid).await;
+        tokio::spawn(run_challenge(config(), claim, Some(processor), rx));
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    });
+
+    assert!(third.requests().is_empty());
+    assert_eq!(collector.challenge_updates(uuid), expected_updates);
+    assert_eq!(collector.removed_streams(uuid), expected_removed);
 }
 
 #[test]
@@ -813,7 +863,7 @@ fn final_processing_concludes_exactly_once_on_resume() {
             .iter()
             .any(|e| matches!(e.event, LifecycleEvent::ChallengeTerminated)),
     );
-    assert_eq!(collector.finish_announcements(uuid), 0);
+    assert!(collector.challenge_updates(uuid).is_empty());
     assert!(!collector.is_deleted(uuid));
 
     // Resume and finish processing.
@@ -834,7 +884,20 @@ fn final_processing_concludes_exactly_once_on_resume() {
         .await;
     });
 
-    assert_eq!(collector.finish_announcements(uuid), 1);
+    assert_eq!(
+        collector.challenge_updates(uuid),
+        vec![
+            ChallengeServerUpdate::StageEnd {
+                stage: Stage::TobMaiden,
+                attempt: None,
+            },
+            ChallengeServerUpdate::Finish,
+        ],
+    );
+    assert_eq!(
+        collector.removed_streams(uuid),
+        BTreeSet::from([(Stage::TobMaiden, None)]),
+    );
     assert!(collector.is_deleted(uuid));
     assert_eq!(
         collector.journal(uuid).last().unwrap().event,

--- a/challenge-harder/src/shadow/diff.rs
+++ b/challenge-harder/src/shadow/diff.rs
@@ -253,7 +253,6 @@ fn diff_commands(
     Ok((compared, skipped))
 }
 
-// TODO(frolv): Track `STAGE_END` after the stage processor lands.
 fn diff_announcements(
     capture: &Capture,
     run: &RunDir,
@@ -261,6 +260,7 @@ fn diff_announcements(
     divergences: &mut Vec<Divergence>,
 ) -> usize {
     let mut recorded_finish = BTreeSet::new();
+    // STAGE_END is ignored as it requires stage processing to be active.
     for record in &capture.records {
         if record.op == CaptureOp::ServerUpdate
             && record.request.get("action").and_then(Value::as_str) == Some("FINISH")
@@ -586,8 +586,6 @@ mod tests {
             vec![(CAP_A, REP_Y)],
             vec![finish_announcement(REP_Y)],
         );
-
-        // TODO(frolv): STAGE_END is ignored
 
         assert_eq!(
             diff(&capture, &run),

--- a/challenge-harder/src/store/mod.rs
+++ b/challenge-harder/src/store/mod.rs
@@ -27,8 +27,8 @@ use crate::players::normalize_rsn;
 mod scripts;
 use scripts::{
     ANNOUNCE_SCRIPT, APPEND_SCRIPT, CLAIM_SCRIPT, CLIENT_SEND_SCRIPT, DELETE_SCRIPT,
-    PROJECT_SCRIPT, REJOIN_SCRIPT, RELEASE_SCRIPT, RENEW_SCRIPT, SEAL_SCRIPT, SEND_SCRIPT,
-    START_SCRIPT,
+    PROJECT_SCRIPT, REJOIN_SCRIPT, RELEASE_SCRIPT, REMOVE_STREAM_SCRIPT, RENEW_SCRIPT, SEAL_SCRIPT,
+    SEND_SCRIPT, START_SCRIPT,
 };
 
 #[cfg(test)]
@@ -188,6 +188,12 @@ fn stage_set(stages: &[Stage]) -> String {
 enum UpdateMessage {
     #[serde(rename = "FINISH")]
     Finish { id: Uuid },
+    #[serde(rename = "STAGE_END")]
+    StageEnd {
+        id: Uuid,
+        stage: Stage,
+        attempt: Option<u32>,
+    },
 }
 
 /// Cloneable handle to the Redis storage layer.
@@ -710,6 +716,11 @@ impl ChallengeClaim for RedisClaim {
     async fn announce(&self, update: &ChallengeServerUpdate) -> Result<(), StoreError> {
         let message = match update {
             ChallengeServerUpdate::Finish => UpdateMessage::Finish { id: self.uuid },
+            ChallengeServerUpdate::StageEnd { stage, attempt } => UpdateMessage::StageEnd {
+                id: self.uuid,
+                stage: *stage,
+                attempt: *attempt,
+            },
         };
         let payload = serde_json::to_string(&message).expect("update serializes");
         let mut connection = checkout(&self.pool).await?;
@@ -751,6 +762,31 @@ impl ChallengeClaim for RedisClaim {
             .await
             .map_err(|e| StoreError::Unavailable(e.to_string()))?;
         if marked == 1 {
+            Ok(())
+        } else {
+            Err(StoreError::Fenced)
+        }
+    }
+
+    async fn remove_stage_stream(
+        &self,
+        stage: Stage,
+        attempt: Option<u32>,
+    ) -> Result<(), StoreError> {
+        let mut connection = checkout(&self.pool).await?;
+
+        let mut invocation = REMOVE_STREAM_SCRIPT.prepare_invoke();
+        invocation
+            .key(&self.lease_key)
+            .key(streams_set_key(self.uuid))
+            .key(stage_stream_key(self.uuid, stage, attempt))
+            .arg(self.epoch.0);
+
+        let removed: i64 = invocation
+            .invoke_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        if removed == 1 {
             Ok(())
         } else {
             Err(StoreError::Fenced)

--- a/challenge-harder/src/store/scripts.rs
+++ b/challenge-harder/src/store/scripts.rs
@@ -230,6 +230,34 @@ pub(super) static SEAL_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
     )
 });
 
+/// Removes a processed stage's event stream, provided the remover's epoch
+/// still holds the challenge's fence.
+///
+/// ## Arguments
+///
+/// - `KEYS[1]` = Challenge's lease hash
+/// - `KEYS[2]` = Challenge's stage streams set
+/// - `KEYS[3]` = The stage's event stream
+///
+/// - `ARGV[1]` = Lease epoch
+///
+/// ## Return value
+///
+/// - `1`: The stream was removed.
+/// - `0`: The epoch no longer holds the fence.
+pub(super) static REMOVE_STREAM_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(
+        r"
+        if redis.call('HGET', KEYS[1], 'fence') ~= ARGV[1] then
+            return 0
+        end
+        redis.call('SREM', KEYS[2], KEYS[3])
+        redis.call('DEL', KEYS[3])
+        return 1
+        ",
+    )
+});
+
 /// Starts a challenge for a client, either creating a new challenge for the
 /// party, or joining the party's existing one if it is live. A live challenge
 /// is either active or does not yet have any state because it is initializing.

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -766,12 +766,65 @@ async fn announce_publishes_finish() {
         .await
         .expect("announce should succeed");
 
-    let message = tokio::time::timeout(Duration::from_secs(5), messages.next())
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let message = tokio::time::timeout_at(deadline, messages.next())
+            .await
+            .expect("update should arrive within the timeout")
+            .expect("pubsub stream should stay open");
+        let payload: String = message.get_payload().unwrap();
+        if payload.contains(&uuid.to_string()) {
+            assert_eq!(payload, format!(r#"{{"action":"FINISH","id":"{uuid}"}}"#));
+            break;
+        }
+    }
+
+    clean_up(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn announce_publishes_stage_end() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let claim = stub_claim(&store, uuid).await;
+
+    let mut pubsub = test_pubsub(CHALLENGE_UPDATES_CHANNEL).await;
+    let mut messages = pubsub.on_message();
+
+    claim
+        .announce(&ChallengeServerUpdate::StageEnd {
+            stage: Stage::MokhaiotlDelve8,
+            attempt: None,
+        })
         .await
-        .expect("update should arrive within the timeout")
-        .expect("pubsub stream should stay open");
-    let payload: String = message.get_payload().unwrap();
-    assert_eq!(payload, format!(r#"{{"action":"FINISH","id":"{uuid}"}}"#));
+        .expect("announce should succeed");
+    claim
+        .announce(&ChallengeServerUpdate::StageEnd {
+            stage: Stage::MokhaiotlDelve8plus,
+            attempt: Some(9),
+        })
+        .await
+        .expect("announce should succeed");
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    for expected in [
+        format!(r#"{{"action":"STAGE_END","id":"{uuid}","stage":57,"attempt":null}}"#),
+        format!(r#"{{"action":"STAGE_END","id":"{uuid}","stage":58,"attempt":9}}"#),
+    ] {
+        loop {
+            let message = tokio::time::timeout_at(deadline, messages.next())
+                .await
+                .expect("update should arrive within the timeout")
+                .expect("pubsub stream should stay open");
+            let payload: String = message.get_payload().unwrap();
+            if payload.contains(&uuid.to_string()) {
+                assert_eq!(payload, expected);
+                break;
+            }
+        }
+    }
 
     clean_up(&store, uuid).await;
 }
@@ -2013,6 +2066,57 @@ async fn mark_processed_closes_stage_streams_under_the_fence() {
 
     let _: () = connection
         .del(&[processed_stages_key(uuid)][..])
+        .await
+        .unwrap();
+    clean_up(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn remove_stage_stream_deletes_the_stream_and_its_set_entry() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let claim = stub_claim(&store, uuid).await;
+
+    let mut connection = store.pool.get().await.unwrap();
+    let streams = [
+        format!("challenge-events:{uuid}:57"),
+        format!("challenge-events:{uuid}:58:9"),
+    ];
+    for stream in &streams {
+        let _: () = connection.set(stream, "events").await.unwrap();
+        let _: () = connection
+            .sadd(streams_set_key(uuid), stream)
+            .await
+            .unwrap();
+    }
+
+    claim
+        .remove_stage_stream(Stage::MokhaiotlDelve8, None)
+        .await
+        .expect("removal should succeed");
+
+    let exists: bool = connection.exists(&streams[0]).await.unwrap();
+    assert!(!exists);
+    let members: BTreeSet<String> = connection.smembers(streams_set_key(uuid)).await.unwrap();
+    assert_eq!(members, BTreeSet::from([streams[1].clone()]));
+
+    // Remove fails if the claim is no longer valid.
+    let _: () = connection.hset(lease_key(uuid), "fence", 99).await.unwrap();
+    assert_eq!(
+        claim
+            .remove_stage_stream(Stage::MokhaiotlDelve8plus, Some(9))
+            .await,
+        Err(StoreError::Fenced),
+    );
+    let members: BTreeSet<String> = connection.smembers(streams_set_key(uuid)).await.unwrap();
+    assert_eq!(members, BTreeSet::from([streams[1].clone()]));
+    let exists: bool = connection.exists(&streams[1]).await.unwrap();
+    assert!(exists);
+
+    let _: () = connection
+        .del(&[streams[1].clone(), streams_set_key(uuid)][..])
         .await
         .unwrap();
     clean_up(&store, uuid).await;


### PR DESCRIPTION
Finishes stage processing bookkeeping by sending a STAGE_END pubsub challenge update, and removing the stage's event stream from Redis.