### PR TITLE
2c2s: Add metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "http-body-util",
  "hyper-util",
  "nix",
+ "prometheus",
  "prost",
  "prost-build",
  "prost-reflect",

--- a/challenge-harder/Cargo.toml
+++ b/challenge-harder/Cargo.toml
@@ -17,6 +17,7 @@ futures-util = { version = "0.3.32", default-features = false, features = ["std"
 http-body-util = "0.1.3"
 hyper-util = { version = "0.1.20", features = ["client-legacy", "http1", "tokio"] }
 nix = { version = "0.31.3", features = ["process", "signal"] }
+prometheus = "0.14.0"
 prost = "0.14.4"
 prost-types = "0.14.4"
 redis = { version = "1.3.0", features = ["tokio-comp"] }

--- a/challenge-harder/src/api.rs
+++ b/challenge-harder/src/api.rs
@@ -3,10 +3,12 @@
 //! Routes and body shapes mirror the current `challenge-server/api.ts`.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::Router;
-use axum::extract::{Path, State};
+use axum::extract::{MatchedPath, Path, Request, State};
 use axum::http::StatusCode;
+use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Json, Response};
 use axum::routing::{get, post};
 use serde::{Deserialize, Serialize};
@@ -29,13 +31,41 @@ pub fn router(coordinator: Arc<Coordinator>) -> Router {
         .route("/challenges/{challenge_id}/finish", post(finish_challenge))
         .route("/challenges/{challenge_id}/join", post(join_challenge))
         .route("/client-status", post(client_status))
+        // Keep health out of the metrics tracking.
+        .layer(middleware::from_fn(track_http))
         .route("/health", get(health))
+        .route("/metrics", get(metrics))
         .layer(TraceLayer::new_for_http())
         .with_state(coordinator)
 }
 
 async fn health() -> StatusCode {
     StatusCode::OK
+}
+
+async fn metrics() -> String {
+    crate::metrics::encode_metrics()
+}
+
+async fn track_http(request: Request, next: Next) -> Response {
+    let start = Instant::now();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|path| path.as_str().to_owned());
+    let method = request.method().clone();
+
+    let response = next.run(request).await;
+
+    if let Some(route) = route {
+        crate::metrics::observe_http_request(
+            &route,
+            method.as_str(),
+            response.status().as_u16(),
+            start.elapsed().as_secs_f64() * 1000.0,
+        );
+    }
+    response
 }
 
 #[derive(Deserialize)]

--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 
 use super::core::apply::apply;
 use super::core::command::{Command, Create, Envelope, Join, Processed};
-use super::core::deadline::{LifecycleConfig, next_deadline};
+use super::core::deadline::{DeadlineKind, LifecycleConfig, next_deadline};
 use super::core::decide::decide;
 use super::core::event::{Cause, JournalEntry, LifecycleEvent};
 use super::core::state::{
@@ -19,6 +19,7 @@ use super::core::state::{
     Snapshot, Trigger,
 };
 use super::core::types::{ClientId, JournalSeq, MsgId, ProcessingPayload, Stage, Timestamp, Uuid};
+use crate::metrics::{self, Decision, FinalizationPath, RunResult, StoreOutcome};
 use crate::processing::{ChallengeInfo, ProcessingRequest, StageProcessor};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -231,7 +232,7 @@ pub async fn run_challenge(
     let mut next_seq = 0;
     let mut resumed_at = Timestamp::ZERO;
 
-    match with_retries(uuid, || claim.load()).await {
+    match with_retries(uuid, "load", || claim.load()).await {
         Ok(entries) => {
             for entry in entries {
                 next_seq = entry.seq.0 + 1;
@@ -265,7 +266,7 @@ const STORE_ATTEMPTS: u32 = 3;
 const STORE_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 /// Runs a store operation, retrying transient failures.
-async fn with_retries<T, F, Fut>(uuid: Uuid, op: F) -> Result<T, StoreError>
+async fn with_retries<T, F, Fut>(uuid: Uuid, name: &'static str, op: F) -> Result<T, StoreError>
 where
     F: Fn() -> Fut,
     Fut: Future<Output = Result<T, StoreError>>,
@@ -278,7 +279,16 @@ where
                 tracing::warn!(%uuid, reason, "store_retry");
                 tokio::time::sleep(STORE_RETRY_DELAY).await;
             }
-            result => return result,
+            result => {
+                let outcome = match &result {
+                    Ok(_) if attempts == STORE_ATTEMPTS => StoreOutcome::Ok,
+                    Ok(_) => StoreOutcome::Retried,
+                    Err(StoreError::Unavailable(_)) => StoreOutcome::Exhausted,
+                    Err(StoreError::Fenced | StoreError::Corrupt(_)) => StoreOutcome::Error,
+                };
+                metrics::record_store_operation(name, outcome);
+                return result;
+            }
         }
     }
 }
@@ -469,7 +479,12 @@ impl ActiveChallenge {
             })
             .collect();
 
+        let record_finish = matches!(cmd, Command::Finish(_));
+
         if batch.is_empty() {
+            if record_finish {
+                metrics::record_finish_request(false, Decision::Rejected);
+            }
             return Ok(false);
         }
 
@@ -482,51 +497,19 @@ impl ActiveChallenge {
         let completed_runs_before = self.state.processing.completed().len();
 
         for entry in batch {
-            tracing::info!(
-                uuid = %self.state.uuid,
-                seq = entry.seq.0,
-                caused_by = ?entry.caused_by,
-                event = ?entry.event,
-                "journal_entry",
-            );
-            let starts_run = matches!(entry.event, LifecycleEvent::ProcessingStarted { .. });
-            let ends_run = match entry.event {
-                LifecycleEvent::ProcessingFinished { .. } => true,
-                LifecycleEvent::ProcessingFailed { trigger, ref error } => {
-                    tracing::error!(
-                        uuid = %self.state.uuid,
-                        trigger = trigger.0,
-                        error = %error.message,
-                        "processing_failed",
-                    );
-                    true
-                }
-                LifecycleEvent::ProcessingTimedOut { trigger } => {
-                    tracing::warn!(
-                        uuid = %self.state.uuid,
-                        trigger = trigger.0,
-                        "processing_timed_out",
-                    );
-                    true
-                }
-                _ => false,
-            };
-            if let LifecycleEvent::StageSealed { stage, attempt, .. } = entry.event {
-                sealed.push((stage, attempt));
-            }
-            apply(&mut self.state, entry);
-            if starts_run {
-                self.processing_task = self.spawn_processing_run(chanel.clone());
-            } else if ends_run {
-                self.processing_task = None;
-            }
+            self.apply_journal_entry(entry, &mut sealed, chanel);
         }
+
+        if record_finish {
+            metrics::record_finish_request(self.state.clients.is_empty(), Decision::Accepted);
+        }
+
         // Close stage streams immediately after they're sealed.
         self.mark_processed(&sealed).await?;
 
         for &trigger in &self.state.processing.completed()[completed_runs_before..] {
             if let Trigger::Stage { stage, attempt, .. } = trigger {
-                if let Err(error) = with_retries(self.state.uuid, || {
+                if let Err(error) = with_retries(self.state.uuid, "remove_stream", || {
                     self.claim.remove_stage_stream(stage, attempt)
                 })
                 .await
@@ -534,8 +517,10 @@ impl ActiveChallenge {
                     tracing::error!(uuid = %self.state.uuid, %error, "stage_stream_removal_failed");
                 }
                 let update = ChallengeServerUpdate::StageEnd { stage, attempt };
-                if let Err(error) =
-                    with_retries(self.state.uuid, || self.claim.announce(&update)).await
+                if let Err(error) = with_retries(self.state.uuid, "challenge_update", || {
+                    self.claim.announce(&update)
+                })
+                .await
                 {
                     tracing::error!(uuid = %self.state.uuid, %error, "stage_end_publish_failed");
                 }
@@ -545,14 +530,76 @@ impl ActiveChallenge {
         Ok(true)
     }
 
+    fn apply_journal_entry(
+        &mut self,
+        entry: JournalEntry,
+        sealed: &mut Vec<(Stage, Option<u32>)>,
+        chanel: &mpsc::Sender<Processed>,
+    ) {
+        tracing::info!(
+            uuid = %self.state.uuid,
+            seq = entry.seq.0,
+            caused_by = ?entry.caused_by,
+            event = ?entry.event,
+            "journal_entry",
+        );
+
+        let mut starts_run = false;
+        let mut processing_outcome = None;
+        match entry.event {
+            LifecycleEvent::StageStarted { stage, .. }
+            | LifecycleEvent::StageAttemptStarted { stage, .. } => {
+                metrics::record_stage_start(self.state.challenge_type, self.state.mode, stage);
+            }
+            LifecycleEvent::StageSealed { stage, attempt, .. } => {
+                sealed.push((stage, attempt));
+            }
+            LifecycleEvent::ProcessingStarted { .. } => starts_run = true,
+            LifecycleEvent::ProcessingFinished { .. } => {
+                processing_outcome = Some(RunResult::Finished);
+            }
+            LifecycleEvent::ProcessingFailed { trigger, ref error } => {
+                tracing::error!(
+                    uuid = %self.state.uuid,
+                    trigger = trigger.0,
+                    error = %error.message,
+                    "processing_failed",
+                );
+                processing_outcome = Some(RunResult::Failed);
+            }
+            LifecycleEvent::ProcessingTimedOut { trigger } => {
+                tracing::warn!(
+                    uuid = %self.state.uuid,
+                    trigger = trigger.0,
+                    "processing_timed_out",
+                );
+                processing_outcome = Some(RunResult::TimedOut);
+            }
+            _ => {}
+        }
+        if let (Some(run), Some(res)) = (self.state.processing.active(), processing_outcome) {
+            metrics::record_processing_run(run.trigger, res);
+        }
+
+        apply(&mut self.state, entry);
+
+        if starts_run {
+            self.processing_task = self.spawn_processing_run(chanel.clone());
+        } else if processing_outcome.is_some() {
+            self.processing_task = None;
+        }
+    }
+
     /// Closes sealed stages' streams to further writes. Marking nothing
     /// trivially succeeds.
     async fn mark_processed(&self, stages: &[(Stage, Option<u32>)]) -> Result<(), StoreError> {
         if stages.is_empty() {
             return Ok(());
         }
-        if let Err(error) =
-            with_retries(self.state.uuid, || self.claim.mark_processed(stages)).await
+        if let Err(error) = with_retries(self.state.uuid, "mark_processed", || {
+            self.claim.mark_processed(stages)
+        })
+        .await
         {
             tracing::error!(uuid = %self.state.uuid, %error, "mark_processed_failed");
             return Err(error);
@@ -570,8 +617,10 @@ impl ActiveChallenge {
             .iter()
             .map(|(&client_id, client)| PublishedClient::of(client_id, client))
             .collect();
-        if let Err(error) =
-            with_retries(self.state.uuid, || self.claim.project(&current, &clients)).await
+        if let Err(error) = with_retries(self.state.uuid, "project", || {
+            self.claim.project(&current, &clients)
+        })
+        .await
         {
             tracing::error!(uuid = %self.state.uuid, %error, "projection_failed");
             return false;
@@ -615,7 +664,7 @@ impl ActiveChallenge {
     }
 
     async fn release_lease(&self) {
-        match with_retries(self.state.uuid, || self.claim.release()).await {
+        match with_retries(self.state.uuid, "release", || self.claim.release()).await {
             Ok(()) => tracing::info!(uuid = %self.state.uuid, "lease_released"),
             Err(error) => {
                 tracing::error!(uuid = %self.state.uuid, %error, "lease_release_failed");
@@ -625,17 +674,42 @@ impl ActiveChallenge {
 
     /// Publishes the challenge's finish and deletes its durable state.
     async fn conclude(&self) {
-        let finish = ChallengeServerUpdate::Finish;
-        if let Err(error) = with_retries(self.state.uuid, || self.claim.announce(&finish)).await {
-            tracing::error!(uuid = %self.state.uuid, %error, "announce_failed");
+        if let PhaseState::Terminated { cause, .. } = self.state.phase {
+            let path = match cause {
+                Cause::Command(_) | Cause::Deadline(DeadlineKind::ChallengeEnd) => {
+                    FinalizationPath::Normal
+                }
+                Cause::Deadline(DeadlineKind::CleanupDisconnect | DeadlineKind::CleanupAllIdle) => {
+                    FinalizationPath::Timeout
+                }
+                // Other causes don't end a challenge.
+                Cause::Deadline(
+                    DeadlineKind::StageEnd
+                    | DeadlineKind::ProcessingDue
+                    | DeadlineKind::ProcessingTimeout,
+                )
+                | Cause::Processing(_) => unreachable!(),
+            };
+            metrics::record_challenge_finalization(path, self.state.status());
         }
-        if let Err(error) = with_retries(self.state.uuid, || self.claim.delete(&self.state)).await {
+
+        let finish = ChallengeServerUpdate::Finish;
+        if let Err(error) = with_retries(self.state.uuid, "challenge_update", || {
+            self.claim.announce(&finish)
+        })
+        .await
+        {
+            tracing::error!(uuid = %self.state.uuid, %error, "challenge_update_failed");
+        }
+        if let Err(error) =
+            with_retries(self.state.uuid, "delete", || self.claim.delete(&self.state)).await
+        {
             tracing::error!(uuid = %self.state.uuid, %error, "challenge_delete_failed");
         }
     }
 
     async fn append(&self, batch: &[JournalEntry]) -> Result<(), StoreError> {
-        with_retries(self.state.uuid, || self.claim.append(batch)).await
+        with_retries(self.state.uuid, "append", || self.claim.append(batch)).await
     }
 
     fn spawn_processing_run(&self, chanel: mpsc::Sender<Processed>) -> Option<ProcessingTask> {
@@ -1035,6 +1109,7 @@ mod tests {
             party_changed: false,
             phase: PhaseState::Terminated {
                 finished_unix_ms: 0,
+                cause: Cause::Command(MsgId::sequence(2)),
             },
             reported_times: None,
             stage: Stage::TobMaiden,
@@ -1166,6 +1241,7 @@ mod tests {
             party_changed: false,
             phase: PhaseState::Terminated {
                 finished_unix_ms: 0,
+                cause: Cause::Command(MsgId::sequence(2)),
             },
             reported_times: None,
             stage: Stage::TobMaiden,

--- a/challenge-harder/src/lifecycle/coordinator.rs
+++ b/challenge-harder/src/lifecycle/coordinator.rs
@@ -13,6 +13,7 @@ use super::core::command::{ClientStatusChange, Command, Create, Finish, Join, Up
 use super::core::deadline::LifecycleConfig;
 use super::core::state::{ChallengePhase, PublishedClient, Snapshot};
 use super::core::types::{ClientId, MsgId, Uuid};
+use crate::metrics::{self, Decision, RequestAction};
 use crate::processing::StageProcessor;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -171,6 +172,7 @@ struct Registry {
 
 impl Registry {
     fn new(count: watch::Sender<usize>) -> Self {
+        metrics::set_active_challenges(0);
         Registry {
             challenges: HashSet::new(),
             count,
@@ -179,11 +181,13 @@ impl Registry {
 
     fn insert(&mut self, uuid: Uuid) {
         self.challenges.insert(uuid);
+        metrics::set_active_challenges(self.challenges.len());
         let _ = self.count.send(self.challenges.len());
     }
 
     fn remove(&mut self, uuid: Uuid) {
         self.challenges.remove(&uuid);
+        metrics::set_active_challenges(self.challenges.len());
         let _ = self.count.send(self.challenges.len());
     }
 }
@@ -280,26 +284,27 @@ impl Coordinator {
     /// the challenge's state once the request has been applied.
     /// `None` means the challenge shut down before the request could be processed.
     pub async fn create_or_join_challenge(&self, create: Create) -> Option<Snapshot> {
-        let challenge_type = create.challenge_type;
-        let stage = create.stage;
-        let user_id = create.user_id;
-        let client_id = create.client_id;
-        let party = create.party.clone();
-
         let (id, uuid, joined) = {
             // Hold off claim scans until the started challenge is registered,
             // so they cannot claim it away during its start.
             let _guard = self.starts.read().await;
-            let start = match self.store.start(create).await {
+            let start = match self.store.start(create.clone()).await {
                 Ok(start) => start,
                 Err(error) => {
                     tracing::error!(
-                        ?challenge_type,
-                        ?party,
-                        %user_id,
-                        %client_id,
+                        challenge_type = ?create.challenge_type,
+                        party = ?create.party,
+                        user_id = %create.user_id,
+                        client_id = %create.client_id,
                         %error,
                         "challenge_start_failed",
+                    );
+                    metrics::record_challenge_request(
+                        RequestAction::Create,
+                        create.challenge_type,
+                        create.mode,
+                        create.recording_type,
+                        Decision::Error,
                     );
                     return None;
                 }
@@ -310,11 +315,11 @@ impl Coordinator {
                     let uuid = claim.uuid();
                     tracing::debug!(
                         %uuid,
-                        ?challenge_type,
-                        ?party,
-                        ?stage,
-                        %user_id,
-                        %client_id,
+                        challenge_type = ?create.challenge_type,
+                        party = ?create.party,
+                        stage = ?create.stage,
+                        user_id = %create.user_id,
+                        client_id = %create.client_id,
                         "challenge_created",
                     );
                     spawn_challenge(
@@ -328,7 +333,12 @@ impl Coordinator {
                     (id, uuid, false)
                 }
                 Start::Joined { uuid, id } => {
-                    tracing::debug!(%uuid, %user_id, %client_id, "challenge_joined");
+                    tracing::debug!(
+                        %uuid,
+                        user_id = %create.user_id,
+                        client_id = %create.client_id,
+                        "challenge_joined",
+                    );
                     (id, uuid, true)
                 }
             }
@@ -342,6 +352,24 @@ impl Coordinator {
             // a realistic path for this to happen. Just log if it ever occurs.
             tracing::error!(msg_id = %id, "challenge_join_incumbent_terminated");
         }
+
+        let action = if joined {
+            RequestAction::Join
+        } else {
+            RequestAction::Create
+        };
+        let decision = if snapshot.is_some() {
+            Decision::Accepted
+        } else {
+            Decision::Error
+        };
+        metrics::record_challenge_request(
+            action,
+            create.challenge_type,
+            create.mode,
+            create.recording_type,
+            decision,
+        );
         snapshot
     }
 
@@ -355,17 +383,31 @@ impl Coordinator {
         );
         let id = match self.store.rejoin(uuid, &join).await {
             Ok(Rejoin::Queued(id)) => id,
-            Ok(Rejoin::UnknownChallenge) => return Err(CommandError::UnknownChallenge),
-            Ok(Rejoin::AlreadyInChallenge) => return Err(CommandError::AlreadyInChallenge),
+            Ok(Rejoin::UnknownChallenge) => {
+                metrics::record_client_reconnect(join.recording_type, Decision::Rejected);
+                return Err(CommandError::UnknownChallenge);
+            }
+            Ok(Rejoin::AlreadyInChallenge) => {
+                metrics::record_client_reconnect(join.recording_type, Decision::Rejected);
+                return Err(CommandError::AlreadyInChallenge);
+            }
             Err(error) => {
                 tracing::warn!(%uuid, %error, "command_enqueue_failed");
+                metrics::record_client_reconnect(join.recording_type, Decision::Error);
                 return Err(CommandError::Unavailable);
             }
         };
+
         self.cache
             .applied(uuid, id)
             .await
             .ok_or(CommandError::Unavailable)
+            .inspect(|_| {
+                metrics::record_client_reconnect(join.recording_type, Decision::Accepted);
+            })
+            .inspect_err(|_| {
+                metrics::record_client_reconnect(join.recording_type, Decision::Error);
+            })
     }
 
     /// Updates the state of an active challenge, returning its new state.
@@ -430,7 +472,10 @@ impl Coordinator {
         );
         match self.store.send(uuid, &Command::Finish(finish)).await {
             Ok(Some(_)) => Ok(()),
-            Ok(None) => Err(CommandError::UnknownChallenge),
+            Ok(None) => {
+                metrics::record_finish_request(false, Decision::Rejected);
+                Err(CommandError::UnknownChallenge)
+            }
             Err(error) => {
                 tracing::warn!(%uuid, %error, "command_enqueue_failed");
                 Err(CommandError::Unavailable)

--- a/challenge-harder/src/lifecycle/core/apply.rs
+++ b/challenge-harder/src/lifecycle/core/apply.rs
@@ -170,7 +170,10 @@ pub fn apply(state: &mut ChallengeState, entry: JournalEntry) {
                     state.created_unix_ms.saturating_add(entry.at.as_millis())
                 }
             };
-            state.phase = PhaseState::Terminated { finished_unix_ms };
+            state.phase = PhaseState::Terminated {
+                finished_unix_ms,
+                cause: entry.caused_by,
+            };
         }
         LifecycleEvent::ModeChanged { mode } => {
             state.mode = mode;
@@ -864,6 +867,7 @@ mod tests {
             state.phase,
             PhaseState::Terminated {
                 finished_unix_ms: 1_785_693_975_535,
+                cause: Cause::Command("1785693975535-0".parse().unwrap()),
             },
         );
     }
@@ -899,6 +903,7 @@ mod tests {
             state.phase,
             PhaseState::Terminated {
                 finished_unix_ms: 1_785_693_975_534,
+                cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
             },
         );
     }

--- a/challenge-harder/src/lifecycle/core/deadline.rs
+++ b/challenge-harder/src/lifecycle/core/deadline.rs
@@ -170,6 +170,7 @@ fn processing_deadline(state: &ChallengeState) -> Option<Deadline> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lifecycle::core::event::Cause;
     use crate::lifecycle::core::state::{ClientState, Processing, Trigger};
     use crate::lifecycle::core::types::{
         ChallengeStatus, ChallengeType, ClientId, JournalSeq, ProcessingError, RecordingType,
@@ -430,6 +431,7 @@ mod tests {
         let state = ChallengeState {
             phase: PhaseState::Terminated {
                 finished_unix_ms: 1_785_693_975_535,
+                cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
             },
             stage_state: StageState::Complete {
                 since: Timestamp::from_millis(7_000),
@@ -496,6 +498,7 @@ mod tests {
         let state = ChallengeState {
             phase: PhaseState::Terminated {
                 finished_unix_ms: 1_785_693_975_535,
+                cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
             },
             processing,
             ..mid_stage_state()
@@ -529,6 +532,7 @@ mod tests {
         let state = ChallengeState {
             phase: PhaseState::Terminated {
                 finished_unix_ms: 1_785_693_975_535,
+                cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
             },
             processing: running_processing(Timestamp::from_millis(5_000)),
             ..mid_stage_state()

--- a/challenge-harder/src/lifecycle/core/decide.rs
+++ b/challenge-harder/src/lifecycle/core/decide.rs
@@ -404,6 +404,7 @@ mod tests {
 
     use super::*;
     use crate::lifecycle::core::command::{Processed, StageProgress};
+    use crate::lifecycle::core::event::Cause;
     use crate::lifecycle::core::state::{ClientState, Processing, ProcessingConfig, Trigger};
     use crate::lifecycle::core::types::{
         ClientId, JournalSeq, ProcessingError, ProcessingPayload, RecordingType, ReportedTimes,
@@ -2019,6 +2020,7 @@ mod tests {
         let mut state = processing_tob_state();
         state.phase = PhaseState::Terminated {
             finished_unix_ms: 1_785_693_975_535,
+            cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
         };
         state.clients.clear();
 

--- a/challenge-harder/src/lifecycle/core/state.rs
+++ b/challenge-harder/src/lifecycle/core/state.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use core::time::Duration;
 
+use super::event::Cause;
 use super::types::{
     ChallengeInfo, ChallengeMode, ChallengeStatus, ChallengeType, ChallengeTypeExt, ClientId,
     JournalSeq, MsgId, ProcessingError, ProcessingPayload, RecordingType, ReportedTimes,
@@ -39,6 +40,8 @@ pub enum PhaseState {
     Terminated {
         /// Time at which the terminated state was first entered.
         finished_unix_ms: u64,
+        /// What terminated the challenge.
+        cause: Cause,
     },
 }
 
@@ -494,7 +497,9 @@ impl ChallengeState {
             created_unix_ms: self.created_unix_ms,
             reported_times: self.reported_times,
             finished_unix_ms: match self.phase {
-                PhaseState::Terminated { finished_unix_ms } => Some(finished_unix_ms),
+                PhaseState::Terminated {
+                    finished_unix_ms, ..
+                } => Some(finished_unix_ms),
                 PhaseState::Active | PhaseState::Finishing { .. } => None,
             },
         }
@@ -546,6 +551,7 @@ fn status_if_finished_now(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lifecycle::core::deadline::DeadlineKind;
 
     fn config(max_attempts: u32) -> ProcessingConfig {
         ProcessingConfig {
@@ -798,6 +804,7 @@ mod tests {
 
         state.phase = PhaseState::Terminated {
             finished_unix_ms: 1_785_693_975_535,
+            cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
         };
         assert_eq!(state.status(), ChallengeStatus::Wiped);
     }
@@ -810,6 +817,7 @@ mod tests {
             stage_status: StageStatus::Wiped,
             phase: PhaseState::Terminated {
                 finished_unix_ms: 1_785_693_975_535,
+                cause: Cause::Deadline(DeadlineKind::ChallengeEnd),
             },
             processing: Processing::new(config(2)),
             ..ChallengeState::default()

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -10,6 +10,7 @@ mod api;
 mod item;
 mod lifecycle;
 mod merging;
+mod metrics;
 mod players;
 mod processing;
 mod proto;

--- a/challenge-harder/src/metrics.rs
+++ b/challenge-harder/src/metrics.rs
@@ -1,0 +1,437 @@
+//! Prometheus metrics for the challenge server.
+
+use std::sync::LazyLock;
+
+use prometheus::{
+    HistogramVec, IntCounterVec, IntGauge, Opts, TextEncoder, histogram_opts,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge,
+};
+
+use crate::lifecycle::core::state::Trigger;
+use crate::lifecycle::core::types::{
+    ChallengeMode, ChallengeStatus, ChallengeType, RecordingType, Stage, StageExt,
+};
+
+static HTTP_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_http_requests_total",
+            "HTTP request results"
+        ),
+        &["route", "method", "status"]
+    )
+    .unwrap()
+});
+
+static HTTP_REQUEST_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        histogram_opts!(
+            "challenge_server_http_request_duration_ms",
+            "HTTP request latency in milliseconds",
+            vec![
+                5.0, 15.0, 30.0, 60.0, 120.0, 250.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0
+            ]
+        ),
+        &["route", "method", "status"]
+    )
+    .unwrap()
+});
+
+static CHALLENGE_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_challenge_requests_total",
+            "Challenge request flow decisions"
+        ),
+        &["action", "type", "mode", "recording_type", "decision"]
+    )
+    .unwrap()
+});
+
+static CLIENT_RECONNECTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_client_reconnects_total",
+            "Client reconnects"
+        ),
+        &["recording_type", "decision"]
+    )
+    .unwrap()
+});
+
+static FINISH_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_finish_requests_total",
+            "Challenge finish attempt outcomes"
+        ),
+        &["all_clients_done", "result"]
+    )
+    .unwrap()
+});
+
+static CHALLENGE_FINALIZATION: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_challenge_finalization_total",
+            "Challenge finalization paths"
+        ),
+        &["path", "status"]
+    )
+    .unwrap()
+});
+
+static STAGE_STARTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_stage_started_total",
+            "Stages started within a challenge"
+        ),
+        &["type", "mode", "stage"]
+    )
+    .unwrap()
+});
+
+static STAGE_PROCESSING_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        histogram_opts!(
+            "challenge_server_stage_processing_duration_ms",
+            "Time spent processing a stage",
+            vec![
+                50.0, 100.0, 200.0, 400.0, 800.0, 1_500.0, 3_000.0, 6_000.0, 12_000.0, 30_000.0
+            ]
+        ),
+        &["stage"]
+    )
+    .unwrap()
+});
+
+static REPOSITORY_WRITES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_repository_writes_total",
+            "Repository write attempts"
+        ),
+        &["target", "kind", "result"]
+    )
+    .unwrap()
+});
+
+static QUERYABLE_EVENTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_queryable_events_total",
+            "Number of queryable events persisted"
+        ),
+        &["stage"]
+    )
+    .unwrap()
+});
+
+static REPORTED_TIME_MISMATCHES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_reported_time_mismatch_total",
+            "Reported time mismatches detected"
+        ),
+        &["type"]
+    )
+    .unwrap()
+});
+
+static ACTIVE_CHALLENGES: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(Opts::new(
+        "challenge_server_active_challenges",
+        "Locally owned active challenges"
+    ))
+    .unwrap()
+});
+
+static STORE_OPERATIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_store_operations_total",
+            "Claim store operation outcomes"
+        ),
+        &["op", "outcome"]
+    )
+    .unwrap()
+});
+
+static PROCESSING_RUNS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        Opts::new(
+            "challenge_server_processing_runs_total",
+            "Processing run attempt outcomes"
+        ),
+        &["trigger", "outcome"]
+    )
+    .unwrap()
+});
+
+/// How a challenge start request was resolved.
+#[derive(Debug, Clone, Copy)]
+pub enum RequestAction {
+    Create,
+    Join,
+}
+
+/// Outcome of an incoming request.
+#[derive(Debug, Clone, Copy)]
+pub enum Decision {
+    Accepted,
+    Rejected,
+    Error,
+}
+
+impl Decision {
+    fn label(self) -> &'static str {
+        match self {
+            Decision::Accepted => "accepted",
+            Decision::Rejected => "rejected",
+            Decision::Error => "error",
+        }
+    }
+}
+
+/// What ended a challenge.
+#[derive(Debug, Clone, Copy)]
+pub enum FinalizationPath {
+    /// Terminated through the regular finish flow.
+    Normal,
+    /// Cleaned up after a disconnection or inactivity window.
+    Timeout,
+}
+
+/// How a store operation resolved.
+#[derive(Debug, Clone, Copy)]
+pub enum StoreOutcome {
+    /// Succeeded on the first attempt.
+    Ok,
+    /// Succeeded after at least one retry.
+    Retried,
+    /// Every retry failed as unavailable.
+    Exhausted,
+    /// Failed prima facie.
+    Error,
+}
+
+impl StoreOutcome {
+    fn label(self) -> &'static str {
+        match self {
+            StoreOutcome::Ok => "ok",
+            StoreOutcome::Retried => "retried",
+            StoreOutcome::Exhausted => "exhausted",
+            StoreOutcome::Error => "error",
+        }
+    }
+}
+
+/// How a processing run attempt settled.
+#[derive(Debug, Clone, Copy)]
+pub enum RunResult {
+    Finished,
+    Failed,
+    TimedOut,
+}
+
+impl RunResult {
+    fn label(self) -> &'static str {
+        match self {
+            RunResult::Finished => "finished",
+            RunResult::Failed => "failed",
+            RunResult::TimedOut => "timed_out",
+        }
+    }
+}
+
+fn type_label(challenge_type: ChallengeType) -> &'static str {
+    match challenge_type {
+        ChallengeType::UnknownChallenge => "unknown",
+        ChallengeType::Tob => "tob",
+        ChallengeType::Cox => "cox",
+        ChallengeType::Toa => "toa",
+        ChallengeType::Colosseum => "colosseum",
+        ChallengeType::Inferno => "inferno",
+        ChallengeType::Mokhaiotl => "mokhaiotl",
+    }
+}
+
+fn mode_label(mode: ChallengeMode) -> &'static str {
+    match mode {
+        ChallengeMode::NoMode => "no_mode",
+        ChallengeMode::TobEntry => "tob_entry",
+        ChallengeMode::TobRegular => "tob_regular",
+        ChallengeMode::TobHard => "tob_hard",
+        _ => unimplemented!("unsupported mode: {mode:?}"),
+    }
+}
+
+fn recording_type_label(recording_type: RecordingType) -> &'static str {
+    match recording_type {
+        RecordingType::Spectator => "spectator",
+        RecordingType::Participant => "participant",
+    }
+}
+
+fn status_label(status: ChallengeStatus) -> &'static str {
+    match status {
+        ChallengeStatus::InProgress => "in_progress",
+        ChallengeStatus::Completed => "completed",
+        ChallengeStatus::Reset => "reset",
+        ChallengeStatus::Wiped => "wiped",
+        ChallengeStatus::Abandoned => "abandoned",
+    }
+}
+
+// Solo challenges collapse into one label to keep cardinality bounded.
+fn stage_label(stage: Stage) -> String {
+    match stage.challenge_type() {
+        Some(ChallengeType::Colosseum) => "colosseum_any".to_owned(),
+        Some(ChallengeType::Inferno) => "inferno_any".to_owned(),
+        Some(ChallengeType::Mokhaiotl) => "mokhaiotl_any".to_owned(),
+        Some(ChallengeType::Tob | ChallengeType::Cox | ChallengeType::Toa) => {
+            stage.as_str_name().to_lowercase()
+        }
+        Some(ChallengeType::UnknownChallenge) | None => "unknown".to_owned(),
+    }
+}
+
+fn bool_label(value: bool) -> &'static str {
+    if value { "true" } else { "false" }
+}
+
+/// Records a served HTTP request.
+pub fn observe_http_request(route: &str, method: &str, status: u16, duration_ms: f64) {
+    let status = status.to_string();
+    let labels = [route, method, status.as_str()];
+    HTTP_REQUESTS.with_label_values(&labels).inc();
+    HTTP_REQUEST_DURATION
+        .with_label_values(&labels)
+        .observe(duration_ms);
+}
+
+/// Records a challenge start request's outcome.
+pub fn record_challenge_request(
+    action: RequestAction,
+    challenge_type: ChallengeType,
+    mode: ChallengeMode,
+    recording_type: RecordingType,
+    decision: Decision,
+) {
+    let action = match action {
+        RequestAction::Create => "create",
+        RequestAction::Join => "join",
+    };
+    CHALLENGE_REQUESTS
+        .with_label_values(&[
+            action,
+            type_label(challenge_type),
+            mode_label(mode),
+            recording_type_label(recording_type),
+            decision.label(),
+        ])
+        .inc();
+}
+
+/// Records a client's reconnection attempt to an active challenge.
+pub fn record_client_reconnect(recording_type: RecordingType, decision: Decision) {
+    CLIENT_RECONNECTS
+        .with_label_values(&[recording_type_label(recording_type), decision.label()])
+        .inc();
+}
+
+/// Records a challenge finish request's outcome.
+pub fn record_finish_request(all_clients_done: bool, decision: Decision) {
+    FINISH_REQUESTS
+        .with_label_values(&[bool_label(all_clients_done), decision.label()])
+        .inc();
+}
+
+/// Records the final outcome of a challenge.
+pub fn record_challenge_finalization(path: FinalizationPath, status: ChallengeStatus) {
+    let path = match path {
+        FinalizationPath::Normal => "normal",
+        FinalizationPath::Timeout => "timeout",
+    };
+    CHALLENGE_FINALIZATION
+        .with_label_values(&[path, status_label(status)])
+        .inc();
+}
+
+/// Records the start of a challenge stage.
+pub fn record_stage_start(challenge_type: ChallengeType, mode: ChallengeMode, stage: Stage) {
+    STAGE_STARTS
+        .with_label_values(&[
+            type_label(challenge_type),
+            mode_label(mode),
+            &stage_label(stage),
+        ])
+        .inc();
+}
+
+/// Records the duration of a stage processing run attempt.
+pub fn observe_stage_processing_duration(stage: Stage, duration_ms: f64) {
+    STAGE_PROCESSING_DURATION
+        .with_label_values(&[&stage_label(stage)])
+        .observe(duration_ms);
+}
+
+/// Records an attempt to write stage events to the data repository.
+pub fn record_stage_events_write(success: bool) {
+    let result = if success { "success" } else { "error" };
+    REPOSITORY_WRITES
+        .with_label_values(&["challenge", "stage_events", result])
+        .inc();
+}
+
+/// Records the number of queryable events written for a stage.
+pub fn record_queryable_events(stage: Stage, count: usize) {
+    QUERYABLE_EVENTS
+        .with_label_values(&[&stage_label(stage)])
+        .inc_by(u64::try_from(count).unwrap_or(u64::MAX));
+}
+
+/// Records a mismatch between reported and recorded challenge times.
+pub fn record_reported_time_mismatch() {
+    REPORTED_TIME_MISMATCHES
+        .with_label_values(&["challenge"])
+        .inc();
+}
+
+/// Sets the number of challenges this instance is running.
+pub fn set_active_challenges(count: usize) {
+    ACTIVE_CHALLENGES.set(i64::try_from(count).unwrap_or(i64::MAX));
+}
+
+/// Records a store operation's outcome.
+pub fn record_store_operation(op: &'static str, outcome: StoreOutcome) {
+    STORE_OPERATIONS
+        .with_label_values(&[op, outcome.label()])
+        .inc();
+}
+
+/// Records the outcome of a processing run attempt.
+pub fn record_processing_run(trigger: Trigger, outcome: RunResult) {
+    let trigger = match trigger {
+        Trigger::Create { .. } => "create",
+        Trigger::Recorder { .. } => "recorder",
+        Trigger::StageStart { .. } => "stage_start",
+        Trigger::Mode { .. } => "mode",
+        Trigger::Stage { .. } => "stage",
+        Trigger::Finish { .. } => "finish",
+    };
+    PROCESSING_RUNS
+        .with_label_values(&[trigger, outcome.label()])
+        .inc();
+}
+
+/// Encodes all registered metrics in Prometheus text format.
+#[must_use]
+pub fn encode_metrics() -> String {
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    encoder
+        .encode_to_string(&metric_families)
+        .unwrap_or_default()
+}

--- a/challenge-harder/src/processing/challenge.rs
+++ b/challenge-harder/src/processing/challenge.rs
@@ -6,6 +6,7 @@ use crate::lifecycle::core::types::{
     ChallengeMode, ChallengeStatus, ChallengeTypeExt, PlayerId, PrimaryMeleeGear, ProcessingError,
     RecordingType, Stage, UserId,
 };
+use crate::metrics;
 use crate::players::normalize_rsn;
 use crate::repository::DataRepository;
 
@@ -167,6 +168,7 @@ pub async fn finish(
             reported_ticks = times.challenge,
             "challenge_time_mismatch",
         );
+        metrics::record_reported_time_mismatch();
         final_ticks = times.challenge;
     }
 

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -1,6 +1,7 @@
 //! Challenge processing pipeline.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use async_trait::async_trait;
 
@@ -8,6 +9,7 @@ use crate::lifecycle::core::state::Trigger;
 use crate::lifecycle::core::types::{
     ChallengeType, PlayerId, PrimaryMeleeGear, ProcessingError, ProcessingPayload,
 };
+use crate::metrics;
 use crate::repository::DataRepository;
 use crate::store::Store;
 
@@ -112,6 +114,7 @@ impl StageProcessor for Pipeline {
             trigger = ?request.trigger,
             "processing_started",
         );
+        let started = Instant::now();
 
         let mut txn = match self.db.start_transaction(uuid, request.trigger).await {
             Ok(txn) => txn,
@@ -153,6 +156,13 @@ impl StageProcessor for Pipeline {
             }
         };
         txn.commit(&payload, custom_data.as_ref()).await?;
+
+        if let Trigger::Stage { stage, .. } = request.trigger {
+            metrics::observe_stage_processing_duration(
+                stage,
+                started.elapsed().as_secs_f64() * 1000.0,
+            );
+        }
 
         Ok(payload)
     }

--- a/challenge-harder/src/processing/stage.rs
+++ b/challenge-harder/src/processing/stage.rs
@@ -12,6 +12,7 @@ use crate::lifecycle::challenge::StoreError;
 use crate::lifecycle::core::types::{
     ClientStageStream, ProcessingError, ProcessingPayload, StageStatus,
 };
+use crate::metrics;
 use crate::repository::DataRepository;
 use crate::store::Store;
 
@@ -138,16 +139,20 @@ async fn persist(
         }
     };
 
-    tokio::try_join!(
-        save_challenge_data,
-        repository.save_stage_events(
-            challenge.uuid,
-            challenge.stage,
-            challenge.stage_attempt,
-            &challenge.party,
-            events,
-        )
-    )?;
+    let save_stage_events = async {
+        let result = repository
+            .save_stage_events(
+                challenge.uuid,
+                challenge.stage,
+                challenge.stage_attempt,
+                &challenge.party,
+                events,
+            )
+            .await;
+        metrics::record_stage_events_write(result.is_ok());
+        result
+    };
+    tokio::try_join!(save_challenge_data, save_stage_events)?;
 
     tracing::info!(
         uuid = %challenge.uuid,
@@ -157,6 +162,7 @@ async fn persist(
         queryable_until,
         "challenge_stage_events_saved",
     );
+    metrics::record_queryable_events(challenge.stage, queryable_events);
 
     Ok(payload)
 }

--- a/challenge-harder/src/store/tests.rs
+++ b/challenge-harder/src/store/tests.rs
@@ -1906,6 +1906,7 @@ fn terminated_state(uuid: Uuid, create: &Create) -> ChallengeState {
         party: create.party.clone(),
         phase: PhaseState::Terminated {
             finished_unix_ms: 1_785_693_975_535,
+            cause: Cause::Command("1785693975535-0".parse().unwrap()),
         },
         recorded_by: [create.client_id].into(),
         ..ChallengeState::default()


### PR DESCRIPTION
Installs the prometheus crate and defines metrics mirroring those of the existing server, with a handful of novel ones specific to the new server's architecture.