### PR TITLE
2c2s: Extend Redis layer for sessions

### DIFF
--- a/challenge-harder/src/lifecycle/challenge.rs
+++ b/challenge-harder/src/lifecycle/challenge.rs
@@ -19,21 +19,9 @@ use super::core::state::{
     Snapshot, Trigger,
 };
 use super::core::types::{ClientId, JournalSeq, MsgId, ProcessingPayload, Stage, Timestamp, Uuid};
-use crate::metrics::{self, Decision, FinalizationPath, RunResult, StoreOutcome};
+use super::store::{StoreError, with_retries};
+use crate::metrics::{self, Decision, FinalizationPath, RunResult};
 use crate::processing::{ChallengeInfo, ProcessingRequest, StageProcessor};
-
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum StoreError {
-    /// A newer incarnation owns the challenge; the challenge must exit.
-    #[error("fenced off by a newer incarnation")]
-    Fenced,
-    /// The operation could not be completed.
-    #[error("store unavailable: {0}")]
-    Unavailable(String),
-    /// Stored state exists but cannot be interpreted.
-    #[error("corrupt state: {0}")]
-    Corrupt(String),
-}
 
 /// A claim on a challenge, pairing the challenge's identity with exclusive
 /// write access to its durable state.
@@ -259,38 +247,6 @@ pub async fn run_challenge(
 
     let mut challenge = ActiveChallenge::new(config, claim, state, next_seq, processor);
     challenge.run(resumed_at, shutdown).await;
-}
-
-// Transient store failures are retried inline before the caller gives up.
-const STORE_ATTEMPTS: u32 = 3;
-const STORE_RETRY_DELAY: Duration = Duration::from_millis(250);
-
-/// Runs a store operation, retrying transient failures.
-async fn with_retries<T, F, Fut>(uuid: Uuid, name: &'static str, op: F) -> Result<T, StoreError>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<T, StoreError>>,
-{
-    let mut attempts = STORE_ATTEMPTS;
-    loop {
-        match op().await {
-            Err(StoreError::Unavailable(reason)) if attempts > 1 => {
-                attempts -= 1;
-                tracing::warn!(%uuid, reason, "store_retry");
-                tokio::time::sleep(STORE_RETRY_DELAY).await;
-            }
-            result => {
-                let outcome = match &result {
-                    Ok(_) if attempts == STORE_ATTEMPTS => StoreOutcome::Ok,
-                    Ok(_) => StoreOutcome::Retried,
-                    Err(StoreError::Unavailable(_)) => StoreOutcome::Exhausted,
-                    Err(StoreError::Fenced | StoreError::Corrupt(_)) => StoreOutcome::Error,
-                };
-                metrics::record_store_operation(name, outcome);
-                return result;
-            }
-        }
-    }
 }
 
 /// Processing task for an ongoing challenge.
@@ -693,6 +649,8 @@ impl ActiveChallenge {
             metrics::record_challenge_finalization(path, self.state.status());
         }
 
+        // TODO(frolv): Trigger external effects like feed and webhooks.
+
         let finish = ChallengeServerUpdate::Finish;
         if let Err(error) = with_retries(self.state.uuid, "challenge_update", || {
             self.claim.announce(&finish)
@@ -755,8 +713,10 @@ mod tests {
     #[derive(Default)]
     struct ClaimLog {
         /// Outcomes of upcoming store operations, popped per call in order;
-        /// once drained, operations succeed.
+        /// once drained, operations resolve with `steady_failure` or succeed.
         results: Mutex<VecDeque<Result<(), StoreError>>>,
+        /// Failure returned by every operation after `results` drains.
+        steady_failure: Option<StoreError>,
         /// Outcomes of upcoming lease renewals.
         renew_results: Mutex<VecDeque<Result<(), StoreError>>>,
         renewals: AtomicU64,
@@ -776,7 +736,14 @@ mod tests {
     impl ClaimLog {
         fn next_result(&self) -> Result<(), StoreError> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            self.results.lock().unwrap().pop_front().unwrap_or(Ok(()))
+            self.results
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| match &self.steady_failure {
+                    Some(error) => Err(error.clone()),
+                    None => Ok(()),
+                })
         }
     }
 
@@ -911,6 +878,7 @@ mod tests {
     /// call order.
     async fn run_scripted(
         script: Vec<Result<(), StoreError>>,
+        steady_failure: Option<StoreError>,
         journal: Vec<JournalEntry>,
         commands: Vec<Command>,
         hold_inbox: bool,
@@ -918,6 +886,7 @@ mod tests {
         let uuid = Uuid::new_v4();
         let log = Arc::new(ClaimLog {
             results: Mutex::new(script.into()),
+            steady_failure,
             ..ClaimLog::default()
         });
         let inbox = commands
@@ -949,7 +918,7 @@ mod tests {
         script: Vec<Result<(), StoreError>>,
         commands: Vec<Command>,
     ) -> RunOutcome {
-        run_scripted(script, Vec::new(), commands, false).await
+        run_scripted(script, None, Vec::new(), commands, false).await
     }
 
     /// Runs a challenge over a single create command whose store operations
@@ -1031,16 +1000,16 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn repeated_transient_failures_exit_unapplied() {
-        let mut script = vec![Ok(())];
-        script.extend(vec![unavailable(); STORE_ATTEMPTS as usize]);
-        let outcome = run_solo_create(script).await;
+    async fn failing_append_exits_unapplied() {
+        let outcome = run_scripted(
+            vec![Ok(())],
+            Some(StoreError::Unavailable("scripted".into())),
+            Vec::new(),
+            vec![create_command()],
+            false,
+        )
+        .await;
 
-        // The load, then the append's exhausted attempts.
-        assert_eq!(
-            outcome.log.calls.load(Ordering::Relaxed),
-            u64::from(STORE_ATTEMPTS) + 1,
-        );
         assert!(outcome.log.appended.lock().unwrap().is_empty());
         assert!(outcome.log.projected.lock().unwrap().is_empty());
     }
@@ -1192,13 +1161,15 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn failing_load_exits_before_processing() {
-        let script = vec![unavailable(); STORE_ATTEMPTS as usize];
-        let outcome = run_commands(script, vec![create_command()]).await;
+        let outcome = run_scripted(
+            Vec::new(),
+            Some(StoreError::Unavailable("scripted".into())),
+            Vec::new(),
+            vec![create_command()],
+            false,
+        )
+        .await;
 
-        assert_eq!(
-            outcome.log.calls.load(Ordering::Relaxed),
-            u64::from(STORE_ATTEMPTS),
-        );
         assert!(outcome.log.appended.lock().unwrap().is_empty());
         assert!(outcome.log.projected.lock().unwrap().is_empty());
         assert!(outcome.log.deleted.lock().unwrap().is_empty());
@@ -1222,7 +1193,7 @@ mod tests {
         journal.push(journaled(3, 500, 2, LifecycleEvent::ChallengeTerminated));
 
         // The queued command is never processed.
-        let outcome = run_scripted(vec![], journal, vec![finish_command()], false).await;
+        let outcome = run_scripted(vec![], None, journal, vec![finish_command()], false).await;
 
         // Load, announcement, deletion.
         assert_eq!(outcome.log.calls.load(Ordering::Relaxed), 3);
@@ -1261,7 +1232,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn resume_projects_the_folded_state_once() {
         let uuid = Uuid::new_v4();
-        let outcome = run_scripted(vec![], created_journal(uuid), vec![], false).await;
+        let outcome = run_scripted(vec![], None, created_journal(uuid), vec![], false).await;
 
         assert!(outcome.log.appended.lock().unwrap().is_empty());
         assert_eq!(
@@ -1289,6 +1260,7 @@ mod tests {
         let uuid = Uuid::new_v4();
         let outcome = run_scripted(
             vec![],
+            None,
             created_journal(uuid),
             vec![create_command(), finish_command()],
             false,
@@ -1337,7 +1309,7 @@ mod tests {
         let window = u64::try_from(config.reconnection_window.as_millis()).unwrap();
 
         let uuid = Uuid::new_v4();
-        let outcome = run_scripted(vec![], dormant_journal(uuid, 1_000), vec![], true).await;
+        let outcome = run_scripted(vec![], None, dormant_journal(uuid, 1_000), vec![], true).await;
 
         // The reconnection window opened at the disconnect and fires a full
         // window after it on the resumed clock.
@@ -1371,7 +1343,7 @@ mod tests {
                 mode: ChallengeMode::TobHard,
             },
         ));
-        let outcome = run_scripted(vec![], journal, vec![], true).await;
+        let outcome = run_scripted(vec![], None, journal, vec![], true).await;
 
         let appended = outcome.log.appended.lock().unwrap();
         assert_eq!(
@@ -1393,7 +1365,7 @@ mod tests {
         let interval = config.lease_renewal_interval.as_millis();
 
         let uuid = Uuid::new_v4();
-        let outcome = run_scripted(vec![], dormant_journal(uuid, 1_000), vec![], true).await;
+        let outcome = run_scripted(vec![], None, dormant_journal(uuid, 1_000), vec![], true).await;
 
         assert_eq!(
             u128::from(outcome.log.renewals.load(Ordering::Relaxed)),

--- a/challenge-harder/src/lifecycle/coordinator.rs
+++ b/challenge-harder/src/lifecycle/coordinator.rs
@@ -561,7 +561,7 @@ impl Coordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lifecycle::challenge::{ChallengeClaim, ChallengeServerUpdate, StoreError};
+    use crate::lifecycle::challenge::{ChallengeClaim, ChallengeServerUpdate};
     use crate::lifecycle::core::command::{ClientStatus, Envelope, StageProgress};
     use crate::lifecycle::core::event::JournalEntry;
     use crate::lifecycle::core::state::ChallengeState;
@@ -569,6 +569,7 @@ mod tests {
         ChallengeMode, ChallengeType, ClientId, RecordingType, Stage, StageStatus, UserId,
     };
     use crate::lifecycle::sim::Collector;
+    use crate::lifecycle::store::StoreError;
 
     fn create_request() -> Create {
         create_request_for(1)

--- a/challenge-harder/src/lifecycle/mod.rs
+++ b/challenge-harder/src/lifecycle/mod.rs
@@ -7,5 +7,7 @@ pub mod challenge;
 pub mod coordinator;
 #[deny(clippy::disallowed_methods, clippy::disallowed_types)]
 pub mod core;
+pub mod session;
 #[cfg(test)]
 pub(crate) mod sim;
+pub mod store;

--- a/challenge-harder/src/lifecycle/session.rs
+++ b/challenge-harder/src/lifecycle/session.rs
@@ -1,0 +1,114 @@
+//! Challenge session management.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use super::core::types::{JournalSeq, MsgId, Timestamp, Uuid};
+use super::store::{StoreError, with_retries};
+
+/// What triggered a session event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SessionCause {
+    /// A command sent to the session's inbox.
+    Command(MsgId),
+    /// The session's inactivity period expired.
+    Expiry,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionJournalEntry {
+    pub seq: JournalSeq,
+    /// Apply time from the session's clock.
+    pub at: Timestamp,
+    pub caused_by: SessionCause,
+    pub event: SessionEvent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionEvent {
+    /// The session was created.
+    Started { uuid: Uuid, party_key: String },
+    /// A member challenge reported activity.
+    Activity,
+    /// Terminal session event.
+    Expired,
+}
+
+/// A command sent to a session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionCommand {
+    Start { uuid: Uuid, party_key: String },
+    Activity,
+}
+
+/// A command with its inbox sequence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionEnvelope {
+    pub id: MsgId,
+    pub cmd: SessionCommand,
+}
+
+/// An exclusive handle to a session's journal and party directory entry.
+#[async_trait]
+pub trait SessionClaim: Send + Sync + 'static {
+    /// Returns every entry in the session's journal, in order.
+    async fn load(&self) -> Result<Vec<SessionJournalEntry>, StoreError>;
+
+    /// Delivers the session's inbox entries positioned after `from` into
+    /// `sink`, in order, until `sink` closes.
+    fn follow(&self, from: MsgId, sink: mpsc::Sender<SessionEnvelope>);
+
+    /// Appends journal entries as a single atomic batch.
+    async fn append(&self, batch: &[SessionJournalEntry]) -> Result<(), StoreError>;
+
+    /// Extends this claim's hold on the session.
+    async fn renew(&self) -> Result<(), StoreError>;
+
+    /// Releases this claim's hold on the session, leaving it immediately
+    /// claimable by any instance.
+    async fn release(&self) -> Result<(), StoreError>;
+
+    /// Deletes the session's durable state, including its directory key if
+    /// it still points to this session.
+    async fn delete(&self, party_key: &str) -> Result<(), StoreError>;
+}
+
+pub struct ClaimedSession {
+    uuid: Uuid,
+    inner: Box<dyn SessionClaim>,
+}
+
+impl ClaimedSession {
+    #[must_use]
+    pub fn new(uuid: Uuid, inner: Box<dyn SessionClaim>) -> Self {
+        ClaimedSession { uuid, inner }
+    }
+
+    /// Identifier of the session this claim owns.
+    #[must_use]
+    pub fn uuid(&self) -> Uuid {
+        self.uuid
+    }
+}
+
+impl std::ops::Deref for ClaimedSession {
+    type Target = dyn SessionClaim;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref()
+    }
+}
+
+/// Durable storage for session state, granting exclusive access through claims.
+#[async_trait]
+pub trait SessionStore: Send + Sync + 'static {
+    /// Finds up to `batch_size` claimable sessions not listed in `exclude`
+    /// and claims each under a fresh epoch, fencing off any previous owner.
+    async fn claim_unowned_sessions(
+        &self,
+        batch_size: usize,
+        exclude: &[Uuid],
+    ) -> Result<Vec<ClaimedSession>, StoreError>;
+}

--- a/challenge-harder/src/lifecycle/sim/mod.rs
+++ b/challenge-harder/src/lifecycle/sim/mod.rs
@@ -22,7 +22,6 @@ use tokio::sync::{mpsc, watch};
 
 use super::challenge::{
     ChallengeClaim, ChallengeServerUpdate, ChallengeSignal, ChallengeStore, Claim, Rejoin, Start,
-    StoreError,
 };
 use super::coordinator::Coordinator;
 use super::core::apply::apply;
@@ -40,6 +39,7 @@ use super::core::types::{
     ProcessingPayload, RecordingType, ReportedTimes, SessionToken, Stage, StageExt, StageStatus,
     UserId, Uuid,
 };
+use super::store::StoreError;
 use crate::processing::{ProcessingRequest, StageProcessor};
 
 /// A scripted client action, issued at a scenario-relative time.

--- a/challenge-harder/src/lifecycle/store.rs
+++ b/challenge-harder/src/lifecycle/store.rs
@@ -1,0 +1,112 @@
+//! The live state storage contract shared by lifecycle actors.
+
+use core::future::Future;
+use core::time::Duration;
+
+use super::core::types::Uuid;
+use crate::metrics::{self, StoreOutcome};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum StoreError {
+    /// A newer incarnation owns the challenge; the challenge must exit.
+    #[error("fenced off by a newer incarnation")]
+    Fenced,
+    /// The operation could not be completed.
+    #[error("store unavailable: {0}")]
+    Unavailable(String),
+    /// Stored state exists but cannot be interpreted.
+    #[error("corrupt state: {0}")]
+    Corrupt(String),
+}
+
+// Transient store failures are retried inline before the caller gives up.
+const STORE_ATTEMPTS: u32 = 3;
+const STORE_RETRY_DELAY: Duration = Duration::from_millis(250);
+
+/// Runs a store operation, retrying transient failures.
+pub(crate) async fn with_retries<T, F, Fut>(
+    uuid: Uuid,
+    name: &'static str,
+    op: F,
+) -> Result<T, StoreError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, StoreError>>,
+{
+    let mut attempts = STORE_ATTEMPTS;
+    loop {
+        match op().await {
+            Err(StoreError::Unavailable(reason)) if attempts > 1 => {
+                attempts -= 1;
+                tracing::warn!(%uuid, reason, "store_retry");
+                tokio::time::sleep(STORE_RETRY_DELAY).await;
+            }
+            result => {
+                let outcome = match &result {
+                    Ok(_) if attempts == STORE_ATTEMPTS => StoreOutcome::Ok,
+                    Ok(_) => StoreOutcome::Retried,
+                    Err(StoreError::Unavailable(_)) => StoreOutcome::Exhausted,
+                    Err(StoreError::Fenced | StoreError::Corrupt(_)) => StoreOutcome::Error,
+                };
+                metrics::record_store_operation(name, outcome);
+                return result;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use super::*;
+
+    #[tokio::test(start_paused = true)]
+    async fn transient_failures_retry_until_success() {
+        let calls = AtomicU32::new(0);
+        let result = with_retries(Uuid::new_v4(), "test", || {
+            let call = calls.fetch_add(1, Ordering::Relaxed) + 1;
+            async move {
+                if call < 3 {
+                    Err(StoreError::Unavailable("scripted".into()))
+                } else {
+                    Ok(call)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result, Ok(3));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn persistent_transient_failures_exhaust() {
+        let calls = AtomicU32::new(0);
+        let result: Result<(), StoreError> = with_retries(Uuid::new_v4(), "test", || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            async { Err(StoreError::Unavailable("scripted".into())) }
+        })
+        .await;
+        assert_eq!(result, Err(StoreError::Unavailable("scripted".into())));
+        assert_eq!(calls.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn permanent_errors_fail_without_retrying() {
+        let calls = AtomicU32::new(0);
+        let result: Result<(), StoreError> = with_retries(Uuid::new_v4(), "test", || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            async { Err(StoreError::Fenced) }
+        })
+        .await;
+        assert_eq!(result, Err(StoreError::Fenced));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+        let result: Result<(), StoreError> = with_retries(Uuid::new_v4(), "test", || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            async { Err(StoreError::Corrupt("scripted".into())) }
+        })
+        .await;
+        assert_eq!(result, Err(StoreError::Corrupt("scripted".into())));
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
+    }
+}

--- a/challenge-harder/src/main.rs
+++ b/challenge-harder/src/main.rs
@@ -14,10 +14,10 @@ mod metrics;
 mod players;
 mod processing;
 mod proto;
+mod redis;
 mod repository;
 mod shadow;
 mod skill;
-mod store;
 
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -94,7 +94,7 @@ async fn serve(config: LifecycleConfig) {
         .and_then(|p| p.parse().ok())
         .unwrap_or(DEFAULT_REDIS_POOL_SIZE);
     let store = Arc::new(
-        store::Store::connect(&redis_uri, identity.clone(), redis_pool_size)
+        redis::Store::connect(&redis_uri, identity.clone(), redis_pool_size)
             .await
             .expect("failed to connect to Redis"),
     );

--- a/challenge-harder/src/processing/mod.rs
+++ b/challenge-harder/src/processing/mod.rs
@@ -10,8 +10,8 @@ use crate::lifecycle::core::types::{
     ChallengeType, PlayerId, PrimaryMeleeGear, ProcessingError, ProcessingPayload,
 };
 use crate::metrics;
+use crate::redis::Store;
 use crate::repository::DataRepository;
-use crate::store::Store;
 
 use challenge_processor::ChallengeProcessor;
 use mokhaiotl::MokhaiotlProcessor;

--- a/challenge-harder/src/processing/stage.rs
+++ b/challenge-harder/src/processing/stage.rs
@@ -8,13 +8,13 @@
 //! 3. `persist` receives the results and writes them to the database and
 //!    blob store.
 
-use crate::lifecycle::challenge::StoreError;
 use crate::lifecycle::core::types::{
     ClientStageStream, ProcessingError, ProcessingPayload, StageStatus,
 };
+use crate::lifecycle::store::StoreError;
 use crate::metrics;
+use crate::redis::Store;
 use crate::repository::DataRepository;
-use crate::store::Store;
 
 use super::challenge::load_database_state;
 use super::challenge_processor::ChallengeProcessor;

--- a/challenge-harder/src/processing/tests/mokhaiotl.rs
+++ b/challenge-harder/src/processing/tests/mokhaiotl.rs
@@ -16,8 +16,8 @@ use crate::lifecycle::core::types::{
 use crate::processing::split::SplitType;
 use crate::processing::{Pipeline, ProcessingRequest, StageProcessor, db};
 use crate::proto::{ChallengeData, challenge_data, event};
+use crate::redis;
 use crate::repository::{DataRepository, FilesystemBackend};
-use crate::store;
 
 /// Properties of the test challenge, fixed so runs are deterministic.
 const CREATED_UNIX_MS: u64 = 1_782_864_000_000;
@@ -28,7 +28,7 @@ async fn delve_test() {
     let Some(db) = db::test_database().await else {
         return;
     };
-    let Some(redis) = store::tests::test_store().await else {
+    let Some(redis) = redis::tests::test_store().await else {
         return;
     };
     let client = db.client().await;

--- a/challenge-harder/src/redis/mod.rs
+++ b/challenge-harder/src/redis/mod.rs
@@ -13,7 +13,6 @@ use tokio::sync::mpsc;
 
 use crate::lifecycle::challenge::{
     ChallengeClaim, ChallengeServerUpdate, ChallengeSignal, ChallengeStore, Claim, Rejoin, Start,
-    StoreError,
 };
 use crate::lifecycle::core::command::{ClientMovedOn, Command, Create, Envelope, Join};
 use crate::lifecycle::core::event::JournalEntry;
@@ -22,13 +21,17 @@ use crate::lifecycle::core::types::{
     ChallengeMode, ChallengeStatus, ChallengeType, ClientId, ClientStageStream, Epoch, MsgId,
     Stage, StageExt, UserId, Uuid,
 };
+use crate::lifecycle::session::{
+    ClaimedSession, SessionClaim, SessionEnvelope, SessionJournalEntry, SessionStore,
+};
+use crate::lifecycle::store::StoreError;
 use crate::players::normalize_rsn;
 
 mod scripts;
 use scripts::{
     ANNOUNCE_SCRIPT, APPEND_SCRIPT, CLAIM_SCRIPT, CLIENT_SEND_SCRIPT, DELETE_SCRIPT,
     PROJECT_SCRIPT, REJOIN_SCRIPT, RELEASE_SCRIPT, REMOVE_STREAM_SCRIPT, RENEW_SCRIPT, SEAL_SCRIPT,
-    SEND_SCRIPT, START_SCRIPT,
+    SEND_SCRIPT, SESSION_CLAIM_SCRIPT, SESSION_DELETE_SCRIPT, START_SCRIPT,
 };
 
 #[cfg(test)]
@@ -47,27 +50,37 @@ const INBOX_BLOCK_TIMEOUT: Duration = Duration::from_secs(5);
 /// dead. Must exceed the block timeout, which holds reads unanswered by design.
 const INBOX_RESPONSE_TIMEOUT: Duration = INBOX_BLOCK_TIMEOUT.saturating_mul(2);
 
+/// How long a deleted journal and inbox are retained for inspection.
+const DELETED_STREAM_RETENTION: Duration = Duration::from_hours(24);
+
+/// How long a deleted challenge's state hash remains readable, covering
+/// response waiters that race the deletion.
+const DELETED_STATE_RETENTION: Duration = Duration::from_mins(1);
+
+/// How long a lease grant lasts before its state becomes claimable.
+const LEASE_TTL: Duration = Duration::from_secs(30);
+
 /// Channel for public challenge lifecycle broadcasts.
 pub(crate) const CHALLENGE_UPDATES_CHANNEL: &str = "challenge-updates";
 
-pub(crate) fn journal_key(uuid: Uuid) -> String {
+pub(crate) fn challenge_journal_key(uuid: Uuid) -> String {
     format!("2c2s:journal:{uuid}")
 }
 
 /// Prefix of every challenge inbox stream key.
-const INBOX_KEY_PREFIX: &str = "2c2s:inbox:";
+const CHALLENGE_INBOX_KEY_PREFIX: &str = "2c2s:inbox:";
 
 /// Stream of commands sent to a challenge.
-fn inbox_key(uuid: Uuid) -> String {
-    format!("{INBOX_KEY_PREFIX}{uuid}")
+fn challenge_inbox_key(uuid: Uuid) -> String {
+    format!("{CHALLENGE_INBOX_KEY_PREFIX}{uuid}")
 }
 
 /// Prefix of every challenge lease hash key.
-const LEASE_KEY_PREFIX: &str = "2c2s:lease:";
+const CHALLENGE_LEASE_KEY_PREFIX: &str = "2c2s:lease:";
 
 /// Fence and ownership record of a challenge's lease.
-fn lease_key(uuid: Uuid) -> String {
-    format!("{LEASE_KEY_PREFIX}{uuid}")
+fn challenge_lease_key(uuid: Uuid) -> String {
+    format!("{CHALLENGE_LEASE_KEY_PREFIX}{uuid}")
 }
 
 /// Prefix of every challenge's projected state key.
@@ -81,32 +94,13 @@ fn challenge_key(uuid: Uuid) -> String {
 
 /// The challenge's published clients.
 /// Matches `challengeClientsKey` in `//common/db/redis.ts`.
-fn clients_key(uuid: Uuid) -> String {
+fn challenge_clients_key(uuid: Uuid) -> String {
     format!("{CHALLENGE_KEY_PREFIX}{uuid}:clients")
 }
 
 /// Which challenge a party is recording.
-fn directory_key(party: &str) -> String {
+fn challenge_directory_key(party: &str) -> String {
     format!("2c2s:directory:{party}")
-}
-
-/// Which challenge a client is recording.
-fn client_key(client: ClientId) -> String {
-    format!("2c2s:client:{client}")
-}
-
-/// Which challenge an OSRS player is in.
-/// Matches `activePlayerKey` in `//common/db/redis.ts`.
-fn player_key(name: &str) -> String {
-    format!("player:{}", normalize_rsn(name))
-}
-
-/// Unique identity for a party running a particular challenge type.
-/// Matches `challengePartyKey` in `//common/db/redis.ts`.
-fn party_key(challenge_type: ChallengeType, party: &[String]) -> String {
-    let mut names: Vec<String> = party.iter().map(|name| normalize_rsn(name)).collect();
-    names.sort_unstable();
-    format!("{}-{}", challenge_type as i32, names.join("-"))
 }
 
 /// Set of the keys of a challenge's stage event streams.
@@ -139,21 +133,48 @@ fn stage_attempt_member(stage: Stage, attempt: Option<u32>) -> String {
     }
 }
 
-/// How long a deleted challenge's journal and inbox are retained for
-/// inspection before expiring.
-const DELETED_STREAM_RETENTION: Duration = Duration::from_hours(24);
-
-/// How long a deleted challenge's state hash remains readable, covering
-/// response waiters that race the deletion.
-const DELETED_STATE_RETENTION: Duration = Duration::from_mins(1);
-
 /// Existence index of every challenge between creation and finalization,
 /// as a sorted set scored by lease deadline as a Unix millisecond timestamp.
 /// A future score is owned, a past score is claimable.
-pub(crate) const LEASES_KEY: &str = "2c2s:leases";
+pub(crate) const CHALLENGE_LEASES_KEY: &str = "2c2s:leases:challenge";
 
-/// How long a lease grant lasts before the challenge becomes claimable.
-const LEASE_TTL: Duration = Duration::from_secs(30);
+/// Which challenge a client is recording.
+fn client_key(client: ClientId) -> String {
+    format!("2c2s:client:{client}")
+}
+
+/// Which challenge an OSRS player is in.
+/// Matches `activePlayerKey` in `//common/db/redis.ts`.
+fn player_key(name: &str) -> String {
+    format!("player:{}", normalize_rsn(name))
+}
+
+/// Prefix of every session lease hash key.
+const SESSION_LEASE_KEY_PREFIX: &str = "2c2s:session:lease:";
+
+/// Ownership record of a session.
+fn session_lease_key(uuid: Uuid) -> String {
+    format!("{SESSION_LEASE_KEY_PREFIX}{uuid}")
+}
+
+/// A session's journal stream.
+fn session_journal_key(uuid: Uuid) -> String {
+    format!("2c2s:session:journal:{uuid}")
+}
+
+/// The stream of commands sent to a session.
+fn session_inbox_key(uuid: Uuid) -> String {
+    format!("2c2s:session:inbox:{uuid}")
+}
+
+/// Which session UUID a party is running.
+fn session_directory_key(party: &str) -> String {
+    format!("2c2s:session:{party}")
+}
+
+/// Existence index of every session between creation and expiry, as a
+/// sorted set scored by lease deadline as a Unix millisecond timestamp.
+pub(crate) const SESSION_LEASES_KEY: &str = "2c2s:leases:session";
 
 /// The current unix time, in milliseconds.
 fn unix_millis() -> u64 {
@@ -168,17 +189,12 @@ fn lease_deadline() -> u64 {
     unix_millis() + u64::try_from(LEASE_TTL.as_millis()).expect("deadline fits in u64")
 }
 
-/// Formats a set of stages as a comma wrapped string for Lua matching.
-fn stage_set(stages: &[Stage]) -> String {
-    if stages.is_empty() {
-        return String::new();
-    }
-    let mut set = String::from(",");
-    for stage in stages {
-        set.push_str(&(*stage as i32).to_string());
-        set.push(',');
-    }
-    set
+/// Unique identity for a party running a particular challenge type.
+/// Matches `challengePartyKey` in `//common/db/redis.ts`.
+fn party_identifier(challenge_type: ChallengeType, party: &[String]) -> String {
+    let mut names: Vec<String> = party.iter().map(|name| normalize_rsn(name)).collect();
+    names.sort_unstable();
+    format!("{}-{}", challenge_type as i32, names.join("-"))
 }
 
 /// A `challenge-updates` message, matching `ChallengeServerUpdate` in
@@ -265,14 +281,25 @@ impl Store {
             .collect())
     }
 
-    /// A write handle to challenge `uuid`'s state under `epoch`.
-    fn redis_claim(&self, uuid: Uuid, epoch: Epoch) -> RedisClaim {
-        RedisClaim {
+    fn new_challenge_claim(&self, uuid: Uuid, epoch: Epoch) -> RedisChallengeClaim {
+        RedisChallengeClaim {
             uuid,
-            journal_key: journal_key(uuid),
-            lease_key: lease_key(uuid),
+            journal_key: challenge_journal_key(uuid),
+            lease_key: challenge_lease_key(uuid),
             challenge_key: challenge_key(uuid),
-            clients_key: clients_key(uuid),
+            clients_key: challenge_clients_key(uuid),
+            epoch,
+            client: self.client.clone(),
+            pool: self.pool.clone(),
+        }
+    }
+
+    fn new_session_claim(&self, uuid: Uuid, epoch: Epoch) -> RedisSessionClaim {
+        RedisSessionClaim {
+            uuid,
+            journal_key: session_journal_key(uuid),
+            inbox_key: session_inbox_key(uuid),
+            lease_key: session_lease_key(uuid),
             epoch,
             client: self.client.clone(),
             pool: self.pool.clone(),
@@ -368,6 +395,19 @@ fn parse_stream_record(fields: &HashMap<String, Vec<u8>>) -> Result<ClientStageS
     }
 }
 
+/// Formats a set of stages as a comma wrapped string for Lua matching.
+fn stage_set(stages: &[Stage]) -> String {
+    if stages.is_empty() {
+        return String::new();
+    }
+    let mut set = String::from(",");
+    for stage in stages {
+        set.push_str(&(*stage as i32).to_string());
+        set.push(',');
+    }
+    set
+}
+
 #[async_trait]
 impl ChallengeStore for Store {
     async fn claim_unowned(
@@ -379,7 +419,7 @@ impl ChallengeStore for Store {
 
         let mut invocation = CLAIM_SCRIPT.prepare_invoke();
         invocation
-            .key(LEASES_KEY)
+            .key(CHALLENGE_LEASES_KEY)
             .arg(&self.identity)
             .arg(unix_millis())
             .arg(lease_deadline())
@@ -401,7 +441,7 @@ impl ChallengeStore for Store {
                 })?;
                 Ok(Claim::new(
                     uuid,
-                    Box::new(self.redis_claim(uuid, Epoch(epoch))),
+                    Box::new(self.new_challenge_claim(uuid, Epoch(epoch))),
                 ))
             })
             .collect()
@@ -409,16 +449,16 @@ impl ChallengeStore for Store {
 
     async fn start(&self, create: Create) -> Result<Start, StoreError> {
         let uuid = Uuid::new_v4();
-        let party = party_key(create.challenge_type, &create.party);
+        let party = party_identifier(create.challenge_type, &create.party);
         let mut connection = checkout(&self.pool).await?;
 
         let mut invocation = START_SCRIPT.prepare_invoke();
         invocation
-            .key(directory_key(&party))
-            .key(LEASES_KEY)
-            .key(lease_key(uuid))
+            .key(challenge_directory_key(&party))
+            .key(CHALLENGE_LEASES_KEY)
+            .key(challenge_lease_key(uuid))
             .key(client_key(create.client_id))
-            .key(inbox_key(uuid));
+            .key(challenge_inbox_key(uuid));
         for key in create.party.iter().map(|name| player_key(name)) {
             invocation.key(key);
         }
@@ -450,7 +490,10 @@ impl ChallengeStore for Store {
         let invalid = || StoreError::Unavailable(format!("invalid start outcome: {outcome:?}"));
         match outcome.as_slice() {
             [action, id] if action == "CREATE" => Ok(Start::Created {
-                claim: Claim::new(uuid, Box::new(self.redis_claim(uuid, Epoch::INITIAL))),
+                claim: Claim::new(
+                    uuid,
+                    Box::new(self.new_challenge_claim(uuid, Epoch::INITIAL)),
+                ),
                 id: id.parse().map_err(|_| invalid())?,
             }),
             [action, incumbent, id] if action == "JOIN" => Ok(Start::Joined {
@@ -468,10 +511,10 @@ impl ChallengeStore for Store {
 
         let mut invocation = REJOIN_SCRIPT.prepare_invoke();
         invocation
-            .key(LEASES_KEY)
+            .key(CHALLENGE_LEASES_KEY)
             .key(challenge_key(uuid))
             .key(client_key(join.client_id))
-            .key(inbox_key(uuid))
+            .key(challenge_inbox_key(uuid))
             .arg(uuid.to_string())
             .arg(payload);
         let outcome: Vec<String> = invocation
@@ -494,8 +537,8 @@ impl ChallengeStore for Store {
 
         let mut invocation = SEND_SCRIPT.prepare_invoke();
         invocation
-            .key(LEASES_KEY)
-            .key(inbox_key(uuid))
+            .key(CHALLENGE_LEASES_KEY)
+            .key(challenge_inbox_key(uuid))
             .arg(uuid.to_string())
             .arg(payload);
         let id: Option<String> = invocation
@@ -595,8 +638,175 @@ impl ChallengeStore for Store {
     }
 }
 
+#[async_trait]
+impl SessionStore for Store {
+    async fn claim_unowned_sessions(
+        &self,
+        batch_size: usize,
+        exclude: &[Uuid],
+    ) -> Result<Vec<ClaimedSession>, StoreError> {
+        let mut connection = checkout(&self.pool).await?;
+
+        let mut invocation = SESSION_CLAIM_SCRIPT.prepare_invoke();
+        invocation
+            .key(SESSION_LEASES_KEY)
+            .arg(&self.identity)
+            .arg(unix_millis())
+            .arg(lease_deadline())
+            .arg(batch_size);
+        for uuid in exclude {
+            invocation.arg(uuid.to_string());
+        }
+
+        let claimed: Vec<(String, u64)> = invocation
+            .invoke_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+
+        claimed
+            .into_iter()
+            .map(|(uuid, epoch)| {
+                let uuid: Uuid = uuid.parse().map_err(|_| {
+                    StoreError::Unavailable(format!("invalid claimed uuid: {uuid}"))
+                })?;
+                Ok(ClaimedSession::new(
+                    uuid,
+                    Box::new(self.new_session_claim(uuid, Epoch(epoch))),
+                ))
+            })
+            .collect()
+    }
+}
+
+async fn load_journal<T: serde::de::DeserializeOwned>(
+    pool: &Pool,
+    key: &str,
+) -> Result<Vec<T>, StoreError> {
+    let mut connection = checkout(pool).await?;
+    let batches: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
+        .arg(key)
+        .arg("-")
+        .arg("+")
+        .query_async(&mut connection)
+        .await
+        .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+
+    let mut entries = Vec::new();
+    for (id, fields) in batches {
+        let batch = fields
+            .iter()
+            .find(|(name, _)| name == "batch")
+            .map(|(_, value)| value)
+            .ok_or_else(|| StoreError::Corrupt(format!("journal entry {id} has no batch")))?;
+        let batch: Vec<T> = serde_json::from_str(batch)
+            .map_err(|error| StoreError::Corrupt(format!("invalid journal batch {id}: {error}")))?;
+        entries.extend(batch);
+    }
+    Ok(entries)
+}
+
+async fn append(
+    pool: &Pool,
+    lease_key: &str,
+    lease_epoch: Epoch,
+    stream_key: &str,
+    stream_payload: &str,
+) -> Result<(), StoreError> {
+    let mut connection = checkout(pool).await?;
+
+    let mut invocation = APPEND_SCRIPT.prepare_invoke();
+    invocation
+        .key(lease_key)
+        .key(stream_key)
+        .arg(lease_epoch.0)
+        .arg(stream_payload);
+
+    let accepted: i64 = invocation
+        .invoke_async(&mut connection)
+        .await
+        .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+    if accepted == 1 {
+        Ok(())
+    } else {
+        Err(StoreError::Fenced)
+    }
+}
+
+/// Feeds a inbox stream's entries into `sink` until it closes, wrapping each
+/// command with its message ID through `envelope`.
+async fn follow_inbox<C, E>(
+    client: redis::Client,
+    uuid: Uuid,
+    key: String,
+    from: MsgId,
+    sink: mpsc::Sender<E>,
+    envelope: fn(MsgId, C) -> E,
+) where
+    C: serde::de::DeserializeOwned,
+    E: Send + 'static,
+{
+    let options = StreamReadOptions::default()
+        .block(usize::try_from(INBOX_BLOCK_TIMEOUT.as_millis()).expect("timeout fits in usize"));
+    let mut position = from;
+    loop {
+        let config =
+            redis::AsyncConnectionConfig::new().set_response_timeout(Some(INBOX_RESPONSE_TIMEOUT));
+        let mut connection = match client
+            .get_multiplexed_async_connection_with_config(&config)
+            .await
+        {
+            Ok(connection) => connection,
+            Err(error) => {
+                tracing::warn!(%uuid, %error, "inbox_connect_failed");
+                tokio::time::sleep(RECONNECT_DELAY).await;
+                continue;
+            }
+        };
+
+        loop {
+            let streams = [&key];
+            let positions = [position.to_string()];
+            let read = redis::AsyncCommands::xread_options(
+                &mut connection,
+                &streams,
+                &positions,
+                &options,
+            );
+            let reply: redis::RedisResult<Option<StreamReadReply>> = tokio::select! {
+                () = sink.closed() => return,
+                reply = read => reply,
+            };
+
+            let keys = match reply {
+                Ok(reply) => reply.map(|reply| reply.keys).unwrap_or_default(),
+                Err(error) => {
+                    tracing::warn!(%uuid, %error, "inbox_read_failed");
+                    tokio::time::sleep(RECONNECT_DELAY).await;
+                    break;
+                }
+            };
+
+            for entry in keys.into_iter().flat_map(|key| key.ids) {
+                let id: MsgId = entry
+                    .id
+                    .parse()
+                    .expect("message ids are parseable from redis");
+                position = id;
+                let payload = entry.get::<String>("cmd");
+                if let Some(Ok(cmd)) = payload.map(|payload| serde_json::from_str::<C>(&payload)) {
+                    if sink.send(envelope(id, cmd)).await.is_err() {
+                        return;
+                    }
+                } else {
+                    tracing::warn!(%uuid, %id, "invalid_inbox_entry");
+                }
+            }
+        }
+    }
+}
+
 /// An exclusive handle to a challenge's Redis state.
-struct RedisClaim {
+struct RedisChallengeClaim {
     uuid: Uuid,
     journal_key: String,
     lease_key: String,
@@ -608,56 +818,32 @@ struct RedisClaim {
 }
 
 #[async_trait]
-impl ChallengeClaim for RedisClaim {
+impl ChallengeClaim for RedisChallengeClaim {
     async fn load(&self) -> Result<Vec<JournalEntry>, StoreError> {
-        let mut connection = checkout(&self.pool).await?;
-        let batches: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
-            .arg(&self.journal_key)
-            .arg("-")
-            .arg("+")
-            .query_async(&mut connection)
-            .await
-            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
-
-        let mut entries = Vec::new();
-        for (id, fields) in batches {
-            let batch = fields
-                .iter()
-                .find(|(name, _)| name == "batch")
-                .map(|(_, value)| value)
-                .ok_or_else(|| StoreError::Corrupt(format!("journal entry {id} has no batch")))?;
-            let batch: Vec<JournalEntry> = serde_json::from_str(batch).map_err(|error| {
-                StoreError::Corrupt(format!("invalid journal batch {id}: {error}"))
-            })?;
-            entries.extend(batch);
-        }
-        Ok(entries)
+        load_journal(&self.pool, &self.journal_key).await
     }
 
     fn follow(&self, from: MsgId, sink: mpsc::Sender<Envelope>) {
-        tokio::spawn(follow_inbox(self.client.clone(), self.uuid, from, sink));
+        tokio::spawn(follow_inbox(
+            self.client.clone(),
+            self.uuid,
+            challenge_inbox_key(self.uuid),
+            from,
+            sink,
+            |id, cmd| Envelope { id, cmd },
+        ));
     }
 
     async fn append(&self, batch: &[JournalEntry]) -> Result<(), StoreError> {
         let payload = serde_json::to_string(batch).expect("journal entries serialize");
-        let mut connection = checkout(&self.pool).await?;
-
-        let mut invocation = APPEND_SCRIPT.prepare_invoke();
-        invocation
-            .key(&self.lease_key)
-            .key(&self.journal_key)
-            .arg(self.epoch.0)
-            .arg(payload);
-
-        let accepted: i64 = invocation
-            .invoke_async(&mut connection)
-            .await
-            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
-        if accepted == 1 {
-            Ok(())
-        } else {
-            Err(StoreError::Fenced)
-        }
+        append(
+            &self.pool,
+            &self.lease_key,
+            self.epoch,
+            &self.journal_key,
+            &payload,
+        )
+        .await
     }
 
     async fn project(
@@ -799,7 +985,7 @@ impl ChallengeClaim for RedisClaim {
         let mut invocation = RENEW_SCRIPT.prepare_invoke();
         invocation
             .key(&self.lease_key)
-            .key(LEASES_KEY)
+            .key(CHALLENGE_LEASES_KEY)
             .arg(self.epoch.0)
             .arg(self.uuid.to_string())
             .arg(lease_deadline());
@@ -821,7 +1007,7 @@ impl ChallengeClaim for RedisClaim {
         let mut invocation = RELEASE_SCRIPT.prepare_invoke();
         invocation
             .key(&self.lease_key)
-            .key(LEASES_KEY)
+            .key(CHALLENGE_LEASES_KEY)
             .arg(self.epoch.0)
             .arg(self.uuid.to_string());
 
@@ -844,14 +1030,14 @@ impl ChallengeClaim for RedisClaim {
         let mut invocation = DELETE_SCRIPT.prepare_invoke();
         invocation
             .key(&self.lease_key)
-            .key(LEASES_KEY)
+            .key(CHALLENGE_LEASES_KEY)
             .key(&self.challenge_key)
             .key(&self.journal_key)
-            .key(inbox_key(self.uuid))
+            .key(challenge_inbox_key(self.uuid))
             .key(streams_set_key(self.uuid))
             .key(&self.clients_key)
             .key(processed_stages_key(self.uuid))
-            .key(directory_key(&party_key(
+            .key(challenge_directory_key(&party_identifier(
                 state.challenge_type,
                 &state.party,
             )));
@@ -880,72 +1066,111 @@ impl ChallengeClaim for RedisClaim {
     }
 }
 
-/// Feeds a challenge's inbox entries into `sink` until it closes.
-async fn follow_inbox(
-    client: redis::Client,
+/// An exclusive handle to a session's Redis state.
+struct RedisSessionClaim {
     uuid: Uuid,
-    from: MsgId,
-    sink: mpsc::Sender<Envelope>,
-) {
-    let key = inbox_key(uuid);
-    let options = StreamReadOptions::default()
-        .block(usize::try_from(INBOX_BLOCK_TIMEOUT.as_millis()).expect("timeout fits in usize"));
-    let mut position = from;
-    loop {
-        let config =
-            redis::AsyncConnectionConfig::new().set_response_timeout(Some(INBOX_RESPONSE_TIMEOUT));
-        let mut connection = match client
-            .get_multiplexed_async_connection_with_config(&config)
+    journal_key: String,
+    inbox_key: String,
+    lease_key: String,
+    epoch: Epoch,
+    client: redis::Client,
+    pool: Pool,
+}
+
+#[async_trait]
+impl SessionClaim for RedisSessionClaim {
+    async fn load(&self) -> Result<Vec<SessionJournalEntry>, StoreError> {
+        load_journal(&self.pool, &self.journal_key).await
+    }
+
+    fn follow(&self, from: MsgId, sink: mpsc::Sender<SessionEnvelope>) {
+        tokio::spawn(follow_inbox(
+            self.client.clone(),
+            self.uuid,
+            self.inbox_key.clone(),
+            from,
+            sink,
+            |id, cmd| SessionEnvelope { id, cmd },
+        ));
+    }
+
+    async fn append(&self, batch: &[SessionJournalEntry]) -> Result<(), StoreError> {
+        let payload = serde_json::to_string(batch).expect("journal entries serialize");
+        append(
+            &self.pool,
+            &self.lease_key,
+            self.epoch,
+            &self.journal_key,
+            &payload,
+        )
+        .await
+    }
+
+    async fn renew(&self) -> Result<(), StoreError> {
+        let mut connection = checkout(&self.pool).await?;
+
+        let mut invocation = RENEW_SCRIPT.prepare_invoke();
+        invocation
+            .key(&self.lease_key)
+            .key(SESSION_LEASES_KEY)
+            .arg(self.epoch.0)
+            .arg(self.uuid.to_string())
+            .arg(lease_deadline());
+
+        let renewed: i64 = invocation
+            .invoke_async(&mut connection)
             .await
-        {
-            Ok(connection) => connection,
-            Err(error) => {
-                tracing::warn!(%uuid, %error, "inbox_connect_failed");
-                tokio::time::sleep(RECONNECT_DELAY).await;
-                continue;
-            }
-        };
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        if renewed == 1 {
+            Ok(())
+        } else {
+            Err(StoreError::Fenced)
+        }
+    }
 
-        loop {
-            let streams = [&key];
-            let positions = [position.to_string()];
-            let read = redis::AsyncCommands::xread_options(
-                &mut connection,
-                &streams,
-                &positions,
-                &options,
-            );
-            let reply: redis::RedisResult<Option<StreamReadReply>> = tokio::select! {
-                () = sink.closed() => return,
-                reply = read => reply,
-            };
+    async fn release(&self) -> Result<(), StoreError> {
+        let mut connection = checkout(&self.pool).await?;
 
-            let keys = match reply {
-                Ok(reply) => reply.map(|reply| reply.keys).unwrap_or_default(),
-                Err(error) => {
-                    tracing::warn!(%uuid, %error, "inbox_read_failed");
-                    tokio::time::sleep(RECONNECT_DELAY).await;
-                    break;
-                }
-            };
+        let mut invocation = RELEASE_SCRIPT.prepare_invoke();
+        invocation
+            .key(&self.lease_key)
+            .key(SESSION_LEASES_KEY)
+            .arg(self.epoch.0)
+            .arg(self.uuid.to_string());
 
-            for entry in keys.into_iter().flat_map(|key| key.ids) {
-                let id: MsgId = entry
-                    .id
-                    .parse()
-                    .expect("message ids are parseable from redis");
-                position = id;
-                let payload = entry.get::<String>("cmd");
-                if let Some(Ok(cmd)) =
-                    payload.map(|payload| serde_json::from_str::<Command>(&payload))
-                {
-                    if sink.send(Envelope { id, cmd }).await.is_err() {
-                        return;
-                    }
-                } else {
-                    tracing::warn!(%uuid, %id, "invalid_inbox_entry");
-                }
-            }
+        let released: i64 = invocation
+            .invoke_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        if released == 1 {
+            Ok(())
+        } else {
+            Err(StoreError::Fenced)
+        }
+    }
+
+    async fn delete(&self, party_key: &str) -> Result<(), StoreError> {
+        let mut connection = checkout(&self.pool).await?;
+
+        let mut invocation = SESSION_DELETE_SCRIPT.prepare_invoke();
+        invocation
+            .key(&self.lease_key)
+            .key(SESSION_LEASES_KEY)
+            .key(session_directory_key(party_key))
+            .key(&self.journal_key)
+            .key(&self.inbox_key)
+            .arg(self.epoch.0)
+            .arg(self.uuid.to_string())
+            .arg(DELETED_STREAM_RETENTION.as_secs());
+
+        let deleted: i64 = invocation
+            .invoke_async(&mut connection)
+            .await
+            .map_err(|e| StoreError::Unavailable(e.to_string()))?;
+        if deleted == 1 {
+            Ok(())
+        } else {
+            Err(StoreError::Fenced)
         }
     }
 }

--- a/challenge-harder/src/redis/scripts.rs
+++ b/challenge-harder/src/redis/scripts.rs
@@ -5,8 +5,8 @@ use std::sync::LazyLock;
 use redis::Script;
 
 use super::{
-    CHALLENGE_KEY_PREFIX, CHALLENGE_UPDATES_CHANNEL, INBOX_KEY_PREFIX, LEASE_KEY_PREFIX,
-    SIGNAL_CHANNEL,
+    CHALLENGE_INBOX_KEY_PREFIX, CHALLENGE_KEY_PREFIX, CHALLENGE_LEASE_KEY_PREFIX,
+    CHALLENGE_UPDATES_CHANNEL, SESSION_LEASE_KEY_PREFIX, SIGNAL_CHANNEL,
 };
 use crate::lifecycle::core::{state::ChallengePhase, types::Epoch};
 
@@ -29,7 +29,7 @@ use crate::lifecycle::core::{state::ChallengePhase, types::Epoch};
 ///
 /// A flat list of alternating uuid, epoch pairs for each claimed challenge.
 /// Empty when nothing was claimable.
-pub(super) static CLAIM_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+fn claim_script(lease_prefix: &str) -> Script {
     Script::new(&format!(
         r"
         local skip = {{}}
@@ -43,7 +43,7 @@ pub(super) static CLAIM_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
                 break
             end
             local uuid = index[i]
-            local lease = '{LEASE_KEY_PREFIX}' .. uuid
+            local lease = '{lease_prefix}' .. uuid
             if not skip[uuid]
                 and (tonumber(index[i + 1]) <= tonumber(ARGV[2])
                     or redis.call('HGET', lease, 'owner') == ARGV[1]) then
@@ -57,7 +57,13 @@ pub(super) static CLAIM_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
         return claimed
         ",
     ))
-});
+}
+
+pub(super) static CLAIM_SCRIPT: LazyLock<Script> =
+    LazyLock::new(|| claim_script(CHALLENGE_LEASE_KEY_PREFIX));
+
+pub(super) static SESSION_CLAIM_SCRIPT: LazyLock<Script> =
+    LazyLock::new(|| claim_script(SESSION_LEASE_KEY_PREFIX));
 
 /// Extends a challenge's lease deadline, provided the renewer's epoch still
 /// holds the challenge's fence.
@@ -303,7 +309,7 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
             local previous = redis.call('GET', KEYS[4])
             if previous and previous ~= target
                 and redis.call('ZSCORE', KEYS[2], previous) then
-                redis.call('XADD', '{INBOX_KEY_PREFIX}' .. previous, '*', 'cmd', ARGV[7])
+                redis.call('XADD', '{CHALLENGE_INBOX_KEY_PREFIX}' .. previous, '*', 'cmd', ARGV[7])
             end
         end
 
@@ -319,7 +325,7 @@ pub(super) static START_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
             if joinable then
                 leave_previous(incumbent)
                 redis.call('SET', KEYS[4], incumbent)
-                local id = redis.call('XADD', '{INBOX_KEY_PREFIX}' .. incumbent, '*', 'cmd', ARGV[6])
+                local id = redis.call('XADD', '{CHALLENGE_INBOX_KEY_PREFIX}' .. incumbent, '*', 'cmd', ARGV[6])
                 return {{'JOIN', incumbent, id}}
             end
         end
@@ -400,6 +406,44 @@ pub(super) static DELETE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
         return 1
         ",
     ))
+});
+
+/// Deletes an expired session's state, provided the deleter's epoch still
+/// holds the session's fence, permanently removing it from the session index.
+/// The journal and inbox are left to expire for inspection.
+///
+/// ## Arguments
+///
+/// - `KEYS[1]` = Session's lease hash
+/// - `KEYS[2]` = Session index
+/// - `KEYS[3]` = Session's party directory key
+/// - `KEYS[4]` = Session's journal stream
+/// - `KEYS[5]` = Session's inbox stream
+///
+/// - `ARGV[1]` = Lease epoch
+/// - `ARGV[2]` = Session uuid
+/// - `ARGV[3]` = Journal and inbox retention, in seconds
+///
+/// ## Return value
+///
+/// - `1`: The session was deleted.
+/// - `0`: The epoch no longer holds the fence.
+pub(super) static SESSION_DELETE_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
+    Script::new(
+        r"
+        if redis.call('HGET', KEYS[1], 'fence') ~= ARGV[1] then
+            return 0
+        end
+        if redis.call('GET', KEYS[3]) == ARGV[2] then
+            redis.call('DEL', KEYS[3])
+        end
+        redis.call('EXPIRE', KEYS[4], ARGV[3])
+        redis.call('EXPIRE', KEYS[5], ARGV[3])
+        redis.call('ZREM', KEYS[2], ARGV[2])
+        redis.call('DEL', KEYS[1])
+        return 1
+        ",
+    )
 });
 
 /// Queues a join command into a challenge's inbox and links the client to
@@ -495,7 +539,7 @@ pub(super) static CLIENT_SEND_SCRIPT: LazyLock<Script> = LazyLock::new(|| {
         if phase == '{terminated}' then
             return false
         end
-        local id = redis.call('XADD', '{INBOX_KEY_PREFIX}' .. uuid, '*', 'cmd', ARGV[1])
+        local id = redis.call('XADD', '{CHALLENGE_INBOX_KEY_PREFIX}' .. uuid, '*', 'cmd', ARGV[1])
         return {{uuid, id}}
         ",
         terminated = ChallengePhase::Terminated.tag(),

--- a/challenge-harder/src/redis/tests.rs
+++ b/challenge-harder/src/redis/tests.rs
@@ -32,12 +32,12 @@ fn test_party_members(client: ClientId) -> Vec<String> {
 
 /// The directory identity of a create request's party.
 fn party_of(create: &Create) -> String {
-    party_key(create.challenge_type, &create.party)
+    party_identifier(create.challenge_type, &create.party)
 }
 
 #[test]
 fn party_key_normalizes_then_sorts_names() {
-    let key = party_key(
+    let key = party_identifier(
         ChallengeType::Tob,
         &[
             "WWWWWWWWWWQQ".into(),
@@ -48,7 +48,7 @@ fn party_key_normalizes_then_sorts_names() {
     );
     assert_eq!(key, "1-1ogp-715-caps_lock13-wwwwwwwwwwqq");
 
-    let key = party_key(ChallengeType::Tob, &["AB".into(), "Aa".into()]);
+    let key = party_identifier(ChallengeType::Tob, &["AB".into(), "Aa".into()]);
     assert_eq!(key, "1-aa-ab");
 }
 
@@ -138,11 +138,11 @@ fn as_identity(store: &Store, identity: &str) -> Store {
 
 /// Establishes a fresh challenge's lease as a start would, returning its
 /// claim at the initial epoch.
-async fn stub_claim(store: &Store, uuid: Uuid) -> RedisClaim {
+async fn stub_claim(store: &Store, uuid: Uuid) -> RedisChallengeClaim {
     let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
         .hset_multiple(
-            lease_key(uuid),
+            challenge_lease_key(uuid),
             &[
                 ("fence", Epoch::INITIAL.to_string()),
                 ("owner", TEST_IDENTITY.to_string()),
@@ -151,10 +151,10 @@ async fn stub_claim(store: &Store, uuid: Uuid) -> RedisClaim {
         .await
         .unwrap();
     let _: () = connection
-        .zadd(LEASES_KEY, uuid.to_string(), lease_deadline())
+        .zadd(CHALLENGE_LEASES_KEY, uuid.to_string(), lease_deadline())
         .await
         .unwrap();
-    store.redis_claim(uuid, Epoch::INITIAL)
+    store.new_challenge_claim(uuid, Epoch::INITIAL)
 }
 
 /// Serializes tests that hold lapsed or foreign-identity leases in the shared
@@ -163,14 +163,17 @@ static SWEEP_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 async fn clean_up(store: &Store, uuid: Uuid) {
     let mut connection = store.pool.get().await.unwrap();
-    let _: () = connection.zrem(LEASES_KEY, uuid.to_string()).await.unwrap();
+    let _: () = connection
+        .zrem(CHALLENGE_LEASES_KEY, uuid.to_string())
+        .await
+        .unwrap();
     let _: () = connection
         .del(
             &[
-                journal_key(uuid),
-                lease_key(uuid),
+                challenge_journal_key(uuid),
+                challenge_lease_key(uuid),
                 challenge_key(uuid),
-                inbox_key(uuid),
+                challenge_inbox_key(uuid),
             ][..],
         )
         .await
@@ -181,7 +184,7 @@ async fn clean_up(store: &Store, uuid: Uuid) {
 /// is isolated by key uniqueness and dies at the next test run's flush.
 async fn clean_up_start(store: &Store, party: &str, clients: &[ClientId], uuids: &[Uuid]) {
     let mut connection = store.pool.get().await.unwrap();
-    let mut keys = vec![directory_key(party)];
+    let mut keys = vec![challenge_directory_key(party)];
     keys.extend(clients.iter().map(|client| client_key(*client)));
     let _: () = connection.del(keys).await.unwrap();
     for uuid in uuids {
@@ -194,7 +197,7 @@ async fn clean_up_start(store: &Store, party: &str, clients: &[ClientId], uuids:
 async fn read_journal(store: &Store, uuid: Uuid) -> Vec<(String, Vec<JournalEntry>)> {
     let mut connection = store.pool.get().await.unwrap();
     let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
-        .arg(journal_key(uuid))
+        .arg(challenge_journal_key(uuid))
         .arg("-")
         .arg("+")
         .query_async(&mut connection)
@@ -218,7 +221,7 @@ async fn read_journal(store: &Store, uuid: Uuid) -> Vec<(String, Vec<JournalEntr
 async fn read_inbox(store: &Store, uuid: Uuid) -> Vec<(MsgId, Vec<(String, Command)>)> {
     let mut connection = store.pool.get().await.unwrap();
     let entries: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
-        .arg(inbox_key(uuid))
+        .arg(challenge_inbox_key(uuid))
         .arg("-")
         .arg("+")
         .query_async(&mut connection)
@@ -308,7 +311,10 @@ async fn bumped_fence_rejects_stale_epoch() {
     claim.append(&first).await.expect("append should succeed");
 
     let mut connection = store.pool.get().await.unwrap();
-    let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 2)
+        .await
+        .unwrap();
 
     let second = vec![entry(
         1,
@@ -347,7 +353,7 @@ async fn expired_leases_are_claimed_and_fenced() {
     // The owning server dies.
     let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
-        .zadd(LEASES_KEY, uuid.to_string(), 500)
+        .zadd(CHALLENGE_LEASES_KEY, uuid.to_string(), 500)
         .await
         .unwrap();
 
@@ -374,11 +380,12 @@ async fn expired_leases_are_claimed_and_fenced() {
         .expect("append should succeed");
     assert_eq!(claim.append(&second).await, Err(StoreError::Fenced));
 
-    let lease: BTreeMap<String, String> = connection.hgetall(lease_key(uuid)).await.unwrap();
+    let lease: BTreeMap<String, String> =
+        connection.hgetall(challenge_lease_key(uuid)).await.unwrap();
     assert_eq!(lease["fence"], "2");
     assert_eq!(lease["owner"], "reclaimer");
     let deadline: Option<u64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert!(deadline.expect("challenge should stay indexed") > unix_millis());
@@ -419,7 +426,10 @@ async fn held_leases_are_reclaimable_only_by_their_owner() {
     assert_eq!(reclaimed.uuid(), uuid);
 
     let mut connection = store.pool.get().await.unwrap();
-    let fence: String = connection.hget(lease_key(uuid), "fence").await.unwrap();
+    let fence: String = connection
+        .hget(challenge_lease_key(uuid), "fence")
+        .await
+        .unwrap();
     assert_eq!(fence, "2");
 
     clean_up_start(&store, &party, &[client], &[uuid]).await;
@@ -450,7 +460,7 @@ async fn running_challenges_are_not_swept() {
 
     let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
-        .zadd(LEASES_KEY, uuid.to_string(), 500)
+        .zadd(CHALLENGE_LEASES_KEY, uuid.to_string(), 500)
         .await
         .unwrap();
     let claims = owner
@@ -459,7 +469,10 @@ async fn running_challenges_are_not_swept() {
         .expect("sweep should succeed");
     assert!(claims.is_empty(), "a running challenge was swept");
 
-    let fence: String = connection.hget(lease_key(uuid), "fence").await.unwrap();
+    let fence: String = connection
+        .hget(challenge_lease_key(uuid), "fence")
+        .await
+        .unwrap();
     assert_eq!(fence, "1");
 
     clean_up_start(&store, &party, &[client], &[uuid]).await;
@@ -483,7 +496,7 @@ async fn claim_sweeps_respect_the_batch_size() {
             panic!("expected a creation");
         };
         let _: () = connection
-            .zadd(LEASES_KEY, claim.uuid().to_string(), deadline)
+            .zadd(CHALLENGE_LEASES_KEY, claim.uuid().to_string(), deadline)
             .await
             .unwrap();
         challenges.push((party, client, claim.uuid()));
@@ -497,7 +510,7 @@ async fn claim_sweeps_respect_the_batch_size() {
     assert_eq!(claimed, vec![challenges[0].2, challenges[1].2]);
 
     let fence: String = connection
-        .hget(lease_key(challenges[2].2), "fence")
+        .hget(challenge_lease_key(challenges[2].2), "fence")
         .await
         .unwrap();
     assert_eq!(fence, "1");
@@ -518,23 +531,26 @@ async fn renewal_extends_a_held_lease() {
 
     let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
-        .zadd(LEASES_KEY, uuid.to_string(), 500)
+        .zadd(CHALLENGE_LEASES_KEY, uuid.to_string(), 500)
         .await
         .unwrap();
 
     claim.renew().await.expect("renew should succeed");
     let renewed: Option<u64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     let renewed = renewed.expect("challenge should stay indexed");
     assert!(renewed > unix_millis());
 
     // If claimed away, the extension fails.
-    let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 2)
+        .await
+        .unwrap();
     assert_eq!(claim.renew().await, Err(StoreError::Fenced));
     let unchanged: Option<u64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert_eq!(unchanged, Some(renewed));
@@ -554,7 +570,7 @@ async fn release_makes_a_lease_immediately_claimable() {
     claim.release().await.expect("release should succeed");
     let mut connection = store.pool.get().await.unwrap();
     let released: Option<u64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert_eq!(released, Some(0));
@@ -572,7 +588,7 @@ async fn release_makes_a_lease_immediately_claimable() {
     // The releaser can no longer reclaim.
     assert_eq!(claim.release().await, Err(StoreError::Fenced));
     let deadline: Option<u64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert!(deadline.expect("challenge should stay indexed") > unix_millis());
@@ -659,7 +675,10 @@ async fn projection_writes_hash_and_signals() {
     assert_eq!(store.read(uuid).await, Ok(Some(updated)));
 
     // The clients hash holds the wire form the old contract's readers parse.
-    let clients: BTreeMap<String, String> = connection.hgetall(clients_key(uuid)).await.unwrap();
+    let clients: BTreeMap<String, String> = connection
+        .hgetall(challenge_clients_key(uuid))
+        .await
+        .unwrap();
     assert_eq!(
         clients,
         [(
@@ -684,7 +703,10 @@ async fn projection_writes_hash_and_signals() {
     let hash: BTreeMap<String, String> = connection.hgetall(challenge_key(uuid)).await.unwrap();
     assert!(!hash.contains_key("stageAttempt"), "{hash:?}");
     assert_eq!(store.read(uuid).await, Ok(Some(snapshot(uuid, 6))));
-    let clients: bool = connection.exists(clients_key(uuid)).await.unwrap();
+    let clients: bool = connection
+        .exists(challenge_clients_key(uuid))
+        .await
+        .unwrap();
     assert!(!clients);
 
     clean_up(&store, uuid).await;
@@ -738,7 +760,10 @@ async fn bumped_fence_rejects_projection() {
     let claim = stub_claim(&store, uuid).await;
 
     let mut connection = store.pool.get().await.unwrap();
-    let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 2)
+        .await
+        .unwrap();
 
     assert_eq!(
         claim.project(&snapshot(uuid, 1), &[]).await,
@@ -838,7 +863,10 @@ async fn bumped_fence_rejects_announcements() {
     let claim = stub_claim(&store, uuid).await;
 
     let mut connection = store.pool.get().await.unwrap();
-    let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 2)
+        .await
+        .unwrap();
 
     assert_eq!(
         claim.announce(&ChallengeServerUpdate::Finish).await,
@@ -857,7 +885,7 @@ async fn missing_fence_rejects_appends() {
     let claim = stub_claim(&store, uuid).await;
 
     let mut connection = store.pool.get().await.unwrap();
-    let _: () = connection.del(lease_key(uuid)).await.unwrap();
+    let _: () = connection.del(challenge_lease_key(uuid)).await.unwrap();
 
     let batch = vec![entry(
         0,
@@ -906,7 +934,7 @@ async fn next_envelope(rx: &mut mpsc::Receiver<Envelope>) -> Envelope {
 async fn register(store: &Store, uuid: Uuid) {
     let mut connection = store.pool.get().await.unwrap();
     let _: () = connection
-        .zadd(LEASES_KEY, uuid.to_string(), lease_deadline())
+        .zadd(CHALLENGE_LEASES_KEY, uuid.to_string(), lease_deadline())
         .await
         .unwrap();
 }
@@ -1026,7 +1054,10 @@ async fn start_creates_and_claims_a_challenge_for_a_free_party() {
     let uuid = claim.uuid();
 
     let mut connection = store.pool.get().await.unwrap();
-    let directory: String = connection.get(directory_key(&party)).await.unwrap();
+    let directory: String = connection
+        .get(challenge_directory_key(&party))
+        .await
+        .unwrap();
     assert_eq!(directory, uuid.to_string());
     let routed: String = connection.get(client_key(client)).await.unwrap();
     assert_eq!(routed, uuid.to_string());
@@ -1043,7 +1074,7 @@ async fn start_creates_and_claims_a_challenge_for_a_free_party() {
     // The challenge should have a lease deadline in the future, held by
     // this instance.
     let deadline: Option<u64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     let now = u64::try_from(
@@ -1054,7 +1085,10 @@ async fn start_creates_and_claims_a_challenge_for_a_free_party() {
     )
     .expect("time fits in u64");
     assert!(deadline.expect("challenge should be indexed") > now);
-    let owner: String = connection.hget(lease_key(uuid), "owner").await.unwrap();
+    let owner: String = connection
+        .hget(challenge_lease_key(uuid), "owner")
+        .await
+        .unwrap();
     assert_eq!(owner, TEST_IDENTITY);
 
     assert_eq!(
@@ -1113,7 +1147,10 @@ async fn start_joins_a_live_incumbent() {
     assert_eq!(target, uuid);
 
     let mut connection = store.pool.get().await.unwrap();
-    let directory: String = connection.get(directory_key(&party)).await.unwrap();
+    let directory: String = connection
+        .get(challenge_directory_key(&party))
+        .await
+        .unwrap();
     assert_eq!(directory, uuid.to_string());
     let routed: String = connection.get(client_key(joiner_client)).await.unwrap();
     assert_eq!(routed, uuid.to_string());
@@ -1220,7 +1257,10 @@ async fn start_at_an_earlier_stage_creates_a_new_challenge() {
     assert_ne!(second, first);
 
     let mut connection = store.pool.get().await.unwrap();
-    let directory: String = connection.get(directory_key(&party)).await.unwrap();
+    let directory: String = connection
+        .get(challenge_directory_key(&party))
+        .await
+        .unwrap();
     assert_eq!(directory, second.to_string());
 
     // The party's keys reference the new challenge.
@@ -1354,11 +1394,14 @@ async fn start_supersedes_a_finished_incumbent() {
     assert_ne!(second, first);
 
     let mut connection = store.pool.get().await.unwrap();
-    let directory: String = connection.get(directory_key(&party)).await.unwrap();
+    let directory: String = connection
+        .get(challenge_directory_key(&party))
+        .await
+        .unwrap();
     assert_eq!(directory, second.to_string());
     // The finished challenge remains indexed until deletion.
     let remaining: Option<f64> = connection
-        .zscore(LEASES_KEY, first.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, first.to_string())
         .await
         .unwrap();
     assert!(remaining.is_some());
@@ -1584,7 +1627,7 @@ async fn send_to_an_unknown_challenge_is_rejected() {
     assert_eq!(store.send(uuid, &update_command()).await, Ok(None));
 
     let mut connection = store.pool.get().await.unwrap();
-    let exists: bool = connection.exists(inbox_key(uuid)).await.unwrap();
+    let exists: bool = connection.exists(challenge_inbox_key(uuid)).await.unwrap();
     assert!(!exists);
 }
 
@@ -1969,20 +2012,20 @@ async fn delete_removes_a_terminated_challenges_state() {
 
     // Routing, stage streams, index entry, and lease are gone.
     for key in [
-        directory_key(&party),
+        challenge_directory_key(&party),
         client_key(client),
         player_key(&create.party[0]),
         player_key(&create.party[1]),
         streams[0].clone(),
         streams[1].clone(),
         streams_set_key(uuid),
-        lease_key(uuid),
+        challenge_lease_key(uuid),
     ] {
         let exists: bool = connection.exists(&key).await.unwrap();
         assert!(!exists, "key should be deleted: {key}");
     }
     let indexed: Option<f64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert_eq!(indexed, None);
@@ -1992,8 +2035,8 @@ async fn delete_removes_a_terminated_challenges_state() {
     let stream_retention = i64::try_from(DELETED_STREAM_RETENTION.as_millis()).unwrap();
     let state_retention = i64::try_from(DELETED_STATE_RETENTION.as_millis()).unwrap();
     for (key, retention) in [
-        (journal_key(uuid), stream_retention),
-        (inbox_key(uuid), stream_retention),
+        (challenge_journal_key(uuid), stream_retention),
+        (challenge_inbox_key(uuid), stream_retention),
         (processed_stages_key(uuid), stream_retention),
         (challenge_key(uuid), state_retention),
     ] {
@@ -2055,7 +2098,10 @@ async fn mark_processed_closes_stage_streams_under_the_fence() {
     assert_eq!(members, BTreeSet::from(["57".to_string(), "58:9".into()]));
 
     // A fenced-off claim marks nothing.
-    let _: () = connection.hset(lease_key(uuid), "fence", 99).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 99)
+        .await
+        .unwrap();
     assert_eq!(
         claim
             .mark_processed(&[(Stage::MokhaiotlDelve8plus, Some(10))])
@@ -2104,7 +2150,10 @@ async fn remove_stage_stream_deletes_the_stream_and_its_set_entry() {
     assert_eq!(members, BTreeSet::from([streams[1].clone()]));
 
     // Remove fails if the claim is no longer valid.
-    let _: () = connection.hset(lease_key(uuid), "fence", 99).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 99)
+        .await
+        .unwrap();
     assert_eq!(
         claim
             .remove_stage_stream(Stage::MokhaiotlDelve8plus, Some(9))
@@ -2141,7 +2190,7 @@ async fn delete_leaves_repointed_routing_keys_alone() {
     let successor = Uuid::new_v4();
     let mut connection = store.pool.get().await.unwrap();
     let routing = [
-        directory_key(&party),
+        challenge_directory_key(&party),
         client_key(client),
         player_key(&create.party[0]),
         player_key(&create.party[1]),
@@ -2160,11 +2209,11 @@ async fn delete_leaves_repointed_routing_keys_alone() {
         assert_eq!(value, successor.to_string(), "routing key: {key}");
     }
     let indexed: Option<f64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert_eq!(indexed, None);
-    let lease: bool = connection.exists(lease_key(uuid)).await.unwrap();
+    let lease: bool = connection.exists(challenge_lease_key(uuid)).await.unwrap();
     assert!(!lease);
 
     clean_up_start(&store, &party, &[client], &[uuid]).await;
@@ -2189,7 +2238,10 @@ async fn bumped_fence_rejects_deletion() {
         .expect("project should succeed");
 
     let mut connection = store.pool.get().await.unwrap();
-    let _: () = connection.hset(lease_key(uuid), "fence", 2).await.unwrap();
+    let _: () = connection
+        .hset(challenge_lease_key(uuid), "fence", 2)
+        .await
+        .unwrap();
 
     assert_eq!(
         claim.delete(&terminated_state(uuid, &create)).await,
@@ -2199,7 +2251,7 @@ async fn bumped_fence_rejects_deletion() {
     // Everything survives, and nothing was scheduled to expire.
     for key in [
         challenge_key(uuid),
-        directory_key(&party),
+        challenge_directory_key(&party),
         client_key(client),
         player_key(&create.party[0]),
         player_key(&create.party[1]),
@@ -2208,12 +2260,12 @@ async fn bumped_fence_rejects_deletion() {
         assert!(exists, "key should survive: {key}");
     }
     let indexed: Option<f64> = connection
-        .zscore(LEASES_KEY, uuid.to_string())
+        .zscore(CHALLENGE_LEASES_KEY, uuid.to_string())
         .await
         .unwrap();
     assert!(indexed.is_some());
     let inbox_ttl: i64 = redis::cmd("PTTL")
-        .arg(inbox_key(uuid))
+        .arg(challenge_inbox_key(uuid))
         .query_async(&mut connection)
         .await
         .unwrap();
@@ -2420,4 +2472,278 @@ async fn stage_streams_read_in_order_skipping_invalid_records() {
 
     let mut connection = store.pool.get().await.unwrap();
     let _: () = connection.del(&key).await.unwrap();
+}
+
+use crate::lifecycle::session::{SessionCause, SessionCommand, SessionEvent};
+
+fn session_entry(seq: u64, event: SessionEvent) -> SessionJournalEntry {
+    SessionJournalEntry {
+        seq: JournalSeq(seq),
+        at: Timestamp::from_millis(seq * 100),
+        caused_by: SessionCause::Command(MsgId::sequence(seq + 1)),
+        event,
+    }
+}
+
+/// Establishes a fresh session's lease.
+async fn stub_session_claim(store: &Store, uuid: Uuid) -> RedisSessionClaim {
+    let mut connection = store.pool.get().await.unwrap();
+    let _: () = connection
+        .hset_multiple(
+            session_lease_key(uuid),
+            &[
+                ("fence", Epoch::INITIAL.to_string()),
+                ("owner", TEST_IDENTITY.to_string()),
+            ],
+        )
+        .await
+        .unwrap();
+    let _: () = connection
+        .zadd(SESSION_LEASES_KEY, uuid.to_string(), lease_deadline())
+        .await
+        .unwrap();
+    store.new_session_claim(uuid, Epoch::INITIAL)
+}
+
+async fn clean_up_session(store: &Store, uuid: Uuid) {
+    let mut connection = store.pool.get().await.unwrap();
+    let _: () = connection
+        .zrem(SESSION_LEASES_KEY, uuid.to_string())
+        .await
+        .unwrap();
+    let _: () = connection
+        .del(&[
+            session_lease_key(uuid),
+            session_journal_key(uuid),
+            session_inbox_key(uuid),
+        ])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn session_sweep_claims_an_available_lease() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let _guard = SWEEP_LOCK.lock().await;
+    let uuid = Uuid::new_v4();
+
+    let mut connection = store.pool.get().await.unwrap();
+    let _: () = connection
+        .hset_multiple(
+            session_lease_key(uuid),
+            &[("fence", "3".to_string()), ("owner", "dead-server".into())],
+        )
+        .await
+        .unwrap();
+    let _: () = connection
+        .zadd(SESSION_LEASES_KEY, uuid.to_string(), 1)
+        .await
+        .unwrap();
+
+    let claimed = as_identity(&store, "session-reclaimer")
+        .claim_unowned_sessions(16, &[])
+        .await
+        .expect("sweep should succeed");
+    let claim = claimed
+        .iter()
+        .find(|claim| claim.uuid() == uuid)
+        .expect("the lapsed session should be claimed");
+
+    let fence: String = connection
+        .hget(session_lease_key(uuid), "fence")
+        .await
+        .unwrap();
+    assert_eq!(fence, "4");
+    let owner: String = connection
+        .hget(session_lease_key(uuid), "owner")
+        .await
+        .unwrap();
+    assert_eq!(owner, "session-reclaimer");
+    let deadline: u64 = connection
+        .zscore(SESSION_LEASES_KEY, uuid.to_string())
+        .await
+        .unwrap();
+    assert!(deadline > unix_millis());
+
+    claim.release().await.expect("release should succeed");
+    clean_up_session(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn session_journal_appends_and_loads_back() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let claim = stub_session_claim(&store, uuid).await;
+
+    let batch = vec![
+        session_entry(
+            0,
+            SessionEvent::Started {
+                uuid,
+                party_key: "1-1ogp-wwwwwwwwwwqq".into(),
+            },
+        ),
+        session_entry(1, SessionEvent::Activity),
+    ];
+    claim.append(&batch).await.expect("append should succeed");
+    assert_eq!(claim.load().await.expect("load should succeed"), batch);
+
+    let stale = store.new_session_claim(uuid, Epoch(0));
+    assert_eq!(
+        stale
+            .append(&[session_entry(2, SessionEvent::Expired)])
+            .await,
+        Err(StoreError::Fenced),
+    );
+    assert_eq!(claim.load().await.expect("load should succeed"), batch);
+
+    clean_up_session(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn session_renew_and_release_update_the_index_deadline() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let _guard = SWEEP_LOCK.lock().await;
+    let uuid = Uuid::new_v4();
+    let claim = stub_session_claim(&store, uuid).await;
+    let mut connection = store.pool.get().await.unwrap();
+
+    claim.renew().await.expect("renew should succeed");
+    let deadline: u64 = connection
+        .zscore(SESSION_LEASES_KEY, uuid.to_string())
+        .await
+        .unwrap();
+    assert!(deadline > unix_millis());
+
+    assert_eq!(
+        store.new_session_claim(uuid, Epoch(0)).renew().await,
+        Err(StoreError::Fenced),
+    );
+
+    claim.release().await.expect("release should succeed");
+    let released: u64 = connection
+        .zscore(SESSION_LEASES_KEY, uuid.to_string())
+        .await
+        .unwrap();
+    assert_eq!(released, 0);
+
+    clean_up_session(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn session_delete_removes_and_expires_keys() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let claim = stub_session_claim(&store, uuid).await;
+    let party_key = format!("1-1ogp_{uuid}");
+    let mut connection = store.pool.get().await.unwrap();
+    let _: () = connection
+        .set(session_directory_key(&party_key), uuid.to_string())
+        .await
+        .unwrap();
+    claim
+        .append(&[session_entry(
+            0,
+            SessionEvent::Started {
+                uuid,
+                party_key: party_key.clone(),
+            },
+        )])
+        .await
+        .expect("append should succeed");
+
+    assert_eq!(
+        store
+            .new_session_claim(uuid, Epoch(0))
+            .delete(&party_key)
+            .await,
+        Err(StoreError::Fenced),
+    );
+
+    claim
+        .delete(&party_key)
+        .await
+        .expect("delete should succeed");
+    let directory: Option<String> = connection
+        .get(session_directory_key(&party_key))
+        .await
+        .unwrap();
+    assert_eq!(directory, None);
+    let indexed: Option<u64> = connection
+        .zscore(SESSION_LEASES_KEY, uuid.to_string())
+        .await
+        .unwrap();
+    assert_eq!(indexed, None);
+    let lease_exists: bool = connection.exists(session_lease_key(uuid)).await.unwrap();
+    assert!(!lease_exists);
+    let journal_ttl: i64 = connection.ttl(session_journal_key(uuid)).await.unwrap();
+    assert!(journal_ttl > 0);
+
+    clean_up_session(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn session_delete_leaves_directory_if_party_moved_on() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let successor = Uuid::new_v4();
+    let claim = stub_session_claim(&store, uuid).await;
+    let party_key = format!("1-1ogp_{uuid}");
+    let mut connection = store.pool.get().await.unwrap();
+    let _: () = connection
+        .set(session_directory_key(&party_key), successor.to_string())
+        .await
+        .unwrap();
+
+    claim
+        .delete(&party_key)
+        .await
+        .expect("delete should succeed");
+
+    let directory: Option<String> = connection
+        .get(session_directory_key(&party_key))
+        .await
+        .unwrap();
+    assert_eq!(directory, Some(successor.to_string()));
+
+    let _: () = connection
+        .del(session_directory_key(&party_key))
+        .await
+        .unwrap();
+    clean_up_session(&store, uuid).await;
+}
+
+#[tokio::test]
+async fn session_follow_delivers_queued_commands() {
+    let Some(store) = test_store().await else {
+        return;
+    };
+    let uuid = Uuid::new_v4();
+    let claim = stub_session_claim(&store, uuid).await;
+    let mut connection = store.pool.get().await.unwrap();
+    let payload = serde_json::to_string(&SessionCommand::Activity).unwrap();
+    let _: String = connection
+        .xadd(session_inbox_key(uuid), "*", &[("cmd", &payload)])
+        .await
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    claim.follow(MsgId::default(), tx);
+    let envelope = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("follow should deliver within the timeout")
+        .expect("the feed should stay open");
+    assert_eq!(envelope.cmd, SessionCommand::Activity);
+
+    clean_up_session(&store, uuid).await;
 }

--- a/challenge-harder/src/shadow/replay.rs
+++ b/challenge-harder/src/shadow/replay.rs
@@ -120,7 +120,7 @@ async fn read_journals(
     let mut journals = BTreeMap::new();
     for uuid in challenges {
         let batches: Vec<(String, Vec<(String, String)>)> = redis::cmd("XRANGE")
-            .arg(crate::store::journal_key(uuid))
+            .arg(crate::redis::challenge_journal_key(uuid))
             .arg("-")
             .arg("+")
             .query_async(redis)
@@ -165,7 +165,7 @@ async fn wait_for_timeouts(
 
     loop {
         let members: Vec<String> = redis::cmd("ZRANGE")
-            .arg(crate::store::LEASES_KEY)
+            .arg(crate::redis::CHALLENGE_LEASES_KEY)
             .arg(0)
             .arg(-1)
             .query_async(redis)
@@ -192,7 +192,7 @@ async fn record_announcements(
 ) -> Result<(tokio::task::JoinHandle<()>, Announcements), ReplayError> {
     let mut pubsub = redis::Client::open(redis_uri)?.get_async_pubsub().await?;
     pubsub
-        .subscribe(crate::store::CHALLENGE_UPDATES_CHANNEL)
+        .subscribe(crate::redis::CHALLENGE_UPDATES_CHANNEL)
         .await?;
 
     let announcements = Announcements::default();


### PR DESCRIPTION
Defines session store and claim interfaces mirroring those of challenges and implements them for redis.